### PR TITLE
Updated base.py to include now option

### DIFF
--- a/tenable/sc/base.py
+++ b/tenable/sc/base.py
@@ -137,7 +137,7 @@ class SCEndpoint(APIEndpoint):
         '''
         self._check('schedule:item', item, dict)
         resp = {'type': self._check('schedule:type', item['type'], str, 
-            choices=['ical', 'dependent', 'never', 'rollover', 'template'],
+            choices=['ical', 'dependent', 'never', 'rollover', 'template', 'now'],
             default='never')}
         
         if resp['type'] == 'ical' and 'start' in item and 'repeatRule' in item:


### PR DESCRIPTION
# Description

I have changed the following script to include a "now" option to allow Tenable.SC scripts to launch immediately.

Fixes #102 & #103 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Executed sample code in Issue #102 

**Test Configuration**:
* Python Version(s) Tested: 2.7 & 3.7
* Tenable.sc version (if necessary): 5.9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
