### PR TITLE
Fixes for issues 144 and 149. 

### DIFF
--- a/tenable/sc/base.py
+++ b/tenable/sc/base.py
@@ -213,7 +213,7 @@ class SCEndpoint(APIEndpoint):
         if resp['type'] == 'ical' and 'start' in item and 'repeatRule' in item:
             resp['start'] = self._check('schedule:start', item['start'], str)
             resp['repeatRule'] = self._check(
-                'schedule:repeatRule', item['repeatRule'], str)
+                'schedule:repeatRule', item['rrule'], str)
         return resp
 
 class SCResultsIterator(APIResultsIterator):

--- a/tenable/sc/base.py
+++ b/tenable/sc/base.py
@@ -213,7 +213,7 @@ class SCEndpoint(APIEndpoint):
         if resp['type'] == 'ical' and 'start' in item and 'repeatRule' in item:
             resp['start'] = self._check('schedule:start', item['start'], str)
             resp['repeatRule'] = self._check(
-                'schedule:repeatRule', item['rrule'], str)
+                'schedule:repeatRule', item['repeatRule'], str)
         return resp
 
 class SCResultsIterator(APIResultsIterator):

--- a/tenable/sc/scans.py
+++ b/tenable/sc/scans.py
@@ -111,7 +111,18 @@ class ScanAPI(SCEndpoint):
             # maxScanTime is a integer encased in a string value.  the snake
             # cased version of that expects an integer and converts it into the
             # string equivalent.
-            kw['maxScanTime'] = str(self._check('max_time', kw['max_time'], int))
+            # if given a value of 0 or less than 0, then 
+            # maxScanTime will be set to 'unlimited' 
+
+            kw['maxScanTime'] = self._check('max_time', kw['max_time'], int)
+
+            # at this point max_time should have been validated as an integer
+            # evaluate if it's equal to or less than 0, else cast the int as a str
+            if kw['max_time'] <= 0:
+                kw['maxScanTime'] = 'unlimited'
+            else:
+                kw['maxScanTime'] = str(kw['max_time'])
+            
             del(kw['max_time'])
 
         if 'auto_mitigation' in kw:


### PR DESCRIPTION
# Description

Changed the keyword 'rrule' to be consistent with the documentation section under Schedule dictionaries (issue 144). Updated scan constructor to support scans that never time out by making values equal to or less than 0 seconds as scans that never time out.


Fixes # 144, 149


