### PR TITLE
Expose optional start/end time variables on scan_instances.list()

### DIFF
--- a/tenable/sc/scan_instances.py
+++ b/tenable/sc/scan_instances.py
@@ -234,7 +234,7 @@ class ScanResultAPI(SCEndpoint):
         return self._api.post('scanResult/{}/import'.format(self._check(
             'id', id, int)), json=payload).json()['response']
 
-    def list(self, fields=None):
+    def list(self, fields=None, start_time=None, end_time=None):
         '''
         Retreives the list of scan instances.
 
@@ -243,6 +243,12 @@ class ScanResultAPI(SCEndpoint):
         Args:
             fields (list, optional): 
                 A list of attributes to return.
+
+            start_time (int, optional):
+                Epoch time to start search (searches against createdTime and defaults to now-30d)
+
+            end_time (int, optional):
+                Epoch time to end search (searches against createdTime and defaults to now)
 
         Returns:
             dict: A list of scan instance resources.
@@ -257,6 +263,12 @@ class ScanResultAPI(SCEndpoint):
         if fields:
             params['fields'] = ','.join([self._check('field', f, str) 
                 for f in fields])
+
+        if start_time:
+            params['startTime'] = str(start_time)
+
+        if end_time:
+            params['endTime'] = str(end_time)
 
         return self._api.get('scanResult', params=params).json()['response']
 

--- a/tenable/sc/scan_instances.py
+++ b/tenable/sc/scan_instances.py
@@ -265,10 +265,10 @@ class ScanResultAPI(SCEndpoint):
                 for f in fields])
 
         if start_time:
-            params['startTime'] = str(start_time)
+            params['startTime'] = self._check('start_time', start_time, int)
 
         if end_time:
-            params['endTime'] = str(end_time)
+            params['endTime'] = self._check('end_time', end_time, int)
 
         return self._api.get('scanResult', params=params).json()['response']
 


### PR DESCRIPTION
# Description

The [Tenable.sc Scan Result API](https://docs.tenable.com/sccv/api/Scan-Result.html) returns results from the last 30d by default, but it allows for providing custom start/end times.  pyTenable's `scan_instances.list()` does not have an option to specify the time range.

This change adds `start_time` and `end_time` variables to `scan_instances.list()` to fix this.

Fixes https://github.com/tenable/pyTenable/issues/108

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Made calls against an internal Security Center install, confirming that the new variables are optional, but when used, correctly return scan results within the specified times.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
