### PR TITLE
Minor audit log filter error. Updated to the correct format. Issue 90

### DIFF
--- a/tenable/io/audit_log.py
+++ b/tenable/io/audit_log.py
@@ -48,7 +48,7 @@ class AuditLogAPI(TIOEndpoint):
             ...     pprint(e)
         '''
         return self._api.get('audit-log/v1/events', params={
-            'f': ['{}:{}:{}'.format(
+            'f': ['{}.{}:{}'.format(
                 self._check('filter_field_name', f[0], str),
                 self._check('filter_operator', f[1], str),
                 self._check('filter_value', f[2], str)) for f in filters],


### PR DESCRIPTION
# Description

Updated the audit log filter to use the correct format "field.operator:value"

Fixes # 90

## Type of change

Please delete options that are not relevant.
- [X] Bug fix (non-breaking change which fixes an issue)
