### PR TITLE
Adds #149, Fixes #158

### DIFF
--- a/tenable/sc/__init__.py
+++ b/tenable/sc/__init__.py
@@ -218,7 +218,7 @@ class TenableSC(APISession):
                 # if a token was passed in the system info page, then we should
                 # update the X-SecurityCenter header with the token info.
                 self._session.headers.update({
-                    'X-SecurityCenter': str(d['response']['token'])
+                    'X-SecurityCenter': str(self.info['token'])
                 })
         except:
             raise ConnectionError('Invalid Tenable.sc Instance')

--- a/tenable/sc/scans.py
+++ b/tenable/sc/scans.py
@@ -119,7 +119,11 @@ class ScanAPI(SCEndpoint):
             # maxScanTime is a integer encased in a string value.  the snake
             # cased version of that expects an integer and converts it into the
             # string equivalent.
-            kw['maxScanTime'] = str(self._check('max_time', kw['max_time'], int))
+            kw['maxScanTime'] = self._check('max_time', kw['max_time'], int)
+            if kw['maxScanTime'] <= 0:
+                kw['maxScanTime'] = 'unlimited';
+            else:
+                kw['maxScanTime'] = str(kw['maxScanTime'])
             del(kw['max_time'])
 
         if 'auto_mitigation' in kw:
@@ -248,6 +252,7 @@ class ScanAPI(SCEndpoint):
                 Should DHCP host tracking be enabled?  The default is False.
             max_time (int, optional):
                 The maximum amount of time that the scan may run in seconds.
+                ``0`` for unlimited.
                 The default is ``3600`` seconds.
             policy_id (int, optional):
                 The policy id to use for a policy-based scan.
@@ -356,6 +361,7 @@ class ScanAPI(SCEndpoint):
                 Should DHCP host tracking be enabled?
             max_time (int, optional):
                 The maximum amount of time that the scan may run in seconds.
+                ``0`` for unlimited.
             name (str, optional): The name of the scan.
             policy (int, optional):
                 The policy id to use for a policy-based scan.

--- a/tenable/sc/scans.py
+++ b/tenable/sc/scans.py
@@ -252,7 +252,7 @@ class ScanAPI(SCEndpoint):
                 Should DHCP host tracking be enabled?  The default is False.
             max_time (int, optional):
                 The maximum amount of time that the scan may run in seconds.
-                ``0`` for unlimited.
+                ``0`` or less for unlimited.
                 The default is ``3600`` seconds.
             policy_id (int, optional):
                 The policy id to use for a policy-based scan.
@@ -361,7 +361,7 @@ class ScanAPI(SCEndpoint):
                 Should DHCP host tracking be enabled?
             max_time (int, optional):
                 The maximum amount of time that the scan may run in seconds.
-                ``0`` for unlimited.
+                ``0`` or less for unlimited.
             name (str, optional): The name of the scan.
             policy (int, optional):
                 The policy id to use for a policy-based scan.


### PR DESCRIPTION
# Description

Adds the ability for setting max_time to unlimited per #149 
Fixes a bug preventing users from logging into security center using a certificate per #158 

## Type of change

- [x] Bug fix
- [x] This change requires a documentation update (done)

# How Has This Been Tested?

Configured a new scan in dev instance of tenable security center server
Certificate authentication succeeded, scan had time set to unlimited
