### PR TITLE
Fix for scans.list last modification date causing an exception and not being used

### DIFF
--- a/tenable/tenable_io/scans.py
+++ b/tenable/tenable_io/scans.py
@@ -586,7 +586,7 @@ class ScansAPI(TIOEndpoint):
         if last_modified:
             # for the last_modified datetime attribute, we will want to convert
             # that into a timestamp integer before passing it to the API.
-            params['last_modified'] = int(time.mktime(self._check(
+            params['last_modification_date'] = int(time.mktime(self._check(
                 'last_modified', last_modified, datetime).timetuple()))
 
         return self._api.get('scans', params=params).json()['scans']

--- a/tenable/tenable_io/scans.py
+++ b/tenable/tenable_io/scans.py
@@ -587,7 +587,7 @@ class ScansAPI(TIOEndpoint):
             # for the last_modified datetime attribute, we will want to convert
             # that into a timestamp integer before passing it to the API.
             params['last_modified'] = int(time.mktime(self._check(
-                'last_modified', last_modified, datetime)))
+                'last_modified', last_modified, datetime).timetuple()))
 
         return self._api.get('scans', params=params).json()['scans']
 


### PR DESCRIPTION
This is a fix for the scans.list api call causing an exception by requiring an datetime object to be passed to the function but the conversion inside the function requiring timetuple.  Once that is fixed it also had an error where the api specified last_modification_date as the correct parameter but the system was passing last_modified