### PR TITLE
Use platform.uname over os.uname for portability

### DIFF
--- a/tenable/base.py
+++ b/tenable/base.py
@@ -1,7 +1,7 @@
 '''
 .. autoclass:: APIResultsIterator
 '''
-import requests, sys, os, logging, re, time, logging, warnings, json
+import requests, sys, platform, logging, re, time, logging, warnings, json
 from .errors import *
 from . import __version__, __author__
 
@@ -374,7 +374,7 @@ class APISession(object):
             self._session.proxies.update(self._proxies)
 
         # Update the User-Agent string with the information necessary.
-        uname = os.uname()
+        uname = platform.uname()
         self._session.headers.update({
             'User-Agent': ' '.join([
                 'Integration/1.0 ({}; {}; Build/{})'.format(
@@ -402,7 +402,7 @@ class APISession(object):
                     uname[0],
 
                     # The source Arch
-                    uname[-1]
+                    uname[-2]
                 ),
             ])
         })


### PR DESCRIPTION
# Description

Switching to us `platform.uname()` rather than `os.uname()` as the latter is not supported in Windows. See https://docs.python.org/3/library/platform.html for more information. To support python 2.x we will continue using indices to access uname values rather name properties from the namedtuple. 

The only difference in switching from `os` to `platform` is that `platform.uname()` also includes a processor in it's output as the final element, meaning we need to change from `-1` to `-2`.

Fixes # (issue)
#164 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in various versions of python on macOS Mojave. 

**Test Configuration**:
* Python Version(s) Tested:
* 2.7.10
* 3.7.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
