### PR TITLE
Set doc sidebar to not be fixed

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -95,7 +95,7 @@ html_theme = 'alabaster'
 #
 html_theme_options = {
     'description': 'A Python library for Tenable application APIs',
-    'fixed_sidebar': True,
+    'fixed_sidebar': False,
     'github_user': 'tenable',
     'github_repo': 'pyTenable',
     'travis_button': True,


### PR DESCRIPTION
Auto-generated documentation sidebar content can flow off the bottom of the screen, and because it is fixed, that content was no longer accessible.

Ideally the sphinx theme will get corrected so that the sidebar can scroll independently, but until then this should do