### PR TITLE
chapters join needs a semi-colon vs colon. fixes tenable/pyTenable#70

### DIFF
--- a/tenable/io/scans.py
+++ b/tenable/io/scans.py
@@ -553,7 +553,7 @@ class ScansAPI(TIOEndpoint):
 
         # The chapters are sent to us in a list, and we need to collapse that
         # down to a comma-delimited string.
-        payload['chapters'] = ','.join(
+        payload['chapters'] = ';'.join(
             self._check('chapters', 
                 kw['chapters'] if 'chapters' in kw else None, 
                 list, 


### PR DESCRIPTION
# Description

When passing chapter info for a scans.export(), chapters are required to be joined with a semi-colon when converting the chapter information from a list into a string.  Previously when a colon was found in the string no return of data was possible only a single entry would work.  With the semi-colon multiple chapters are not possible to be pulled.

Fixes # 70

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I was able to make the change locally and test with the same code getting successful results with the update.

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
