### PR TITLE
Tenable.io User Edit Permissions - Payload Spelling Correction

### DIFF
--- a/tenable/io/users.py
+++ b/tenable/io/users.py
@@ -142,7 +142,8 @@ class UsersAPI(TIOEndpoint):
         payload = dict()
 
         if permissions:
-            payload['permisions'] = self._check('permissions', permissions, int)
+            payload['permissions'] = self._check('permissions', permissions,
+                                                 int)
         if enabled is not None:
             payload['enabled'] = self._check('enabled', enabled, bool)
         if email:


### PR DESCRIPTION
# Description

Spelling police! Setting the permissions during user updates would fail as a result of the misspelled 'permissions' key. This corrects the spelling and ensures the permissions are passed appropriately.

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Hasn't been tested. Simple update correcting a JSON payload argument to the correct spelling.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
