### PR TITLE
Enable export of web-app scans

### DIFF
--- a/tenable/io/base.py
+++ b/tenable/io/base.py
@@ -89,17 +89,17 @@ class TIOEndpoint(APIEndpoint):
 
         return resp
 
-    def _wait_for_download(self, path, resource, resource_id, file_id):
+    def _wait_for_download(self, path, resource, resource_id, file_id, **kw):
         '''
         A simple method to centralize waiting for an export to enter a
         completed state.  The initial request will be made and then we will
         recheck every two and a half seconds after that.  Once the status
         returns one of the completed states, we will return the status.
         '''
-        status = self._api.get(path).json()['status']
+        status = self._api.get(path, **kw).json()['status']
         while status not in ['error', 'ready']:
             time.sleep(2.5)
-            status = self._api.get(path).json()['status']
+            status = self._api.get(path, **kw).json()['status']
 
         # If the status that has been reported back is "error", then we will
         # need to throw the appropriate error back to the user.

--- a/tests/io/cassettes/test_scan_export_was.yaml
+++ b/tests/io/cassettes/test_scan_export_was.yaml
@@ -1,0 +1,5301 @@
+interactions:
+- request:
+    body: '{"format": "nessus", "chapters": "vuln_by_host"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '48'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.0.0
+        (pyTenable/1.0.0; Python/3.8.1; Linux/x86_64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scans/6799/export?type=web-app
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSsvMSVWyUkoxNTIxNjQx1zUzMDbRNbFIMdW1NDQy0k0zNzBJTTI0TDYySFSq
+        BQDIL1IKLwAAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 09 Jan 2020 01:26:57 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=ap-syd-1; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=ap-syd-1; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-uhhl3-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 99d422cd9a2a2a4ff47c342c61685284
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=ap-syd-1
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.0.0
+        (pyTenable/1.0.0; Python/3.8.1; Linux/x86_64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/6799/export/d5243147-6034-48d5-9122-f704eb11c20a/status?type=web-app
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWKi5JLCktVrJSKkpNTKlUqgUAnw0ZyRIAAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 09 Jan 2020 01:26:58 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=ap-syd-1; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=ap-syd-1; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-uhhl3-ap-southeast-1-prod
+      X-Request-Uuid:
+      - a4c7eb5e2c6fadae9b03754a4c8edd45
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=ap-syd-1
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.0.0
+        (pyTenable/1.0.0; Python/3.8.1; Linux/x86_64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/6799/export/d5243147-6034-48d5-9122-f704eb11c20a/download?type=web-app
+  response:
+    body:
+      string: "<?xml version=\"1.0\" ?>\n<NessusClientData_v2><Policy><policyName/><policyComments/><Preferences><ServerPreferences><preference><name>scan_description</name><value/></preference><preference><name>name</name><value>gruyere</value></preference><preference><name>was_debug_mode</name><value>no</value></preference><preference><name>wizard_uuid</name><value>09805055-a034-4088-8986-aac5e1c57d5f0d44f09d736969bf</value></preference><preference><name>was_http_request_concurrency</name><value>10</value></preference><preference><name>was_audit_ui_forms</name><value>yes</value></preference><preference><name>was_chrome_script_command_wait</name><value>500</value></preference><preference><name>was_scope_exclude_binaries</name><value>1</value></preference><preference><name>was_http_custom_user_agent</name><value>no</value></preference><preference><name>was_assessment_dictionary</name><value>limited</value></preference><preference><name>assessment_mode</name><value>was_quick</value></preference><preference><name>was_http_response_max_size</name><value>500000</value></preference><preference><name>was_plugins_rate_limiter_requests_per_second</name><value>25</value></preference><preference><name>was_audit_xmls</name><value>no</value></preference><preference><name>was_browser_cluster_screen_height</name><value>1200</value></preference><preference><name>was_audit_jsons</name><value>no</value></preference><preference><name>was_audit_ui_inputs</name><value>yes</value></preference><preference><name>was_scope_directory_depth_limit</name><value>10</value></preference><preference><name>was_plugins_rate_limiter_timeout_threshold</name><value>100</value></preference><preference><name>was_assessment_enable</name><value>1</value></preference><preference><name>was_chrome_script_finish_wait</name><value>5000</value></preference><preference><name>was_scope_exclude_file_extensions</name><value>js,
+        css, png, jpeg, gif, pdf, csv, svn-base, svg, jpg, ico</value></preference><preference><name>was_scope_auto_redundant_paths</name><value>2</value></preference><preference><name>was_plugins_autothrottle</name><value>yes</value></preference><preference><name>was_http_request_headers</name><value>Accept:
+        text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\nAccept-Language:
+        en-US,en;q=0.5</value></preference><preference><name>visibility</name><value>private</value></preference><preference><name>was_audit_parameter_values</name><value>yes</value></preference><preference><name>was_scope_exclude_path_patterns</name><value>logout</value></preference><preference><name>was_scope_page_limit</name><value>10000</value></preference><preference><name>was_browser_cluster_ignore_images</name><value>yes</value></preference><preference><name>was_audit_cookies</name><value>yes</value></preference><preference><name>was_audit_parameter_names</name><value>no</value></preference><preference><name>was_scope_dom_depth_limit</name><value>5</value></preference><preference><name>was_browser_pool_size</name><value>3</value></preference><preference><name>was_assessment_rfi_remote_url</name><value>http://rfi.nessus.org/rfi.txt</value></preference><preference><name>was_timeout</name><value>08:00:00</value></preference><preference><name>was_http_request_redirect_limit</name><value>2</value></preference><preference><name>was_audit_headers</name><value>yes</value></preference><preference><name>was_http_request_timeout</name><value>5</value></preference><preference><name>was_scope_option</name><value>all</value></preference><preference><name>was_audit_links</name><value>yes</value></preference><preference><name>was_browser_cluster_job_timeout</name><value>10</value></preference><preference><name>was_audit_forms</name><value>yes</value></preference><preference><name>was_chrome_script_page_load_wait</name><value>10000</value></preference><preference><name>was_browser_cluster_screen_width</name><value>1600</value></preference><preference><name>http_include_scan_id</name><value>no</value></preference><preference><name>was_scope_decompose_paths</name><value>no</value></preference><preference><name>tenableio.scan_uuid</name><value>e48ec0f3-8cfb-48c8-a353-8fe1b5f53c59</value></preference><preference><name>tenableio.scan_nonce</name><value>2b21091c6be8c407bbb7e464f3aaed54b982d84a3c4ed19fa9a800ab8623a2ff</value></preference><preference><name>tenableio.site_id</name><value>ap-syd-1</value></preference></ServerPreferences><PluginsPreferences/></Preferences><FamilySelection/><IndividualPluginSelection/></Policy><Report
+        name=\"google-gruyere.appspot.com\" xmlns:cm=\"http://www.nessus.org/cm\"><ReportHost
+        name=\"google-gruyere.appspot.com\"><HostProperties><tag name=\"host-fqdn\">google-gruyere.appspot.com</tag><tag
+        name=\"system-type\">web_application</tag><tag name=\"HOST_START\">Tue Jan
+        \ 7 03:32:56 2020</tag><tag name=\"HOST_END\">Tue Jan  7 09:25:23 2020</tag></HostProperties><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98050\"
+        pluginName=\"Interesting response\" pluginFamily=\"Web Applications\"><description>The
+        scanner identified some responses with a status code other than the usual
+        200 (OK), 301 (Moved Permanently), 302 (Found) and 404 (Not Found) codes.\n
+        \ These codes can provide useful insights into the behavior of the web application
+        and identify any unexpected responses to be addressed.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2018/05/09</plugin_modification_date><plugin_name>Interesting
+        response</plugin_name><risk_factor>Informational</risk_factor><see_also>http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html</see_also><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/part1\n\n\nProof\n-------\nHTTP/1.1
+        400 Bad Request\n\n\nRequest\n---------\n\nGET /part1 HTTP/1.1\n | Accept-Encoding:
+        gzip, deflate\n | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Host: print 28763*4196403\n | Cookie:
+        GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        400 Bad Request\n | Content-Type: text/html; charset=UTF-8\n | Referrer-Policy:
+        no-referrer\n | Content-Length: 1555\n | Date: Tue, 07 Jan 2020 04:21:23 GMT\n
+        | \n | &lt;!DOCTYPE html>\n&lt;html lang=en>\n  &lt;meta charset=utf-8>\n
+        \ &lt;meta name=viewport content=\"initial-scale=1, minimum-scale=1, width=device-width\">\n
+        \ &lt;title>Error 400 (Bad Request)!!1&lt;/title>\n  &lt;style>\n    *{margin:0;padding:0}html,code{font:15px/22px
+        arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7%
+        auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png)
+        100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a
+        img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png)
+        no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png)
+        no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png)
+        0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png)
+        no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}\n
+        \ &lt;/style>\n  &lt;a href=//www.google.com/>&lt;span id=logo aria-label=Google>&lt;/span>&lt;/a>\n
+        \ &lt;p>&lt;b>400.&lt;/b> &lt;ins>That?????????s an error.&lt;/ins>\n  &lt;p>Your
+        client has issued a malformed or illegal request.  &lt;ins>That?????????s
+        all we know.&lt;/ins>\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\" pluginName=\"Cross-Site
+        Scripting (XSS) in path\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  the requested PATH and have it returned in the server's
+        response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`, where `INJECTION_HERE`\n
+        \ represents the location where the scanner payload was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/412569245047960484377262321708701598236\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/%3E%22'%3E%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        86ac2494596d59626a6b8ba34d852ab5\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 04:39:53 GMT\n | Server: Google Frontend\n | Content-Length: 907\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: />\"'>&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98104\"
+        pluginName=\"Cross-Site Scripting (XSS)\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  HTML element content.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS)</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : &lt;xss_6332112/>\n\n\n\nProof\n-------\n&lt;xss_6332112/>\n\n\nRequest\n---------\n\nGET
+        /531899522745731123167764836993191970177/snippets.gtl?uid=cheddar%3Cxss_6332112%2F%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        31aa322a05110396c39a281d63f35256\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 04:46:43 GMT\n | Server: Google Frontend\n | Content-Length: 1011\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/531899522745731123167764836993191970177/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/531899522745731123167764836993191970177/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/531899522745731123167764836993191970177/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/531899522745731123167764836993191970177/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar&lt;xss_6332112/>\n  \n\n\n&lt;/h2>\n&lt;div
+        class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"531899522745731123167764836993191970177\",
+        \"cheddar&lt;xss_6332112/>\")'\n  href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div
+        class='content'>\n\n\n  \n    cheddar&lt;xss_6332112/>\n    is not an author.\n
+        \ \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98050\"
+        pluginName=\"Interesting response\" pluginFamily=\"Web Applications\"><description>The
+        scanner identified some responses with a status code other than the usual
+        200 (OK), 301 (Moved Permanently), 302 (Found) and 404 (Not Found) codes.\n
+        \ These codes can provide useful insights into the behavior of the web application
+        and identify any unexpected responses to be addressed.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2018/05/09</plugin_modification_date><plugin_name>Interesting
+        response</plugin_name><risk_factor>Informational</risk_factor><see_also>http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html</see_also><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/code/index.php?s=captcha\n\n\nProof\n-------\nHTTP/1.1
+        405 Method Not Allowed\n\n\nRequest\n---------\n\nPOST /code/index.php?s=captcha
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Content-Type: application/x-www-form-urlencoded\n
+        | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n | Content-Length:
+        71\n | \n | _method=__construct&amp;filter[]=system&amp;method=get&amp;server[]=cat%20index.php\n\nResponse\n----------\n\nHTTP/1.1
+        405 Method Not Allowed\n | Allow: GET\n | Content-Type: text/html; charset=UTF-8\n
+        | Content-Encoding: gzip\n | X-Cloud-Trace-Context: ee1486787f9cb79f8cb176af7d5e4e63\n
+        | Vary: Accept-Encoding\n | Date: Tue, 07 Jan 2020 04:52:11 GMT\n | Server:
+        Google Frontend\n | Cache-Control: private\n | Content-Length: 142\n | \n
+        | &lt;html>\n &lt;head>\n  &lt;title>405 Method Not Allowed&lt;/title>\n &lt;/head>\n
+        &lt;body>\n  &lt;h1>405 Method Not Allowed&lt;/h1>\n  The method POST is not
+        allowed for this resource. &lt;br />&lt;br />\n\n &lt;/body>\n&lt;/html></plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98105\"
+        pluginName=\"Cross-Site Scripting (XSS) in HTML tag\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert content directly into an HTML\n  tag. For example
+        `&lt;INJECTION_HERE href=.......etc>` where `INJECTION_HERE`\n  represents
+        the location where the scanner payload was detected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in HTML tag</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/412569245047960484377262321708701598236/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : ' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n\n\n\nProof\n-------\n' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n\n\nRequest\n---------\n\nGET /412569245047960484377262321708701598236/snippets.gtl?uid=cheddar%27%20tenable_wasscan_xss_in_tag%3D%2736b4c4a8-603d-435a-8d44-9ec90d4b9777%27%20blah%3D%27
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        52a9bacf8d0b74f6a84e4cfd515649b3\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:24:13 GMT\n | Server: Google Frontend\n | Content-Length: 1061\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/412569245047960484377262321708701598236/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n  \n\n\n&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"412569245047960484377262321708701598236\",
+        \"cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\")'\n  href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div class='content'>\n\n\n
+        \ \n    cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n    is not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177/newaccount.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /531899522745731123167764836993191970177/newaccount.gtl/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        8217a5cede7d77166f17e9e2daff42d3\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:30:27 GMT\n | Server: Google Frontend\n | Content-Length: 905\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/531899522745731123167764836993191970177/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/531899522745731123167764836993191970177/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/531899522745731123167764836993191970177/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /newaccount.gtl/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98081\"
+        pluginName=\"Password field with auto-complete\" pluginFamily=\"Authentication
+        &amp; Session\"><description>In typical form-based web applications, it is
+        common practice for developers to\n  allow `autocomplete` within the HTML
+        form to improve the usability of the page.\n  With `autocomplete` enabled
+        (default), the browser is allowed to cache previously\n  entered form values.\n\n
+        \ For legitimate purposes, this allows the user to quickly re-enter the same
+        data\n  when completing the form multiple times.\n\n  When `autocomplete`
+        is enabled on either/both the username and password fields,\n  this could
+        allow a cyber-criminal with access to the victim's computer the ability\n
+        \ to have the victim's credentials automatically entered as the cyber-criminal\n
+        \ visits the affected page.\n\n  Scanner has discovered that the affected
+        page contains a form containing a\n  password field that has not disabled
+        `autocomplete`.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Password
+        field with auto-complete</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)</see_also><solution>The
+        `autocomplete` value can be configured in two different locations.\n  The
+        first and most secure location is to disable the `autocomplete` attribute
+        on   the `&lt;form>` HTML tag. This will disable `autocomplete` for all inputs
+        within that form.   An example of disabling `autocomplete` within the form
+        tag is `&lt;form autocomplete=off>`.\n  The second slightly less desirable
+        option is to disable the `autocomplete` attribute   for a specific `&lt;input>`
+        HTML tag.   While this may be the less desired solution from a security perspective,
+        it may   be preferred method for usability reasons, depending on size of the
+        form.   An example of disabling the `autocomplete` attribute within a password
+        input tag   is `&lt;input type=password autocomplete=off>`.</solution><xref>owasp:2010-A6</xref><xref>cwe:16</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        following form has been found to have not restricted Password Auto Complete:\n\n&lt;form
+        method=\"get\" action=\"/412569245047960484377262321708701598236/login\">\n
+        \ &lt;input type=\"text\" name=\"uid\">\n  &lt;/input>\n  &lt;input type=\"password\"
+        name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"submit\" value=\"Login\">\n
+        \ &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\" pluginName=\"Error
+        Message\" pluginFamily=\"Data Exposure\"><description>An error or warning
+        message has been found on the remote web server. It may be possible for an
+        attacker to view sensitive information and conduct further attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On http://google-gruyere.appspot.com/412569245047960484377262321708701598236/newaccount.gtl
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;b>WARNING: Gruyere is not secure.</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/&amp;gt\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/&amp;gt/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        ec8664212f62433a1dc86be3a68c8a17\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:30:25 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /&amp;gt/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98108\"
+        pluginName=\"Cross-Site Scripting (XSS) in event tag of HTML element\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  an HTML event
+        attribute. For example `&lt;div onmouseover=\"x=INJECTION_HERE\"&lt;/div>`,\n
+        \ where `INJECTION_HERE` represents the location where the scanner payload
+        was detected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in event tag of HTML element</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   :  script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n\n\n\nProof\n-------\n_refreshsnippets(\"412569245047960484377262321708701598236\",
+        \"cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\")\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/snippets.gtl?uid=cheddar%20script%3A%3Btenable_wasscan_xss_in_element_event%3D36b4c4a8-603d-435a-8d44-9ec90d4b9777%2F%2F
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        a45e78b898bf29e4674788dc7934f27f\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:35:58 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/412569245047960484377262321708701598236/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n
+        \ \n\n\n&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"412569245047960484377262321708701598236\",
+        \"cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\")'\n
+        \ href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div class='content'>\n\n\n  \n    cheddar
+        script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n
+        \   is not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /652479776707981538544840512166060390157//%3E%22'%3E%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        e02efe0781bdaa145546de3e625d9570\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:34:48 GMT\n | Server: Google Frontend\n | Content-Length: 906\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: //>\"'>&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"115491\"
+        pluginName=\"SSL/TLS Cipher Suites Supported\" pluginFamily=\"SSL/TLS\"><description>This
+        plugin displays supported SSL/TLS cipher suites.</description><plugin_publication_date>2019/01/09</plugin_publication_date><plugin_modification_date>2019/01/09</plugin_modification_date><plugin_name>SSL/TLS
+        Cipher Suites Supported</plugin_name><risk_factor>Informational</risk_factor><plugin_output>\nCipher
+        Suite Name (RFC)\t\t\t\t-\tOpenSSL Name\t\t-\tEncryption  -   KeyExchange
+        \ -  Bits\n------------------------------------------------------------------------------------------------------------------------------------\n\n------\t\t\t\t\t------\t\t\t\tTLS1.0\t\t------\t\t------\n\nTLS_RSA_WITH_3DES_EDE_CBC_SHA\t\t\t\tDES-CBC3-SHA\t\t\t3DES\t\tRSA\t\t168\nTLS_RSA_WITH_AES_128_CBC_SHA\t\t\t\tAES128-SHA\t\t\tAES\t\tRSA\t\t128\nTLS_RSA_WITH_AES_256_CBC_SHA\t\t\t\tAES256-SHA\t\t\tAES\t\tRSA\t\t256\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\t\t\tECDHE-RSA-AES128-SHA\t\tAES\t\tECDH\t\t128\nTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\t\t\tECDHE-RSA-AES256-SHA\t\tAES\t\tECDH\t\t256\n\n------\t\t\t\t\t------\t\t\t\tTLS1.1\t\t------\t\t------\n\nTLS_RSA_WITH_3DES_EDE_CBC_SHA\t\t\t\tDES-CBC3-SHA\t\t\t3DES\t\tRSA\t\t168\nTLS_RSA_WITH_AES_128_CBC_SHA\t\t\t\tAES128-SHA\t\t\tAES\t\tRSA\t\t128\nTLS_RSA_WITH_AES_256_CBC_SHA\t\t\t\tAES256-SHA\t\t\tAES\t\tRSA\t\t256\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\t\t\tECDHE-RSA-AES128-SHA\t\tAES\t\tECDH\t\t128\nTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\t\t\tECDHE-RSA-AES256-SHA\t\tAES\t\tECDH\t\t256\n\n------\t\t\t\t\t------\t\t\t\tTLS1.2\t\t------\t\t------\n\nTLS_RSA_WITH_3DES_EDE_CBC_SHA\t\t\t\tDES-CBC3-SHA\t\t\t3DES\t\tRSA\t\t168\nTLS_RSA_WITH_AES_128_CBC_SHA\t\t\t\tAES128-SHA\t\t\tAES\t\tRSA\t\t128\nTLS_RSA_WITH_AES_256_CBC_SHA\t\t\t\tAES256-SHA\t\t\tAES\t\tRSA\t\t256\nTLS_RSA_WITH_AES_128_GCM_SHA256\t\t\t\tAES128-GCM-SHA256\t\tAESGCM\t\tRSA\t\t128\nTLS_RSA_WITH_AES_256_GCM_SHA384\t\t\t\tAES256-GCM-SHA384\t\tAESGCM\t\tRSA\t\t256\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA\t\t\tECDHE-RSA-AES128-SHA\t\tAES\t\tECDH\t\t128\nTLS_ECDHE_RSA_WITH_AES_256_CBC_SHA\t\t\tECDHE-RSA-AES256-SHA\t\tAES\t\tECDH\t\t256\nTLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\t\t\tECDHE-RSA-AES128-GCM-SHA256\tAESGCM\t\tECDH\t\t128\nTLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\t\t\tECDHE-RSA-AES256-GCM-SHA384\tAESGCM\t\tECDH\t\t256\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98033\"
+        pluginName=\"Login Form Detected\" pluginFamily=\"Authentication &amp; Session\"><description>This
+        is an informational notice that the scanner identified a potential login form
+        that could be used by the scanner to authenticate and have access to additional
+        pages for extending its coverage.</description><plugin_publication_date>2018/02/08</plugin_publication_date><plugin_modification_date>2018/02/08</plugin_modification_date><plugin_name>Login
+        Form Detected</plugin_name><risk_factor>Informational</risk_factor><solution>Edit
+        scan policy and add login form authentication credentials to allow scanner
+        to authenticate to the web application.</solution><plugin_output>Potential
+        login form has been identified in URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/login'
+        with following fields:\n- uid (TEXT)\n- pw (PASSWORD)\nTo perform authenticated
+        scan, configure your scan and add 'Login Form' authentication, with the URL
+        associated to this plugin and as login parameters values for the above non-hidden
+        fields.</plugin_output></ReportItem><ReportItem port=\"80\" svc_name=\"http\"
+        protocol=\"TCP\" severity=\"1\" pluginID=\"98612\" pluginName=\"Missing 'Expect-CT'
+        Header\" pluginFamily=\"HTTP Security Header\"><description>The Expect-CT
+        header allows sites to opt in to reporting and or enforcement of Certificate
+        Transparency requirements, which prevents the use of misissued certificates
+        for that site from going unnoticed. This URL is flagged as an specific example.</description><plugin_publication_date>2019/05/29</plugin_publication_date><plugin_modification_date>2019/05/29</plugin_modification_date><plugin_name>Missing
+        'Expect-CT' Header</plugin_name><risk_factor>Low</risk_factor><see_also>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Expect-CT</see_also><solution>Configure
+        your web server to include an 'Expect-CT' header with a value of 'maxage'
+        defined therein.</solution><xref>owasp:2010-A6</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>cwe:693</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        Expect-Ct header was not detected on http://google-gruyere.appspot.com/652479776707981538544840512166060390157/</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/%253e%253c\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/%253e%253c/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        2bb80110dab6b239f103d92ba84788d1\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:26:35 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /%3e%3c/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98104\"
+        pluginName=\"Cross-Site Scripting (XSS)\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  HTML element content.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS)</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : ()\"&amp;%1'-;&lt;xss_5428095/>'\n\n\n\nProof\n-------\n&lt;xss_5428095/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/snippets.gtl?uid=cheddar%28%29%22%26%251%27-%3B%3Cxss_5428095%2F%3E%27
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        37bfcc6d5690630f9cdd7262b597b220\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:34:57 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/412569245047960484377262321708701598236/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar()\"&amp;%1'-;&lt;xss_5428095/>'\n  \n\n\n&lt;/h2>\n&lt;div
+        class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"412569245047960484377262321708701598236\",
+        \"cheddar()\"&amp;%1'-;&lt;xss_5428095/>'\")'\n  href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div
+        class='content'>\n\n\n  \n    cheddar()\"&amp;%1'-;&lt;xss_5428095/>'\n    is
+        not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236//%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        af1071f10cf51ee6169b72adf07ba14a\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:36:02 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: //&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98105\"
+        pluginName=\"Cross-Site Scripting (XSS) in HTML tag\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert content directly into an HTML\n  tag. For example
+        `&lt;INJECTION_HERE href=.......etc>` where `INJECTION_HERE`\n  represents
+        the location where the scanner payload was detected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in HTML tag</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : ' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n\n\n\nProof\n-------\n' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n\n\nRequest\n---------\n\nGET /412569245047960484377262321708701598236/snippets.gtl?uid=cheddar%27%20tenable_wasscan_xss_in_tag%3D%2736b4c4a8-603d-435a-8d44-9ec90d4b9777%27%20blah%3D%27
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        c21b659c5c9295128e4edbbd4b83621f\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:36:39 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/412569245047960484377262321708701598236/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n  \n\n\n&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"412569245047960484377262321708701598236\",
+        \"cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\")'\n  href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div class='content'>\n\n\n
+        \ \n    cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n    is not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/%3Cscript%3Ealert(1)%3C/script%3E\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/%3Cscript%3Ealert(1)%3C/script%3E/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        6bb8687870696a11ddddbac8dd853c09\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:42:07 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /&lt;script>alert(1)&lt;/script>/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/...\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/.../%3E%22'%3E%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        37829cf1f668e8492b9fa73cd5a1713d\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:02:29 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head&gt;\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /.../>\"'>&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"112529\"
+        pluginName=\"Missing 'X-Content-Type-Options' Header\" pluginFamily=\"HTTP
+        Security Header\"><description>The HTTP 'X-Content-Type-Options' response
+        header prevents the browser from MIME-sniffing a response away from the declared
+        content-type.\n\nThe server did not return a correct 'X-Content-Type-Options'
+        header, which means that this website could be at risk of a Cross-Site Scripting
+        (XSS) attack.</description><plugin_publication_date>2018/11/28</plugin_publication_date><plugin_modification_date>2018/11/28</plugin_modification_date><plugin_name>Missing
+        'X-Content-Type-Options' Header</plugin_name><risk_factor>Low</risk_factor><see_also>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options</see_also><solution>Configure
+        your web server to include an 'X-Content-Type-Options' header with a value
+        of 'nosniff'.</solution><xref>owasp:2010-A6</xref><xref>wasc:Application Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>cwe:693</xref><xref>owasp:2017-A6</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/\n\n\nProof\n-------\nHTTP/1.1
+        200 OK\n\n\nRequest\n---------\n\nGET /652479776707981538544840512166060390157/
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        0399f435f593ffed93624f1095f9ccf1\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:33:03 GMT\n | Server: Google Frontend\n | Content-Length: 1226\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Home&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/652479776707981538544840512166060390157/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'>Gruyere:
+        Home&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button' onclick='_refreshHome(\"652479776707981538544840512166060390157\")'
+        href='#'>Refresh&lt;/a>&lt;/div>\n&lt;/div>\n&lt;div class='content'>\n&lt;table
+        width='100%'>\n\n  &lt;tr>&lt;td colspan='3'>&lt;b>Most recent snippets:&lt;/b>&lt;/td>&lt;/tr>\n\n\n\n\n\n\n
+        \ &lt;tr>\n    &lt;td>\n     \n    &lt;/td>\n    &lt;td>\n      &lt;b>&lt;span
+        style='color:blue'>Cheddar Mac&lt;/span>&lt;/b>\n    &lt;/td>\n    &lt;td
+        width='100%'>&lt;span id='cheddar'>Gruyere is the cheesiest application on
+        the web.&lt;/span>\n    &lt;br>\n          &lt;a href='/652479776707981538544840512166060390157/snippets.gtl?uid=cheddar'>All
+        snippets&lt;/a>&amp;nbsp;\n      &lt;a href='https://images.google.com/?q=cheddar+cheese'>Homepage&lt;/a>\n
+        \   &lt;br>\n    &lt;br>\n    &lt;/td>\n  &lt;/tr>\n\n\n\n  &lt;tr>\n    &lt;td>\n
+        \    \n    &lt;/td>\n    &lt;td>\n      &lt;b>&lt;span style='color:red; text-decoration:underline'>Brie&lt;/span>&lt;/b>\n
+        \   &lt;/td>\n    &lt;td width='100%'>&lt;span id='brie'>Brie is the queen
+        of the cheeses&lt;span style=color:red>!!!&lt;/span>&lt;/span>\n    &lt;br>\n
+        \         &lt;a href='/652479776707981538544840512166060390157/snippets.gtl?uid=brie'>All
+        snippets&lt;/a>&amp;nbsp;\n      &lt;a href='https://news.google.com/news/search?q=brie'>Homepage&lt;/a>\n
+        \   &lt;br>\n    &lt;br>\n    &lt;/td>\n  &lt;/tr>\n\n\n&lt;/table>\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98105\"
+        pluginName=\"Cross-Site Scripting (XSS) in HTML tag\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert content directly into an HTML\n  tag. For example
+        `&lt;INJECTION_HERE href=.......etc>` where `INJECTION_HERE`\n  represents
+        the location where the scanner payload was detected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in HTML tag</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : ' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n\n\n\nProof\n-------\n' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n\n\nRequest\n---------\n\nGET /652479776707981538544840512166060390157/snippets.gtl?uid=cheddar%27%20tenable_wasscan_xss_in_tag%3D%2736b4c4a8-603d-435a-8d44-9ec90d4b9777%27%20blah%3D%27
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        006f791ea68f27ded7179626700e1a87\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:35:17 GMT\n | Server: Google Frontend\n | Content-Length: 1059\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/652479776707981538544840512166060390157/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n  \n\n\n&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"652479776707981538544840512166060390157\",
+        \"cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\")'\n  href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div class='content'>\n\n\n
+        \ \n    cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n    is not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/login\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /652479776707981538544840512166060390157/login/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        52a0a798eb7fa889ba78f484647beb46\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:37:41 GMT\n | Server: Google Frontend\n | Content-Length: 904\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /login/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\"
+        pluginName=\"Error Message\" pluginFamily=\"Data Exposure\"><description>An
+        error or warning message has been found on the remote web server. It may be
+        possible for an attacker to view sensitive information and conduct further
+        attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On http://google-gruyere.appspot.com/652479776707981538544840512166060390157/newaccount.gtl
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;b>WARNING: Gruyere is not secure.</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98033\"
+        pluginName=\"Login Form Detected\" pluginFamily=\"Authentication &amp; Session\"><description>This
+        is an informational notice that the scanner identified a potential login form
+        that could be used by the scanner to authenticate and have access to additional
+        pages for extending its coverage.</description><plugin_publication_date>2018/02/08</plugin_publication_date><plugin_modification_date>2018/02/08</plugin_modification_date><plugin_name>Login
+        Form Detected</plugin_name><risk_factor>Informational</risk_factor><solution>Edit
+        scan policy and add login form authentication credentials to allow scanner
+        to authenticate to the web application.</solution><plugin_output>Potential
+        login form has been identified in URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/login'
+        with following fields:\n- uid (TEXT)\n- pw (PASSWORD)\nTo perform authenticated
+        scan, configure your scan and add 'Login Form' authentication, with the URL
+        associated to this plugin and as login parameters values for the above non-hidden
+        fields.</plugin_output></ReportItem><ReportItem port=\"80\" svc_name=\"http\"
+        protocol=\"TCP\" severity=\"1\" pluginID=\"98081\" pluginName=\"Password field
+        with auto-complete\" pluginFamily=\"Authentication &amp; Session\"><description>In
+        typical form-based web applications, it is common practice for developers
+        to\n  allow `autocomplete` within the HTML form to improve the usability of
+        the page.\n  With `autocomplete` enabled (default), the browser is allowed
+        to cache previously\n  entered form values.\n\n  For legitimate purposes,
+        this allows the user to quickly re-enter the same data\n  when completing
+        the form multiple times.\n\n  When `autocomplete` is enabled on either/both
+        the username and password fields,\n  this could allow a cyber-criminal with
+        access to the victim's computer the ability\n  to have the victim's credentials
+        automatically entered as the cyber-criminal\n  visits the affected page.\n\n
+        \ Scanner has discovered that the affected page contains a form containing
+        a\n  password field that has not disabled `autocomplete`.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Password
+        field with auto-complete</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)</see_also><solution>The
+        `autocomplete` value can be configured in two different locations.\n  The
+        first and most secure location is to disable the `autocomplete` attribute
+        on   the `&lt;form>` HTML tag. This will disable `autocomplete` for all inputs
+        within that form.   An example of disabling `autocomplete` within the form
+        tag is `&lt;form autocomplete=off>`.\n  The second slightly less desirable
+        option is to disable the `autocomplete` attribute   for a specific `&lt;input>`
+        HTML tag.   While this may be the less desired solution from a security perspective,
+        it may   be preferred method for usability reasons, depending on size of the
+        form.   An example of disabling the `autocomplete` attribute within a password
+        input tag   is `&lt;input type=password autocomplete=off>`.</solution><xref>owasp:2010-A6</xref><xref>cwe:16</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        following form has been found to have not restricted Password Auto Complete:\n\n&lt;form
+        method=\"get\" action=\"/531899522745731123167764836993191970177/login\">\n
+        \ &lt;input type=\"text\" name=\"uid\">\n  &lt;/input>\n  &lt;input type=\"password\"
+        name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"submit\" value=\"Login\">\n
+        \ &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\" pluginName=\"Cross-Site
+        Scripting (XSS) in path\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  the requested PATH and have it returned in the server's
+        response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`, where `INJECTION_HERE`\n
+        \ represents the location where the scanner payload was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177/login\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /531899522745731123167764836993191970177/login/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        cfe7aa07c4507b0ba7c5d6adfd01d747\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:26:37 GMT\n | Server: Google Frontend\n | Content-Length: 905\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/531899522745731123167764836993191970177/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/531899522745731123167764836993191970177/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/531899522745731123167764836993191970177/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /login/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"2\" pluginID=\"98082\"
+        pluginName=\"Unencrypted password form\" pluginFamily=\"Authentication &amp;
+        Session\"><description>The HTTP protocol by itself is clear text, meaning
+        that any data that is\n  transmitted via HTTP can be captured and the contents
+        viewed.\n\n  To keep data private, and prevent it from being intercepted,
+        HTTP is often\n  tunnelled through either Secure Sockets Layer (SSL), or Transport
+        Layer Security\n  (TLS).\n  When either of these encryption standards are
+        used it is referred to as HTTPS.\n\n  Cyber-criminals will often attempt to
+        compromise credentials passed from the\n  client to the server using HTTP.\n
+        \ This can be conducted via various different Man-in-The-Middle (MiTM) attacks
+        or\n  through network packet captures.\n\n  Scanner discovered that the affected
+        page contains a `password` input, however,\n  the value of the field is not
+        sent to the server utilising HTTPS. Therefore it\n  is possible that any submitted
+        credential may become compromised.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Unencrypted
+        password form</plugin_name><risk_factor>Medium</risk_factor><see_also>http://www.owasp.org/index.php/Top_10_2010-A9-Insufficient_Transport_Layer_Protection</see_also><solution>The
+        affected site should be secured utilising the latest and most secure encryption
+        \  protocols.   These include SSL version 3.0 and TLS version 1.2. While TLS
+        1.2 is the latest   and the most preferred protocol, not all browsers will
+        support this encryption   method. Therefore, the more common SSL is included.
+        Older protocols such as SSL   version 2, and weak ciphers (&lt; 128 bit) should
+        also be disabled.</solution><xref>owasp:2017-A3</xref><xref>owasp:2010-A9</xref><xref>cwe:319</xref><xref>owasp:2017-A2</xref><xref>cwe:523</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><xref>owasp:2010-A3</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177/newaccount.gtl\n\n\nProof\n-------\n&lt;form
+        method=\"get\" action=\"/531899522745731123167764836993191970177/saveprofile\">\n
+        \ &lt;input type=\"hidden\" name=\"action\" value=\"new\">\n  &lt;/input>\n
+        \ &lt;input type=\"text\" name=\"uid\" value=\"\" maxlength=\"16\">\n  &lt;/input>\n
+        \ &lt;input type=\"password\" name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"hidden\"
+        name=\"is_author\" value=\"True\">\n  &lt;/input>\n  &lt;input type=\"submit\"
+        value=\"Create account\">\n  &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98081\"
+        pluginName=\"Password field with auto-complete\" pluginFamily=\"Authentication
+        &amp; Session\"><description>In typical form-based web applications, it is
+        common practice for developers to\n  allow `autocomplete` within the HTML
+        form to improve the usability of the page.\n  With `autocomplete` enabled
+        (default), the browser is allowed to cache previously\n  entered form values.\n\n
+        \ For legitimate purposes, this allows the user to quickly re-enter the same
+        data\n  when completing the form multiple times.\n\n  When `autocomplete`
+        is enabled on either/both the username and password fields,\n  this could
+        allow a cyber-criminal with access to the victim's computer the ability\n
+        \ to have the victim's credentials automatically entered as the cyber-criminal\n
+        \ visits the affected page.\n\n  Scanner has discovered that the affected
+        page contains a form containing a\n  password field that has not disabled
+        `autocomplete`.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Password
+        field with auto-complete</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)</see_also><solution>The
+        `autocomplete` value can be configured in two different locations.\n  The
+        first and most secure location is to disable the `autocomplete` attribute
+        on   the `&lt;form>` HTML tag. This will disable `autocomplete` for all inputs
+        within that form.   An example of disabling `autocomplete` within the form
+        tag is `&lt;form autocomplete=off>`.\n  The second slightly less desirable
+        option is to disable the `autocomplete` attribute   for a specific `&lt;input>`
+        HTML tag.   While this may be the less desired solution from a security perspective,
+        it may   be preferred method for usability reasons, depending on size of the
+        form.   An example of disabling the `autocomplete` attribute within a password
+        input tag   is `&lt;input type=password autocomplete=off>`.</solution><xref>owasp:2010-A6</xref><xref>cwe:16</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        following form has been found to have not restricted Password Auto Complete:\n\n&lt;form
+        method=\"get\" action=\"/412569245047960484377262321708701598236/saveprofile\">\n
+        \ &lt;input type=\"hidden\" name=\"action\" value=\"new\">\n  &lt;/input>\n
+        \ &lt;input type=\"text\" name=\"uid\" value=\"\" maxlength=\"16\">\n  &lt;/input>\n
+        \ &lt;input type=\"password\" name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"hidden\"
+        name=\"is_author\" value=\"True\">\n  &lt;/input>\n  &lt;input type=\"submit\"
+        value=\"Create account\">\n  &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"2\" pluginID=\"98082\"
+        pluginName=\"Unencrypted password form\" pluginFamily=\"Authentication &amp;
+        Session\"><description>The HTTP protocol by itself is clear text, meaning
+        that any data that is\n  transmitted via HTTP can be captured and the contents
+        viewed.\n\n  To keep data private, and prevent it from being intercepted,
+        HTTP is often\n  tunnelled through either Secure Sockets Layer (SSL), or Transport
+        Layer Security\n  (TLS).\n  When either of these encryption standards are
+        used it is referred to as HTTPS.\n\n  Cyber-criminals will often attempt to
+        compromise credentials passed from the\n  client to the server using HTTP.\n
+        \ This can be conducted via various different Man-in-The-Middle (MiTM) attacks
+        or\n  through network packet captures.\n\n  Scanner discovered that the affected
+        page contains a `password` input, however,\n  the value of the field is not
+        sent to the server utilising HTTPS. Therefore it\n  is possible that any submitted
+        credential may become compromised.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Unencrypted
+        password form</plugin_name><risk_factor>Medium</risk_factor><see_also>http://www.owasp.org/index.php/Top_10_2010-A9-Insufficient_Transport_Layer_Protection</see_also><solution>The
+        affected site should be secured utilising the latest and most secure encryption
+        \  protocols.   These include SSL version 3.0 and TLS version 1.2. While TLS
+        1.2 is the latest   and the most preferred protocol, not all browsers will
+        support this encryption   method. Therefore, the more common SSL is included.
+        Older protocols such as SSL   version 2, and weak ciphers (&lt; 128 bit) should
+        also be disabled.</solution><xref>owasp:2017-A3</xref><xref>owasp:2010-A9</xref><xref>cwe:319</xref><xref>owasp:2017-A2</xref><xref>cwe:523</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><xref>owasp:2010-A3</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/newaccount.gtl\n\n\nProof\n-------\n&lt;form
+        method=\"get\" action=\"/652479776707981538544840512166060390157/saveprofile\">\n
+        \ &lt;input type=\"hidden\" name=\"action\" value=\"new\">\n  &lt;/input>\n
+        \ &lt;input type=\"text\" name=\"uid\" value=\"\" maxlength=\"16\">\n  &lt;/input>\n
+        \ &lt;input type=\"password\" name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"hidden\"
+        name=\"is_author\" value=\"True\">\n  &lt;/input>\n  &lt;input type=\"submit\"
+        value=\"Create account\">\n  &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /652479776707981538544840512166060390157/snippets.gtl/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        47c3d8df7cd7045004cc160255ec1c33\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:44:53 GMT\n | Server: Google Frontend\n | Content-Length: 910\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /snippets.gtl/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /652479776707981538544840512166060390157/saveprofile/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        15b34d78fca2d3dc40683134b7956641\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 04:09:26 GMT\n | Server: Google Frontend\n | Content-Length: 910\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /saveprofile/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\"
+        pluginName=\"Error Message\" pluginFamily=\"Data Exposure\"><description>An
+        error or warning message has been found on the remote web server. It may be
+        possible for an attacker to view sensitive information and conduct further
+        attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On https://google-gruyere.appspot.com/start
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;b>WARNING: Gruyere is not secure.</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"2\" pluginID=\"98056\"
+        pluginName=\"Missing HTTP Strict Transport Security Policy\" pluginFamily=\"HTTP
+        Security Header\"><description>The HTTP protocol by itself is clear text,
+        meaning that any data that is\n  transmitted via HTTP can be captured and
+        the contents viewed. To keep data\n  private and prevent it from being intercepted,
+        HTTP is often tunnelled through\n  either Secure Sockets Layer (SSL) or Transport
+        Layer Security (TLS).\n  When either of these encryption standards are used,
+        it is referred to as HTTPS.\n\n  HTTP Strict Transport Security (HSTS) is
+        an optional response header that can be\n  configured on the server to instruct
+        the browser to only communicate via HTTPS.\n  This will be enforced by the
+        browser even if the user requests a HTTP resource\n  on the same server.\n\n
+        \ Cyber-criminals will often attempt to compromise sensitive information passed\n
+        \ from the client to the server using HTTP. This can be conducted via various\n
+        \ Man-in-The-Middle (MiTM) attacks or through network packet captures.\n\n
+        \ Scanner discovered that the affected application is using HTTPS however
+        does not\n  use the HSTS header.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Missing
+        HTTP Strict Transport Security Policy</plugin_name><risk_factor>Medium</risk_factor><see_also>https://tools.ietf.org/html/rfc6797</see_also><solution>Depending
+        on the framework being used the implementation methods will vary,   however
+        it is advised that the `Strict-Transport-Security` header be configured   on
+        the server.\n  One of the options for this header is `max-age`, which is a
+        representation (in   milliseconds) determining the time in which the client's
+        browser will adhere to   the header policy.\n  Depending on the environment
+        and the application this time period could be from   as low as minutes to
+        as long as days.</solution><xref>owasp:2010-A9</xref><xref>owasp:2017-A3</xref><xref>cwe:319</xref><xref>owasp:2017-A2</xref><xref>cwe:523</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><xref>owasp:2010-A3</xref><plugin_output>The
+        scanner did not find any Strict-Transport-Security header in the response
+        returned by the target when querying URL 'https://google-gruyere.appspot.com/start':\n\nHTTP/1.1
+        200 OK&#xd;\nContent-Type: text/html; charset=utf-8&#xd;\nCache-Control: no-cache&#xd;\nContent-Encoding:
+        gzip&#xd;\nX-Cloud-Trace-Context: 5ab9268cbfedd729ad803983931d4763&#xd;\nVary:
+        Accept-Encoding&#xd;\nDate: Tue, 07 Jan 2020 05:03:44 GMT&#xd;\nServer: Google
+        Frontend&#xd;\nAlt-Svc: quic=\":443\"; ma=2592000; v=\"46,43\",h3-Q050=\":443\";
+        ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\";
+        ma=2592000,h3-Q043=\":443\"; ma=2592000&#xd;\nTransfer-Encoding: chunked&#xd;\n&#xd;\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98081\"
+        pluginName=\"Password field with auto-complete\" pluginFamily=\"Authentication
+        &amp; Session\"><description>In typical form-based web applications, it is
+        common practice for developers to\n  allow `autocomplete` within the HTML
+        form to improve the usability of the page.\n  With `autocomplete` enabled
+        (default), the browser is allowed to cache previously\n  entered form values.\n\n
+        \ For legitimate purposes, this allows the user to quickly re-enter the same
+        data\n  when completing the form multiple times.\n\n  When `autocomplete`
+        is enabled on either/both the username and password fields,\n  this could
+        allow a cyber-criminal with access to the victim's computer the ability\n
+        \ to have the victim's credentials automatically entered as the cyber-criminal\n
+        \ visits the affected page.\n\n  Scanner has discovered that the affected
+        page contains a form containing a\n  password field that has not disabled
+        `autocomplete`.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Password
+        field with auto-complete</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)</see_also><solution>The
+        `autocomplete` value can be configured in two different locations.\n  The
+        first and most secure location is to disable the `autocomplete` attribute
+        on   the `&lt;form>` HTML tag. This will disable `autocomplete` for all inputs
+        within that form.   An example of disabling `autocomplete` within the form
+        tag is `&lt;form autocomplete=off>`.\n  The second slightly less desirable
+        option is to disable the `autocomplete` attribute   for a specific `&lt;input>`
+        HTML tag.   While this may be the less desired solution from a security perspective,
+        it may   be preferred method for usability reasons, depending on size of the
+        form.   An example of disabling the `autocomplete` attribute within a password
+        input tag   is `&lt;input type=password autocomplete=off>`.</solution><xref>owasp:2010-A6</xref><xref>cwe:16</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        following form has been found to have not restricted Password Auto Complete:\n\n&lt;form
+        method=\"get\" action=\"/531899522745731123167764836993191970177/saveprofile\">\n
+        \ &lt;input type=\"hidden\" name=\"action\" value=\"new\">\n  &lt;/input>\n
+        \ &lt;input type=\"text\" name=\"uid\" value=\"\" maxlength=\"16\">\n  &lt;/input>\n
+        \ &lt;input type=\"password\" name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"hidden\"
+        name=\"is_author\" value=\"True\">\n  &lt;/input>\n  &lt;input type=\"submit\"
+        value=\"Create account\">\n  &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98081\"
+        pluginName=\"Password field with auto-complete\" pluginFamily=\"Authentication
+        &amp; Session\"><description>In typical form-based web applications, it is
+        common practice for developers to\n  allow `autocomplete` within the HTML
+        form to improve the usability of the page.\n  With `autocomplete` enabled
+        (default), the browser is allowed to cache previously\n  entered form values.\n\n
+        \ For legitimate purposes, this allows the user to quickly re-enter the same
+        data\n  when completing the form multiple times.\n\n  When `autocomplete`
+        is enabled on either/both the username and password fields,\n  this could
+        allow a cyber-criminal with access to the victim's computer the ability\n
+        \ to have the victim's credentials automatically entered as the cyber-criminal\n
+        \ visits the affected page.\n\n  Scanner has discovered that the affected
+        page contains a form containing a\n  password field that has not disabled
+        `autocomplete`.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Password
+        field with auto-complete</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)</see_also><solution>The
+        `autocomplete` value can be configured in two different locations.\n  The
+        first and most secure location is to disable the `autocomplete` attribute
+        on   the `&lt;form>` HTML tag. This will disable `autocomplete` for all inputs
+        within that form.   An example of disabling `autocomplete` within the form
+        tag is `&lt;form autocomplete=off>`.\n  The second slightly less desirable
+        option is to disable the `autocomplete` attribute   for a specific `&lt;input>`
+        HTML tag.   While this may be the less desired solution from a security perspective,
+        it may   be preferred method for usability reasons, depending on size of the
+        form.   An example of disabling the `autocomplete` attribute within a password
+        input tag   is `&lt;input type=password autocomplete=off>`.</solution><xref>owasp:2010-A6</xref><xref>cwe:16</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        following form has been found to have not restricted Password Auto Complete:\n\n&lt;form
+        method=\"get\" action=\"/412569245047960484377262321708701598236/login\">\n
+        \ &lt;input type=\"text\" name=\"uid\">\n  &lt;/input>\n  &lt;input type=\"password\"
+        name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"submit\" value=\"Login\">\n
+        \ &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\" pluginName=\"Error
+        Message\" pluginFamily=\"Data Exposure\"><description>An error or warning
+        message has been found on the remote web server. It may be possible for an
+        attacker to view sensitive information and conduct further attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On https://google-gruyere.appspot.com/412569245047960484377262321708701598236/newaccount.gtl
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;b>WARNING: Gruyere is not secure.</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98033\"
+        pluginName=\"Login Form Detected\" pluginFamily=\"Authentication &amp; Session\"><description>This
+        is an informational notice that the scanner identified a potential login form
+        that could be used by the scanner to authenticate and have access to additional
+        pages for extending its coverage.</description><plugin_publication_date>2018/02/08</plugin_publication_date><plugin_modification_date>2018/02/08</plugin_modification_date><plugin_name>Login
+        Form Detected</plugin_name><risk_factor>Informational</risk_factor><solution>Edit
+        scan policy and add login form authentication credentials to allow scanner
+        to authenticate to the web application.</solution><plugin_output>Potential
+        login form has been identified in URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/login'
+        with following fields:\n- uid (TEXT)\n- pw (PASSWORD)\nTo perform authenticated
+        scan, configure your scan and add 'Login Form' authentication, with the URL
+        associated to this plugin and as login parameters values for the above non-hidden
+        fields.</plugin_output></ReportItem><ReportItem port=\"80\" svc_name=\"http\"
+        protocol=\"TCP\" severity=\"0\" pluginID=\"98059\" pluginName=\"Technologies
+        Detected\" pluginFamily=\"Web Applications\"><description>This is an informational
+        plugin to inform the user what technologies the framework has detected on\n
+        \ the target application, which can then be examined and checked for known
+        vulnerable software versions</description><plugin_publication_date>2017/12/06</plugin_publication_date><plugin_modification_date>2017/12/11</plugin_modification_date><plugin_name>Technologies
+        Detected</plugin_name><risk_factor>Informational</risk_factor><solution>Only
+        use components that do not have known vulnerabilities, only use components
+        \  that when combined to not introduce a security vulnerability, and ensure
+        that a misconfiguration does not   cause any vulnerabilities</solution><plugin_output>The
+        framework has detected the following technologies in the target application:\n\n-
+        Backbone JS Framework (version unknown)\n- jQuery Mobile (v{:error=>\"unexpected
+        alert open: {Alert text : 1}\\n  (Session info: headless chrome=77.0.3865.90)\\n
+        \ (Driver info: chromedriver=77.0.3865.40 (f484704e052e0b556f8030b65b953dce96503217-refs/branch-heads/3865@{#442}),platform=Linux
+        3.10.0-862.9.1.el7.x86_64 x86_64)\"})</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98000\"
+        pluginName=\"Scan Information\" pluginFamily=\"General\"><description>Provides
+        scan information and statistics of plugins run.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/03/31</plugin_modification_date><plugin_name>Scan
+        Information</plugin_name><risk_factor>Informational</risk_factor><plugin_output>\nEngine
+        Version      0.41.1-120\nScan ID             36b4c4a8-603d-435a-8d44-9ec90d4b9777\n\nStart
+        Time          2020-01-07 03:32:56 +0000\nDuration            05:51:56\n\nRequests
+        \           454814\nRequests/s          22.9709\nMean Response Time  0.3177s\n\nBandwidth
+        Usage\n- Data to Target    212 MB\n- Data from Target  1.66 GB\n\nNetwork
+        TimeOuts    401\nBrowser TimeOuts    0\nProtocols           HTTP/HTTPs\n\nAuthentication\n-
+        None\n\nPlugins Included:\n- 98000 \"Scan Information\"\n- 98003 \"OS Detection\"\n-
+        98009 \"Web Application Sitemap\"\n- 98019 \"Network Timeout Encountered\"\n-
+        98024 \"HTTP Server Authentication Detected\"\n- 98025 \"HTTP Server Authentication
+        Succeeded\"\n- 98026 \"HTTP Server Authentication Failed\"\n- 98033 \"Login
+        Form Detected\"\n- 98034 \"Login Form Authentication Failed\"\n- 98035 \"Login
+        Form Authentication Succeeded\"\n- 98043 \"Scan logged-out intermittently\"\n-
+        98044 \"Scan aborted after being logged out\"\n- 98047 \"Allowed HTTP Methods\"\n-
+        98048 \"HTTP TRACE Allowed\"\n- 98050 \"Interesting response\"\n- 98054 \"Unvalidated
+        Redirection\"\n- 98056 \"Missing HTTP Strict Transport Security Policy\"\n-
+        98057 \"Insecure 'Access-Control-Allow-Origin' header\"\n- 98059 \"Technologies
+        Detected\"\n- 98060 \"Missing 'X-Frame-Options' Header\"\n- 98062 \"Cookie
+        set for parent domain\"\n- 98063 \"Cookie Without HttpOnly Flag Detected\"\n-
+        98064 \"Cookie Without Secure Flag Detected\"\n- 98065 \"Insecure client-access
+        policy\"\n- 98067 \"Insecure cross-domain policy (allow-access-from)\"\n-
+        98068 \"Insecure cross-domain policy (allow-http-request-headers-from)\"\n-
+        98070 \"Common Administration Interfaces Detection\"\n- 98071 \"Common Files
+        Detection\"\n- 98072 \"Common Directories Detection\"\n- 98073 \"Backup directory\"\n-
+        98074 \"Backup file\"\n- 98077 \"Private IP address disclosure\"\n- 98078
+        \"E-mail address disclosure\"\n- 98079 \"CVS/SVN user disclosure\"\n- 98080
+        \"Form-based File Upload\"\n- 98081 \"Password field with auto-complete\"\n-
+        98082 \"Unencrypted password form\"\n- 98083 \"CAPTCHA Detection\"\n- 98084
+        \"Directory Listing\"\n- 98087 \"WebDAV\"\n- 98088 \"Exposed localstart.asp
+        page\"\n- 98091 \"Mixed Resource Detection\"\n- 98092 \"HTML Object\"\n- 98095
+        \"Misconfiguration in LIMIT directive of .htaccess file\"\n- 98096 \"Access
+        restriction bypass via origin spoof\"\n- 98097 \"Backdoor Detection\"\n- 98098
+        \"Source code disclosure\"\n- 98099 \"Publicly writable directory\"\n- 98100
+        \"Path Traversal\"\n- 98101 \"Response Splitting\"\n- 98102 \"Session fixation\"\n-
+        98103 \"Unvalidated DOM redirect\"\n- 98104 \"Cross-Site Scripting (XSS)\"\n-
+        98105 \"Cross-Site Scripting (XSS) in HTML tag\"\n- 98106 \"Cross-Site Scripting
+        (XSS) in script context\"\n- 98107 \"Cross-Site Scripting (XSS) in path\"\n-
+        98108 \"Cross-Site Scripting (XSS) in event tag of HTML element\"\n- 98109
+        \"DOM-based Cross-Site Scripting (XSS)\"\n- 98110 \"DOM-based Cross-Site Scripting
+        (XSS) in script context\"\n- 98112 \"Cross-Site Request Forgery\"\n- 98113
+        \"XML External Entity\"\n- 98114 \"XPath Injection\"\n- 98115 \"SQL Injection\"\n-
+        98116 \"NoSQL Injection\"\n- 98117 \"Blind SQL Injection (differential analysis)\"\n-
+        98118 \"Blind SQL Injection (timing attack)\"\n- 98119 \"Blind NoSQL Injection
+        (differential analysis)\"\n- 98120 \"Code injection\"\n- 98121 \"Code injection
+        (php://input wrapper)\"\n- 98122 \"Code injection (timing attack)\"\n- 98123
+        \"Operating System Command Injection\"\n- 98124 \"Operating system command
+        injection (timing attack)\"\n- 98125 \"Local File Inclusion\"\n- 98126 \"Remote
+        File Inclusion\"\n- 98127 \"LDAP Injection\"\n- 98129 \"Credit card number
+        disclosure\"\n- 98136 \"Target Information\"\n- 98137 \"Scan aborted after
+        too many timeouts\"\n- 98138 \"Screenshot\"\n- 98139 \"Cookie Authentication
+        Succeeded\"\n- 98140 \"Cookie Authentication Failed\"\n- 98141 \"Selenium
+        Authentication Succeeded\"\n- 98142 \"Selenium Authentication Failed\"\n-
+        98143 \"Selenium Crawl Succeeded\"\n- 98145 \"Selenium Crawl Failed\"\n- 98200
+        \"Drupal Administration Panel Login Form Detected\"\n- 98201 \"Drupal User
+        Registration Form Detected\"\n- 98202 \"WordPress User Registration Form Detected\"\n-
+        98203 \"WordPress User Enumeration\"\n- 98204 \"WordPress Configuration Backup
+        Files Detected\"\n- 98205 \"Joomla! User Registration Form Detected\"\n- 98206
+        \"Joomla! Administration Panel Login Form Detected\"\n- 98207 \"WordPress
+        Administration Panel Login Form Detected\"\n- 98208 \"Joomla! User Enumeration\"\n-
+        98209 \"Drupal User Enumeration\"\n- 98210 \"Drupal Configuration Backup Files
+        Detected\"\n- 98211 \"Joomla! Configuration Backup Files Detected\"\n- 98212
+        \"WordPress Directory Listing\"\n- 98213 \"Drupal Directory Listing\"\n- 98214
+        \"Joomla! Directory Listing\"\n- 98215 \"WordPress XML-RPC Interface Detected\"\n-
+        98216 \"Drupal &lt; 7.58 / 8.x &lt; 8.3.9 / 8.4.x &lt; 8.4.6 / 8.5.x &lt;
+        8.5.1 Remote Code Execution\"\n- 98217 \"WordPress 4.7.x &lt; 4.7.2 REST API
+        'id' Parameter Privilege Escalation\"\n- 98218 \"Joomla! 3.7.0 &lt; 3.7.1
+        fields.php getListQuery() Method SQLi\"\n- 98219 \"Drupal RESTWS Module Page
+        Callback RCE\"\n- 98220 \"Drupal Database Abstraction API SQLi\"\n- 98221
+        \"Drupal Coder Module Deserialization RCE\"\n- 98222 \"Joomla! User-Agent
+        Object Injection RCE\"\n- 98223 \"Web Server info.php / phpinfo.php Detection\"\n-
+        98224 \"WordPress Media Attachment Enumeration\"\n- 98225 \"Apache mod_status
+        /server-status Information Disclosure\"\n- 98226 \"Apache mod_info /server-info
+        Information Disclosure\"\n- 98227 \"WordPress Unsupported Version\"\n- 98228
+        \"Drupal Unsupported Version\"\n- 98229 \"Joomla! Unsupported Version\"\n-
+        98230 \"PHP Unsupported Version\"\n- 98231 \"Apache Unsupported Version\"\n-
+        98232 \"Apache Tomcat Unsupported Version\"\n- 98233 \"jQuery File Upload
+        Arbitrary File Upload\"\n- 98234 \"PHP 7.3.x &lt; 7.3.3 Multiple Vulnerabilities\"\n-
+        98235 \"PHP 7.2.x &lt; 7.2.16 Multiple Vulnerabilities\"\n- 98236 \"PHP 7.1.x
+        &lt; 7.1.27 Multiple Vulnerabilities\"\n- 98237 \"MediaElement.js &lt; 2.11.2
+        Cross-Site Scripting\"\n- 98238 \"Drupal Version End of Life Advanced Notification\"\n-
+        98239 \"PHP Version End of Life Advanced Notification\"\n- 98240 \"Joomla!
+        3.0.x &lt; 3.9.4 Multiple Vulnerabilities\"\n- 98241 \"PHP 7.3.x &lt; 7.3.2
+        Information Disclosure\"\n- 98242 \"PHP 7.3.x &lt; 7.3.1 Multiple vulnerabilities\"\n-
+        98243 \"PHP 7.2.x &lt; 7.2.14 Multiple vulnerabilities\"\n- 98244 \"PHP 7.1.x
+        &lt; 7.1.26 Multiple vulnerabilities\"\n- 98245 \"PHP 5.6.x &lt; 5.6.40 Multiple
+        vulnerabilities\"\n- 98246 \"WordPress 3.9.x &lt; 3.9.27 Cross-Site Scripting\"\n-
+        98247 \"WordPress 4.0.x &lt; 4.0.26 Cross-Site Scripting\"\n- 98248 \"WordPress
+        4.1.x &lt; 4.1.26 Cross-Site Scripting\"\n- 98249 \"WordPress 4.2.x &lt; 4.2.23
+        Cross-Site Scripting\"\n- 98250 \"WordPress 4.7.x &lt; 4.7.1 Multiple Vulnerabilities\"\n-
+        98251 \"WordPress 4.6.x &lt; 4.6.2 Multiple Vulnerabilities\"\n- 98252 \"WordPress
+        4.5.x &lt; 4.5.5 Multiple Vulnerabilities\"\n- 98253 \"WordPress 4.4.x &lt;
+        4.4.6 Multiple Vulnerabilities\"\n- 98254 \"WordPress 4.3.x &lt; 4.3.7 Multiple
+        Vulnerabilities\"\n- 98255 \"WordPress 4.2.x &lt; 4.2.11 Multiple Vulnerabilities\"\n-
+        98256 \"WordPress 4.1.x &lt; 4.1.14 Multiple Vulnerabilities\"\n- 98257 \"WordPress
+        4.0.x &lt; 4.0.14 Multiple Vulnerabilities\"\n- 98258 \"WordPress 3.9.x &lt;
+        3.9.15 Multiple Vulnerabilities\"\n- 98259 \"WordPress 3.8.x &lt; 3.8.17 Multiple
+        Vulnerabilities\"\n- 98260 \"WordPress 3.7.x &lt; 3.7.17 Multiple Vulnerabilities\"\n-
+        98261 \"WordPress 4.7.x &lt; 4.7.2 Multiple Vulnerabilities\"\n- 98262 \"WordPress
+        4.6.x &lt; 4.6.3 Multiple Vulnerabilities\"\n- 98263 \"WordPress 4.5.x &lt;
+        4.5.6 Multiple Vulnerabilities\"\n- 98264 \"WordPress 4.4.x &lt; 4.4.7 Multiple
+        Vulnerabilities\"\n- 98265 \"WordPress 4.3.x &lt; 4.3.8 Multiple Vulnerabilities\"\n-
+        98266 \"WordPress 4.2.x &lt; 4.2.12 Multiple Vulnerabilities\"\n- 98267 \"WordPress
+        4.1.x &lt; 4.1.15 Multiple Vulnerabilities\"\n- 98268 \"WordPress 4.0.x &lt;
+        4.0.15 Multiple Vulnerabilities\"\n- 98269 \"WordPress 3.9.x &lt; 3.9.16 Multiple
+        Vulnerabilities\"\n- 98270 \"WordPress 3.8.x &lt; 3.8.18 Multiple Vulnerabilities\"\n-
+        98271 \"WordPress 3.7.x &lt; 3.7.18 Multiple Vulnerabilities\"\n- 98272 \"WordPress
+        4.7.x &lt; 4.7.3 Multiple Vulnerabilities\"\n- 98273 \"WordPress 4.6.x &lt;
+        4.6.4 Multiple Vulnerabilities\"\n- 98274 \"WordPress 4.5.x &lt; 4.5.7 Multiple
+        Vulnerabilities\"\n- 98275 \"WordPress 4.4.x &lt; 4.4.8 Multiple Vulnerabilities\"\n-
+        98276 \"WordPress 4.3.x &lt; 4.3.9 Multiple Vulnerabilities\"\n- 98277 \"WordPress
+        4.2.x &lt; 4.2.13 Multiple Vulnerabilities\"\n- 98278 \"WordPress 4.1.x &lt;
+        4.1.16 Multiple Vulnerabilities\"\n- 98279 \"WordPress 4.0.x &lt; 4.0.16 Multiple
+        Vulnerabilities\"\n- 98280 \"WordPress 3.9.x &lt; 3.9.17 Multiple Vulnerabilities\"\n-
+        98281 \"WordPress 3.8.x &lt; 3.8.19 Multiple Vulnerabilities\"\n- 98282 \"WordPress
+        3.7.x &lt; 3.7.19 Multiple Vulnerabilities\"\n- 98283 \"WordPress 4.7.x &lt;
+        4.7.5 Multiple Vulnerabilities\"\n- 98284 \"WordPress 4.6.x &lt; 4.6.6 Multiple
+        Vulnerabilities\"\n- 98285 \"WordPress 4.5.x &lt; 4.5.9 Multiple Vulnerabilities\"\n-
+        98286 \"WordPress 4.4.x &lt; 4.4.10 Multiple Vulnerabilities\"\n- 98287 \"WordPress
+        4.3.x &lt; 4.3.11 Multiple Vulnerabilities\"\n- 98288 \"WordPress 4.2.x &lt;
+        4.2.15 Multiple Vulnerabilities\"\n- 98289 \"WordPress 4.1.x &lt; 4.1.18 Multiple
+        Vulnerabilities\"\n- 98290 \"WordPress 4.0.x &lt; 4.0.18 Multiple Vulnerabilities\"\n-
+        98291 \"WordPress 3.9.x &lt; 3.9.19 Multiple Vulnerabilities\"\n- 98292 \"WordPress
+        3.8.x &lt; 3.8.21 Multiple Vulnerabilities\"\n- 98293 \"WordPress 3.7.x &lt;
+        3.7.21 Multiple Vulnerabilities\"\n- 98294 \"WordPress 4.8.x &lt; 4.8.2 Multiple
+        Vulnerabilities\"\n- 98295 \"WordPress 4.7.x &lt; 4.7.6 Multiple Vulnerabilities\"\n-
+        98296 \"WordPress 4.6.x &lt; 4.6.7 Multiple Vulnerabilities\"\n- 98297 \"WordPress
+        4.5.x &lt; 4.5.10 Multiple Vulnerabilities\"\n- 98298 \"WordPress 4.4.x &lt;
+        4.4.11 Multiple Vulnerabilities\"\n- 98299 \"WordPress 4.3.x &lt; 4.3.12 Multiple
+        Vulnerabilities\"\n- 98300 \"WordPress 4.2.x &lt; 4.2.16 Multiple Vulnerabilities\"\n-
+        98301 \"WordPress 4.1.x &lt; 4.1.19 Multiple Vulnerabilities\"\n- 98302 \"WordPress
+        4.0.x &lt; 4.0.19 Multiple Vulnerabilities\"\n- 98303 \"WordPress 3.9.x &lt;
+        3.9.20 Multiple Vulnerabilities\"\n- 98304 \"WordPress 3.8.x &lt; 3.8.22 Multiple
+        Vulnerabilities\"\n- 98305 \"WordPress 3.7.x &lt; 3.7.22 Multiple Vulnerabilities\"\n-
+        98306 \"WordPress 4.8.x &lt; 4.8.3 Multiple Vulnerabilities\"\n- 98307 \"WordPress
+        4.7.x &lt; 4.7.7 Multiple Vulnerabilities\"\n- 98308 \"WordPress 4.6.x &lt;
+        4.6.8 Multiple Vulnerabilities\"\n- 98309 \"WordPress 4.5.x &lt; 4.5.11 Multiple
+        Vulnerabilities\"\n- 98310 \"WordPress 4.4.x &lt; 4.4.12 Multiple Vulnerabilities\"\n-
+        98311 \"WordPress 4.3.x &lt; 4.3.13 Multiple Vulnerabilities\"\n- 98312 \"WordPress
+        4.2.x &lt; 4.2.17 Multiple Vulnerabilities\"\n- 98313 \"WordPress 4.1.x &lt;
+        4.1.20 Multiple Vulnerabilities\"\n- 98314 \"WordPress 4.0.x &lt; 4.0.20 Multiple
+        Vulnerabilities\"\n- 98315 \"WordPress 3.9.x &lt; 3.9.21 Multiple Vulnerabilities\"\n-
+        98316 \"WordPress 3.8.x &lt; 3.8.23 Multiple Vulnerabilities\"\n- 98317 \"WordPress
+        3.7.x &lt; 3.7.23 Multiple Vulnerabilities\"\n- 98318 \"WordPress 4.9.x &lt;
+        4.9.1 Multiple Vulnerabilities\"\n- 98319 \"WordPress 4.8.x &lt; 4.8.4 Multiple
+        Vulnerabilities\"\n- 98320 \"WordPress 4.7.x &lt; 4.7.8 Multiple Vulnerabilities\"\n-
+        98321 \"WordPress 4.6.x &lt; 4.6.9 Multiple Vulnerabilities\"\n- 98322 \"WordPress
+        4.5.x &lt; 4.5.12 Multiple Vulnerabilities\"\n- 98323 \"WordPress 4.4.x &lt;
+        4.4.13 Multiple Vulnerabilities\"\n- 98324 \"WordPress 4.3.x &lt; 4.3.14 Multiple
+        Vulnerabilities\"\n- 98325 \"WordPress 4.2.x &lt; 4.2.18 Multiple Vulnerabilities\"\n-
+        98326 \"WordPress 4.1.x &lt; 4.1.21 Multiple Vulnerabilities\"\n- 98327 \"WordPress
+        4.0.x &lt; 4.0.21 Multiple Vulnerabilities\"\n- 98328 \"WordPress 3.9.x &lt;
+        3.9.22 Multiple Vulnerabilities\"\n- 98329 \"WordPress 3.8.x &lt; 3.8.24 Multiple
+        Vulnerabilities\"\n- 98330 \"WordPress 3.7.x &lt; 3.7.24 Multiple Vulnerabilities\"\n-
+        98331 \"WordPress 4.9.x &lt; 4.9.2 MediaElement.js Flash Fallback XSS\"\n-
+        98332 \"WordPress 4.8.x &lt; 4.8.5 MediaElement.js Flash Fallback XSS\"\n-
+        98333 \"WordPress 4.7.x &lt; 4.7.9 MediaElement.js Flash Fallback XSS\"\n-
+        98334 \"WordPress 4.6.x &lt; 4.6.10 MediaElement.js Flash Fallback XSS\"\n-
+        98335 \"WordPress 4.5.x &lt; 4.5.13 MediaElement.js Flash Fallback XSS\"\n-
+        98336 \"WordPress 4.4.x &lt; 4.4.14 MediaElement.js Flash Fallback XSS\"\n-
+        98337 \"WordPress 4.3.x &lt; 4.3.15 MediaElement.js Flash Fallback XSS\"\n-
+        98338 \"WordPress 4.2.x &lt; 4.2.19 MediaElement.js Flash Fallback XSS\"\n-
+        98339 \"WordPress 4.1.x &lt; 4.1.22 MediaElement.js Flash Fallback XSS\"\n-
+        98340 \"WordPress 4.0.x &lt; 4.0.22 MediaElement.js Flash Fallback XSS\"\n-
+        98341 \"WordPress 3.9.x &lt; 3.9.23 MediaElement.js Flash Fallback XSS\"\n-
+        98342 \"WordPress 3.8.x &lt; 3.8.25 MediaElement.js Flash Fallback XSS\"\n-
+        98343 \"WordPress 3.7.x &lt; 3.7.25 MediaElement.js Flash Fallback XSS\"\n-
+        98344 \"WordPress 4.9.x &lt; 4.9.5 Multiple Vulnerabilities\"\n- 98345 \"WordPress
+        4.8.x &lt; 4.8.6 Multiple Vulnerabilities\"\n- 98346 \"WordPress 4.7.x &lt;
+        4.7.10 Multiple Vulnerabilities\"\n- 98347 \"WordPress 4.6.x &lt; 4.6.11 Multiple
+        Vulnerabilities\"\n- 98348 \"WordPress 4.5.x &lt; 4.5.14 Multiple Vulnerabilities\"\n-
+        98349 \"WordPress 4.4.x &lt; 4.4.15 Multiple Vulnerabilities\"\n- 98350 \"WordPress
+        4.3.x &lt; 4.3.16 Multiple Vulnerabilities\"\n- 98351 \"WordPress 4.2.x &lt;
+        4.2.20 Multiple Vulnerabilities\"\n- 98352 \"WordPress 4.1.x &lt; 4.1.23 Multiple
+        Vulnerabilities\"\n- 98353 \"WordPress 4.0.x &lt; 4.0.23 Multiple Vulnerabilities\"\n-
+        98354 \"WordPress 3.9.x &lt; 3.9.24 Multiple Vulnerabilities\"\n- 98355 \"WordPress
+        3.8.x &lt; 3.8.26 Multiple Vulnerabilities\"\n- 98356 \"WordPress 3.7.x &lt;
+        3.7.26 Multiple Vulnerabilities\"\n- 98357 \"WordPress 4.9.x &lt; 4.9.7 Arbitrary
+        File Deletion\"\n- 98358 \"WordPress 4.8.x &lt; 4.8.7 Arbitrary File Deletion\"\n-
+        98359 \"WordPress 4.7.x &lt; 4.7.11 Arbitrary File Deletion\"\n- 98360 \"WordPress
+        4.6.x &lt; 4.6.12 Arbitrary File Deletion\"\n- 98361 \"WordPress 4.5.x &lt;
+        4.5.15 Arbitrary File Deletion\"\n- 98362 \"WordPress 4.4.x &lt; 4.4.16 Arbitrary
+        File Deletion\"\n- 98363 \"WordPress 4.3.x &lt; 4.3.17 Arbitrary File Deletion\"\n-
+        98364 \"WordPress 4.2.x &lt; 4.2.21 Arbitrary File Deletion\"\n- 98365 \"WordPress
+        4.1.x &lt; 4.1.24 Arbitrary File Deletion\"\n- 98366 \"WordPress 4.0.x &lt;
+        4.0.24 Arbitrary File Deletion\"\n- 98367 \"WordPress 3.9.x &lt; 3.9.25 Arbitrary
+        File Deletion\"\n- 98368 \"WordPress 3.8.x &lt; 3.8.27 Arbitrary File Deletion\"\n-
+        98369 \"WordPress 3.7.x &lt; 3.7.27 Arbitrary File Deletion\"\n- 98370 \"WordPress
+        5.0.x &lt; 5.0.1 Multiple Vulnerabilities\"\n- 98371 \"WordPress 4.9.x &lt;
+        4.9.9 Multiple Vulnerabilities\"\n- 98372 \"WordPress 4.8.x &lt; 4.8.8 Multiple
+        Vulnerabilities\"\n- 98373 \"WordPress 4.7.x &lt; 4.7.12 Multiple Vulnerabilities\"\n-
+        98374 \"WordPress 4.6.x &lt; 4.6.13 Multiple Vulnerabilities\"\n- 98375 \"WordPress
+        4.5.x &lt; 4.5.16 Multiple Vulnerabilities\"\n- 98376 \"WordPress 4.4.x &lt;
+        4.4.17 Multiple Vulnerabilities\"\n- 98377 \"WordPress 4.3.x &lt; 4.3.18 Multiple
+        Vulnerabilities\"\n- 98378 \"WordPress 4.2.x &lt; 4.2.22 Multiple Vulnerabilities\"\n-
+        98379 \"WordPress 4.1.x &lt; 4.1.25 Multiple Vulnerabilities\"\n- 98380 \"WordPress
+        4.0.x &lt; 4.0.25 Multiple Vulnerabilities\"\n- 98381 \"WordPress 3.9.x &lt;
+        3.9.26 Multiple Vulnerabilities\"\n- 98382 \"WordPress 3.8.x &lt; 3.8.28 Multiple
+        Vulnerabilities\"\n- 98383 \"WordPress 3.7.x &lt; 3.7.28 Multiple Vulnerabilities\"\n-
+        98384 \"WordPress 4.3.x &lt; 4.3.19 Cross-Site Scripting\"\n- 98385 \"WordPress
+        4.4.x &lt; 4.4.18 Cross-Site Scripting\"\n- 98386 \"WordPress 4.5.x &lt; 4.5.17
+        Cross-Site Scripting\"\n- 98387 \"WordPress 4.6.x &lt; 4.6.14 Cross-Site Scripting\"\n-
+        98388 \"WordPress 4.7.x &lt; 4.7.13 Cross-Site Scripting\"\n- 98389 \"WordPress
+        4.8.x &lt; 4.8.9 Cross-Site Scripting\"\n- 98390 \"WordPress 4.9.x &lt; 4.9.10
+        Cross-Site Scripting\"\n- 98391 \"WordPress 5.0.x &lt; 5.0.4 Cross-Site Scripting\"\n-
+        98392 \"WordPress 5.1.x &lt; 5.1.1 Cross-Site Scripting\"\n- 98393 \"jQuery
+        UI &lt; 1.12.0 Cross-Site Scripting\"\n- 98394 \"jQuery UI &lt; 1.10.0 Multiple
+        Vulnerabilities\"\n- 98395 \"Drupal 8.6.x &lt; 8.6.13 Cross-Site Scripting\"\n-
+        98396 \"Drupal 8.5.x &lt; 8.5.14 Cross-Site Scripting\"\n- 98397 \"Drupal
+        7.x &lt; 7.65 Cross-Site Scripting\"\n- 98398 \"JK Status Manager Information
+        Disclosure\"\n- 98399 \"Drupal 8.5.x &lt; 8.5.8 / 8.6.x &lt; 8.6.2 Open Redirect\"\n-
+        98400 \"Joomla! 3.6.x &lt; 3.6.4 Multiple Vulnerabilities\"\n- 98401 \"Joomla!
+        3.5.x &lt; 3.6.4 Multiple Vulnerabilities\"\n- 98402 \"Joomla! 3.4.4 &lt;
+        3.6.4 Multiple Vulnerabilities\"\n- 98403 \"Joomla! 3.6.x &lt; 3.6.5 Multiple
+        Vulnerabilities\"\n- 98404 \"Joomla! 3.5.x &lt; 3.6.5 Multiple Vulnerabilities\"\n-
+        98405 \"Joomla! 3.4.x &lt; 3.6.5 Multiple Vulnerabilities\"\n- 98406 \"Joomla!
+        3.3.x &lt; 3.6.5 Multiple Vulnerabilities\"\n- 98407 \"WordPress Debug Mode\"\n-
+        98408 \"Joomla! 3.2.x &lt; 3.6.5 Multiple Vulnerabilities\"\n- 98409 \"Joomla!
+        3.1.x &lt; 3.6.5 Multiple Vulnerabilities\"\n- 98410 \"Joomla! 3.0.x &lt;
+        3.6.5 Multiple Vulnerabilities\"\n- 98411 \"Joomla! 2.5.x &lt; 3.6.5 Multiple
+        Vulnerabilities\"\n- 98412 \"Joomla! 1.7.x &lt; 3.6.5 Multiple Vulnerabilities\"\n-
+        98413 \"Joomla! 1.6.x &lt; 3.6.5 Multiple Vulnerabilities\"\n- 98414 \"Joomla!
+        3.6.x &lt; 3.7.0 Multiple Vulnerabilities\"\n- 98415 \"Joomla! 3.5.x &lt;
+        3.7.0 Multiple Vulnerabilities\"\n- 98416 \"Joomla! 3.4.x &lt; 3.7.0 Multiple
+        Vulnerabilities\"\n- 98417 \"Joomla! 3.3.x &lt; 3.7.0 Multiple Vulnerabilities\"\n-
+        98418 \"Joomla! 3.2.x &lt; 3.7.0 Multiple Vulnerabilities\"\n- 98419 \"Joomla!
+        3.1.x &lt; 3.7.0 Multiple Vulnerabilities\"\n- 98420 \"Joomla! 3.0.x &lt;
+        3.7.0 Multiple Vulnerabilities\"\n- 98421 \"Joomla! 2.5.x &lt; 3.7.0 Multiple
+        Vulnerabilities\"\n- 98422 \"Joomla! 1.7.x &lt; 3.7.0 Multiple Vulnerabilities\"\n-
+        98423 \"Joomla! 1.6.x &lt; 3.7.0 Multiple Vulnerabilities\"\n- 98424 \"Joomla!
+        1.5.x &lt; 3.7.0 Multiple Vulnerabilities\"\n- 98425 \"Joomla! 3.7.x &lt;
+        3.7.1 fields.php getListQuery() Method SQLi\"\n- 98426 \"Joomla! 3.7.x &lt;
+        3.7.3 Multiple Vulnerabilities\"\n- 98427 \"Joomla! 3.6.x &lt; 3.7.3 Multiple
+        Vulnerabilities\"\n- 98428 \"Joomla! 3.5.x &lt; 3.7.3 Multiple Vulnerabilities\"\n-
+        98429 \"Joomla! 3.4.x &lt; 3.7.3 Multiple Vulnerabilities\"\n- 98430 \"Joomla!
+        3.3.x &lt; 3.7.3 Multiple Vulnerabilities\"\n- 98431 \"Joomla! 3.2.x &lt;
+        3.7.3 Multiple Vulnerabilities\"\n- 98432 \"Joomla! 3.1.x &lt; 3.7.3 Multiple
+        Vulnerabilities\"\n- 98433 \"Joomla! 3.0.x &lt; 3.7.3 Multiple Vulnerabilities\"\n-
+        98434 \"Joomla! 2.5.x &lt; 3.7.3 Multiple Vulnerabilities\"\n- 98435 \"Joomla!
+        1.7.x &lt; 3.7.3 Multiple Vulnerabilities\"\n- 98436 \"Joomla! 1.6.x &lt;
+        3.7.3 Multiple Vulnerabilities\"\n- 98437 \"Joomla! 1.5.x &lt; 3.7.3 Multiple
+        Vulnerabilities\"\n- 98438 \"Joomla! 3.7.x &lt; 3.7.4 Multiple Vulnerabilities\"\n-
+        98439 \"Joomla! 3.6.x &lt; 3.7.4 Multiple Vulnerabilities\"\n- 98440 \"Joomla!
+        3.5.x &lt; 3.7.4 Multiple Vulnerabilities\"\n- 98441 \"Joomla! 3.4.x &lt;
+        3.7.4 Multiple Vulnerabilities\"\n- 98442 \"Joomla! 3.3.x &lt; 3.7.4 Multiple
+        Vulnerabilities\"\n- 98443 \"Joomla! 3.2.x &lt; 3.7.4 Multiple Vulnerabilities\"\n-
+        98444 \"Joomla! 3.1.x &lt; 3.7.4 Multiple Vulnerabilities\"\n- 98445 \"Joomla!
+        3.0.x &lt; 3.7.4 Multiple Vulnerabilities\"\n- 98446 \"Joomla! 2.5.x &lt;
+        3.7.4 Multiple Vulnerabilities\"\n- 98447 \"Joomla! 1.7.x &lt; 3.7.4 Multiple
+        Vulnerabilities\"\n- 98448 \"Joomla! 1.6.x &lt; 3.7.4 Multiple Vulnerabilities\"\n-
+        98449 \"Joomla! 1.5.x &lt; 3.7.4 Multiple Vulnerabilities\"\n- 98450 \"Joomla!
+        1.0.x &lt; 3.7.4 Multiple Vulnerabilities\"\n- 98451 \"Joomla! 3.7.x &lt;
+        3.8.0 Multiple Vulnerabilities\"\n- 98452 \"Joomla! 3.6.x &lt; 3.8.0 Multiple
+        Vulnerabilities\"\n- 98453 \"Joomla! 3.5.x &lt; 3.8.0 Multiple Vulnerabilities\"\n-
+        98454 \"Joomla! 3.4.x &lt; 3.8.0 Multiple Vulnerabilities\"\n- 98455 \"Joomla!
+        3.3.x &lt; 3.8.0 Multiple Vulnerabilities\"\n- 98456 \"Joomla! 3.2.x &lt;
+        3.8.0 Multiple Vulnerabilities\"\n- 98457 \"Joomla! 3.1.x &lt; 3.8.0 Multiple
+        Vulnerabilities\"\n- 98458 \"Joomla! 3.0.x &lt; 3.8.0 Multiple Vulnerabilities\"\n-
+        98459 \"Joomla! 2.5.x &lt; 3.8.0 Multiple Vulnerabilities\"\n- 98460 \"Joomla!
+        1.7.x &lt; 3.8.0 Multiple Vulnerabilities\"\n- 98461 \"Joomla! 1.6.x &lt;
+        3.8.0 Multiple Vulnerabilities\"\n- 98462 \"Joomla! 1.5.x &lt; 3.8.0 Multiple
+        Vulnerabilities\"\n- 98463 \"Joomla! 3.8.x &lt; 3.8.2 Multiple Vulnerabilities\"\n-
+        98464 \"Joomla! 3.7.x &lt; 3.8.2 Multiple Vulnerabilities\"\n- 98465 \"Joomla!
+        3.6.x &lt; 3.8.2 Multiple Vulnerabilities\"\n- 98466 \"Joomla! 3.5.x &lt;
+        3.8.2 Multiple Vulnerabilities\"\n- 98467 \"Joomla! 3.4.x &lt; 3.8.2 Multiple
+        Vulnerabilities\"\n- 98468 \"Joomla! 3.3.x &lt; 3.8.2 Multiple Vulnerabilities\"\n-
+        98469 \"Joomla! 3.2.x &lt; 3.8.2 Multiple Vulnerabilities\"\n- 98470 \"Joomla!
+        3.1.x &lt; 3.8.2 Multiple Vulnerabilities\"\n- 98471 \"Joomla! 3.0.x &lt;
+        3.8.2 Multiple Vulnerabilities\"\n- 98472 \"Joomla! 2.5.x &lt; 3.8.2 Multiple
+        Vulnerabilities\"\n- 98473 \"Joomla! 1.7.x &lt; 3.8.2 Multiple Vulnerabilities\"\n-
+        98474 \"Joomla! 1.6.x &lt; 3.8.2 Multiple Vulnerabilities\"\n- 98475 \"Joomla!
+        1.5.x &lt; 3.8.2 Multiple Vulnerabilities\"\n- 98476 \"Joomla! 3.8.x &lt;
+        3.8.4 Multiple Vulnerabilities\"\n- 98477 \"Joomla! 3.7.x &lt; 3.8.4 Multiple
+        Vulnerabilities\"\n- 98478 \"Joomla! 3.6.x &lt; 3.8.4 Multiple Vulnerabilities\"\n-
+        98479 \"Joomla! 3.5.x &lt; 3.8.4 Multiple Vulnerabilities\"\n- 98480 \"Joomla!
+        3.4.x &lt; 3.8.4 Multiple Vulnerabilities\"\n- 98481 \"Joomla! 3.3.x &lt;
+        3.8.4 Multiple Vulnerabilities\"\n- 98482 \"Joomla! 3.2.x &lt; 3.8.4 Multiple
+        Vulnerabilities\"\n- 98483 \"Joomla! 3.1.x &lt; 3.8.4 Multiple Vulnerabilities\"\n-
+        98484 \"Joomla! 3.0.x &lt; 3.8.4 Multiple Vulnerabilities\"\n- 98485 \"Joomla!
+        2.5.x &lt; 3.8.4 Multiple Vulnerabilities\"\n- 98486 \"Joomla! 1.7.x &lt;
+        3.8.4 Multiple Vulnerabilities\"\n- 98487 \"Joomla! 1.6.x &lt; 3.8.4 Multiple
+        Vulnerabilities\"\n- 98488 \"Joomla! 1.5.x &lt; 3.8.4 Multiple Vulnerabilities\"\n-
+        98489 \"Joomla! 3.8.x &lt; 3.8.6 User Notes List View SQL Injection\"\n- 98490
+        \"Joomla! 3.7.x &lt; 3.8.6 User Notes List View SQL Injection\"\n- 98491 \"Joomla!
+        3.6.x &lt; 3.8.6 User Notes List View SQL Injection\"\n- 98492 \"Joomla! 3.5.x
+        &lt; 3.8.6 User Notes List View SQL Injection\"\n- 98493 \"Joomla! 3.8.x &lt;
+        3.8.8 Multiple Vulnerabilities\"\n- 98494 \"Joomla! 3.7.x &lt; 3.8.8 Multiple
+        Vulnerabilities\"\n- 98495 \"Joomla! 3.6.x &lt; 3.8.8 Multiple Vulnerabilities\"\n-
+        98496 \"Joomla! 3.5.x &lt; 3.8.8 Multiple Vulnerabilities\"\n- 98497 \"Joomla!
+        3.4.x &lt; 3.8.8 Multiple Vulnerabilities\"\n- 98498 \"Joomla! 3.3.x &lt;
+        3.8.8 Multiple Vulnerabilities\"\n- 98499 \"Joomla! 3.2.x &lt; 3.8.8 Multiple
+        Vulnerabilities\"\n- 98500 \"Joomla! 3.1.x &lt; 3.8.8 Multiple Vulnerabilities\"\n-
+        98501 \"Joomla! 3.0.x &lt; 3.8.8 Multiple Vulnerabilities\"\n- 98502 \"Joomla!
+        2.5.x &lt; 3.8.8 Multiple Vulnerabilities\"\n- 98503 \"Joomla! 1.7.x &lt;
+        3.8.8 Multiple Vulnerabilities\"\n- 98504 \"Joomla! 1.6.x &lt; 3.8.8 Multiple
+        Vulnerabilities\"\n- 98505 \"Joomla! 1.5.x &lt; 3.8.8 Multiple Vulnerabilities\"\n-
+        98506 \"Joomla! 3.8.x &lt; 3.8.9 Multiple Vulnerabilities\"\n- 98507 \"Joomla!
+        3.7.x &lt; 3.8.9 Multiple Vulnerabilities\"\n- 98508 \"Joomla! 3.6.x &lt;
+        3.8.9 Multiple Vulnerabilities\"\n- 98509 \"Joomla! 3.5.x &lt; 3.8.9 Multiple
+        Vulnerabilities\"\n- 98510 \"Joomla! 3.4.x &lt; 3.8.9 Multiple Vulnerabilities\"\n-
+        98511 \"Joomla! 3.3.x &lt; 3.8.9 Multiple Vulnerabilities\"\n- 98512 \"Joomla!
+        3.2.x &lt; 3.8.9 Multiple Vulnerabilities\"\n- 98513 \"Joomla! 3.1.x &lt;
+        3.8.9 Multiple Vulnerabilities\"\n- 98514 \"Joomla! 3.0.x &lt; 3.8.9 Multiple
+        Vulnerabilities\"\n- 98515 \"Joomla! 2.5.x &lt; 3.8.9 Multiple Vulnerabilities\"\n-
+        98516 \"Joomla! 1.7.x &lt; 3.8.9 Multiple Vulnerabilities\"\n- 98517 \"Joomla!
+        1.6.x &lt; 3.8.9 Multiple Vulnerabilities\"\n- 98518 \"Joomla! 1.5.x &lt;
+        3.8.12 Multiple Vulnerabilities\"\n- 98519 \"Joomla! 1.5.x &lt; 3.8.13 Multiple
+        Vulnerabilities\"\n- 98520 \"Joomla! 2.5.x &lt; 3.9.2 Multiple Vulnerabilities\"\n-
+        98521 \"Joomla! 1.0.x &lt; 3.9.3 Multiple Vulnerabilities\"\n- 98522 \"Apache
+        Tomcat JK Connector 1.2.x &lt; 1.2.46 Access Control Bypass\"\n- 98523 \"Apache
+        Tomcat JK Connector 1.2.x &lt; 1.2.41 JkUnmount Directive Handling Remote
+        Information Disclosure\"\n- 98524 \"Apache Tomcat Default Files\"\n- 98525
+        \"Apache Tomcat Manager Detected\"\n- 98526 \"Missing Feature Policy\"\n-
+        98527 \"Missing Referrer Policy\"\n- 98528 \"Social Warfare Plugin for WordPress
+        &lt; 3.5.3 Remote Code Execution\"\n- 98529 \"Easy WP SMTP Plugin for WordPress
+        1.3.9 Remote Code Execution\"\n- 98530 \"Apache 2.4.x &lt; 2.4.39 Multiple
+        Vulnerabilities\"\n- 98531 \"Magento 2.1.x &lt; 2.1.17 / 2.2.x &lt; 2.2.8
+        / 2.3.x &lt; 2.3.1 SQL Injection\"\n- 98532 \"Joomla! 1.5.x &lt; 3.9.5 Multiple
+        Vulnerabilities\"\n- 98533 \"PHP 7.3.x &lt; 7.3.4 Multiple Vulnerabilities\"\n-
+        98534 \"PHP 7.2.x &lt; 7.2.17 Multiple Vulnerabilities\"\n- 98535 \"PHP 7.1.x
+        &lt; 7.1.28 Multiple Vulnerabilities\"\n- 98536 \"Duplicate Page Plugin for
+        WordPress &lt; 3.4 SQL Injection\"\n- 98537 \"Apache 2.4.x &lt; 2.4.38 Multiple
+        Vulnerabilities\"\n- 98538 \"Environment Configuration File Detected\"\n-
+        98539 \"Apache Tomcat 9.0.0.M1 &lt; 9.0.19 Remote Code Execution on Windows\"\n-
+        98540 \"Apache Tomcat 8.5.0 &lt; 8.5.40 Remote Code Execution on Windows\"\n-
+        98541 \"Apache Tomcat 7.0.0 &lt; 7.0.94 Remote Code Execution on Windows\"\n-
+        98542 \"Apache Tomcat 9.0.0.M1 &lt; 9.0.16 Denial of Service\"\n- 98543 \"Apache
+        Tomcat 8.5.0 &lt; 8.5.38 Denial of Service\"\n- 98544 \"Drupal 8.6.x &lt;
+        8.6.15 Multiple Vulnerabilities\"\n- 98545 \"Drupal 8.x &lt; 8.5.15 Multiple
+        Vulnerabilities\"\n- 98546 \"Drupal 7.x &lt; 7.66 Multiple Vulnerabilities\"\n-
+        98547 \"Yellow Pencil Visual Theme Customizer Plugin for WordPress &lt; 7.2.1
+        Privilege Escalation\"\n- 98548 \"WP GDPR Compliance Plugin for WordPress
+        &lt; 1.4.3 Multiple Vulnerabilities\"\n- 98549 \"Yuzo Related Posts Plugin
+        for WordPress Cross-Site Scripting\"\n- 98550 \"Drupal 8.2.x &lt; 8.2.0-rc2
+        Multiple Vulnerabilities\"\n- 98551 \"Drupal 8.x &lt; 8.1.10 Multiple Vulnerabilities\"\n-
+        98552 \"Drupal 8.x &lt; 8.2.3 Multiple Vulnerabilities\"\n- 98553 \"Drupal
+        7.x &lt; 7.52 Multiple Vulnerabilities\"\n- 98554 \"Drupal 8.3.x &lt; 8.3.0-rc2
+        Multiple Vulnerabilities\"\n- 98555 \"Drupal 8.x &lt; 8.2.7 Multiple Vulnerabilities\"\n-
+        98556 \"Drupal 8.3.x &lt; 8.3.1 Access Bypass Vulnerability\"\n- 98557 \"Drupal
+        8.x &lt; 8.2.8 Access Bypass Vulnerability\"\n- 98558 \"Drupal 8.x &lt; 8.3.4
+        Multiple Vulnerabilities\"\n- 98559 \"Drupal 7.x &lt; 7.56 Multiple Vulnerabilities\"\n-
+        98560 \"Drupal 8.x &lt; 8.3.7 Multiple Vulnerabilities\"\n- 98561 \"Drupal
+        8.5.x &lt; 8.5.0-rc1 Multiple Vulnerabilities\"\n- 98562 \"Drupal 8.x &lt;
+        8.4.5 Multiple Vulnerabilities\"\n- 98563 \"Drupal 7.x &lt; 7.57 Multiple
+        Vulnerabilities\"\n- 98564 \"Drupal 8.5.x &lt; 8.5.1 Remote Code Execution
+        Vulnerability\"\n- 98565 \"Drupal 8.4.x &lt; 8.4.6 Remote Code Execution Vulnerability\"\n-
+        98566 \"Drupal 8.3.x &lt; 8.3.9 Remote Code Execution Vulnerability\"\n- 98567
+        \"Drupal 8.2.x &lt; 8.5.1 Remote Code Execution Vulnerability\"\n- 98568 \"Drupal
+        8.1.x &lt; 8.5.1 Remote Code Execution Vulnerability\"\n- 98569 \"Drupal 8.0.x
+        &lt; 8.5.1 Remote Code Execution Vulnerability\"\n- 98570 \"Drupal 7.x &lt;
+        7.58 Remote Code Execution Vulnerability\"\n- 98571 \"Drupal 8.5.x &lt; 8.5.2
+        Enhanced Image Plugin XSS\"\n- 98572 \"Drupal 8.x &lt; 8.4.7 Enhanced Image
+        Plugin XSS\"\n- 98573 \"Drupal 8.5.x &lt; 8.5.3 Remote Code Execution Vulnerability\"\n-
+        98574 \"Drupal 8.4.x &lt; 8.4.8 Remote Code Execution Vulnerability\"\n- 98575
+        \"Drupal 8.3.x &lt; 8.5.3 Remote Code Execution Vulnerability\"\n- 98576 \"Drupal
+        8.2.x &lt; 8.5.3 Remote Code Execution Vulnerability\"\n- 98577 \"Drupal 8.1.x
+        &lt; 8.5.3 Remote Code Execution Vulnerability\"\n- 98578 \"Drupal 8.0.x &lt;
+        8.5.3 Remote Code Execution Vulnerability\"\n- 98579 \"Drupal 7.x &lt; 7.59
+        Remote Code Execution Vulnerability\"\n- 98580 \"Drupal 8.6.x &lt; 8.6.0-beta2
+        Symfony Legacy HTTP Headers Vulnerability\"\n- 98581 \"Drupal 8.x &lt; 8.5.6
+        Symfony Legacy HTTP Headers Vulnerability\"\n- 98582 \"Drupal 7.x &lt; 7.60
+        Multiple Vulnerabilities\"\n- 98583 \"Drupal 8.x &lt; 8.5.8 Multiple Vulnerabilities\"\n-
+        98584 \"Drupal 8.6.x &lt; 8.6.2 Multiple Vulnerabilities\"\n- 98585 \"Drupal
+        7.x &lt; 7.62 Multiple Vulnerabilities\"\n- 98586 \"Drupal 8.x &lt; 8.5.9
+        Multiple Vulnerabilities\"\n- 98587 \"Drupal 8.6.x &lt; 8.6.6 Multiple Vulnerabilities\"\n-
+        98588 \"Drupal 8.5.x &lt; 8.5.11 Remote Code Execution Vulnerability\"\n-
+        98589 \"Drupal 8.6.x &lt; 8.6.10 Remote Code Execution Vulnerability\"\n-
+        98590 \"jQuery &lt; 3.4.0 Prototype Pollution\"\n- 98591 \"WooCommerce Checkout
+        Manager Plugin for WordPress &lt; 4.3 Arbitrary File Upload\"\n- 98592 \"Blog
+        Designer Plugin for WordPress &lt; 1.8.11 Cross-Site Scripting\"\n- 98593
+        \"PHP error_log File Detected\"\n- 98594 \"Web.config File Information Disclosure\"\n-
+        98595 \"Gitignore File Detected\"\n- 98596 \"nginx 1.x &lt; 1.14.1 Multiple
+        Vulnerabilties\"\n- 98597 \"nginx 1.15.x &lt; 1.15.6 Multiple Vulnerabilties\"\n-
+        98598 \"jQuery Mobile &lt; 1.2.0 Cross-Site Scripting\"\n- 98599 \"PHP 7.3.x
+        &lt; 7.3.5 Heap-based Buffer Overflow Vulnerability\"\n- 98600 \"PHP 7.2.x
+        &lt; 7.2.18 Heap-based Buffer Overflow Vulnerability\"\n- 98601 \"PHP 7.1.x
+        &lt; 7.1.29 Heap-based Buffer Overflow Vulnerability\"\n- 98602 \"Drupal 8.7.x
+        &lt; 8.7.1 Third-Party Libraries Vulnerability\"\n- 98603 \"Drupal 8.6.x &lt;
+        8.6.16 Third-Party Libraries Vulnerability\"\n- 98604 \"Drupal 7.x &lt; 7.67
+        Third-Party Libraries Vulnerability\"\n- 98605 \"Slimstat Analytics Plugin
+        for WordPress &lt; 4.8.1 Cross-Site Scripting\"\n- 98606 \"WP Live Chat Support
+        Plugin for WordPress &lt; 8.0.27 Cross-Site Scripting\"\n- 98607 \"Ultimate
+        Member Plugin for WordPress &lt; 2.0.46 Multiples Vulnerabilities\"\n- 98608
+        \"Give Plugin for WordPress &lt; 2.4.7 Cross-Site Scripting\"\n- 98609 \"W3
+        Total Cache Plugin for WordPress &lt; 0.9.7.4 Multiples Vulnerabilities\"\n-
+        98610 \"All-in-One Event Calendar Plugin for WordPress &lt; 2.5.39 Cross-Site
+        Scripting\"\n- 98611 \"Error Message\"\n- 98612 \"Missing 'Expect-CT' Header\"\n-
+        98613 \"Atlassian Confluence &lt; 6.6.12 / 6.7.x &lt; 6.12.3 / 6.13.x &lt;
+        6.13.3 / 6.14.x &lt; 6.14.2 Template Injection\"\n- 98614 \"Joomla! 1.7.x
+        &lt; 3.9.6 Multiple Vulnerabilities\"\n- 98615 \"Basic Authentication Without
+        HTTPS\"\n- 98616 \"TLS 1.2 Not Supported Protocol\"\n- 98617 \"SSL/TLS Forward
+        Secrecy Cipher Suites Not Supported\"\n- 98618 \"HTTP Header Information Disclosure\"\n-
+        98619 \"PHP 7.3.x &lt; 7.3.6 Multiple Vulnerabilities\"\n- 98620 \"PHP 7.2.x
+        &lt; 7.2.19 Multiple Vulnerabilities\"\n- 98621 \"PHP 7.1.x &lt; 7.1.30 Multiple
+        Vulnerabilities\"\n- 98622 \"Joomla! 3.6.x &lt; 3.9.7 Multiple Vulnerabilities\"\n-
+        98623 \"Host Header Injection\"\n- 98624 \"WP Statistics Plugin for WordPress
+        &lt; 12.6.7 SQL Injection\"\n- 98625 \"Apache Tomcat 9.0.0.M1 &lt; 9.0.20
+        Denial of Service\"\n- 98626 \"WP Live Chat Support Plugin for WordPress &lt;
+        8.0.33 Authentication Bypass\"\n- 98627 \"Convert Plus Plugin for WordPress
+        &lt; 3.4.3 Arbitrary User Role Creation\"\n- 98628 \"WP Database Backup Plugin
+        for WordPress &lt; 5.2 Command Injection\"\n- 98629 \"Apache Tomcat 8.5.0
+        &lt; 8.5.41 Denial of Service\"\n- 98630 \"Apache .htaccess and .htpasswd
+        Disclosure\"\n- 98631 \"Joomla! 3.9.7 &lt; 3.9.9 Remote Code Execution\"\n-
+        98632 \"WS_FTP.LOG File Detected\"\n- 98633 \"Atlassian Confluence 6.15.x
+        &lt; 6.15.2 Directory Traversal Vulnerability\"\n- 98634 \"Atlassian Confluence
+        6.14.x &lt; 6.14.3 Directory Traversal Vulnerability\"\n- 98635 \"Atlassian
+        Confluence 6.13.x &lt; 6.13.4 Directory Traversal Vulnerability\"\n- 98636
+        \"Atlassian Confluence 6.7.x &lt; 6.12.4 Directory Traversal Vulnerability\"\n-
+        98637 \"Atlassian Confluence &lt; 6.6.13 Directory Traversal Vulnerability\"\n-
+        98638 \"Atlassian Confluence 6.14.x &lt; 6.14.2 Multiple Vulnerabilities\"\n-
+        98639 \"Atlassian Confluence 6.13.x &lt; 6.13.3 Multiple Vulnerabilities\"\n-
+        98640 \"Atlassian Confluence 6.7.x &lt; 6.12.3 Multiple Vulnerabilities\"\n-
+        98641 \"Atlassian Confluence &lt; 6.6.12 Multiple Vulnerabilities\"\n- 98642
+        \"Magento Adminstration Panel Login Form Detected\"\n- 98643 \"Drupal 8.7.4
+        Access Bypass Vulnerability\"\n- 98644 \"Magento Connect Manager Detected\"\n-
+        98645 \"Sessvars &lt; 1.01 DOM-based Cross-Site Scripting\"\n- 98646 \".DS_Store
+        File Detected\"\n- 98647 \"Missing Subresource Integrity (SRI)\"\n- 98648
+        \"Missing 'Content-Type' Header\"\n- 98649 \"Invalid Subresource Integrity\"\n-
+        98650 \"SVN Repository Detected\"\n- 98651 \"Atlassian JIRA 4.4.x &lt; 7.6.14
+        Template Injection Vulnerability\"\n- 98652 \"Atlassian JIRA 7.7.x &lt; 7.13.5
+        Template Injection Vulnerability\"\n- 98653 \"Atlassian JIRA 8.0.x &lt; 8.0.3
+        Template Injection Vulnerability\"\n- 98654 \"Atlassian JIRA 8.1.x &lt; 8.1.2
+        Template Injection Vulnerability\"\n- 98655 \"Atlassian JIRA 8.2.x &lt; 8.2.3
+        Template Injection Vulnerability\"\n- 98656 \"Atlassian Crowd 3.4.x &lt; 3.4.4
+        RCE Vulnerability\"\n- 98657 \"Atlassian Crowd 3.3.x &lt; 3.3.5 RCE Vulnerability\"\n-
+        98658 \"Atlassian Crowd 3.2.x &lt; 3.2.8 RCE Vulnerability\"\n- 98659 \"Atlassian
+        Crowd 3.1.x &lt; 3.1.6 RCE Vulnerability\"\n- 98660 \"Atlassian Crowd 2.1.x
+        &lt; 3.0.5 RCE Vulnerability\"\n- 98661 \"PHP 7.3.x &lt; 7.3.8 Multiple Vulnerabilities\"\n-
+        98662 \"PHP 7.2.x &lt; 7.2.21 Multiple Vulnerabilities\"\n- 98663 \"PHP 7.1.x
+        &lt; 7.1.31 Multiple Vulnerabilities\"\n- 98664 \"Give Plugin for WordPress
+        &lt; 2.5.1 SQL Injection\"\n- 98665 \"Moment.js &lt; 2.15.2 Regular Expression
+        Denial of Service\"\n- 98666 \"Joomla! 1.6.2 &lt; 3.9.11 Incorrect Access
+        Control\"\n- 98667 \"nginx 1.17.x &lt; 1.17.3 Multiple Vulnerabilties\"\n-
+        98668 \"nginx 1.9.5 &lt; 1.16.1 Multiple Vulnerabilties\"\n- 98669 \"Apache
+        2.4.x &lt; 2.4.41 Multiple Vulnerabilities\"\n- 98670 \"Webmin 1.890 &lt;
+        1.930 Remote Command Execution\"\n- 98671 \"CVS Entries Detected\"\n- 98672
+        \"Webmin 1.880 Local File Inclusion Vulnerability\"\n- 98673 \"Webmin 1.840
+        Local File Inclusion Vulnerability\"\n- 98674 \"Webmin &lt; 1.870 Cross-Site
+        Scripting Vulnerability\"\n- 98675 \"Webmin &lt; 1.860 Multiple Vulnerabilities\"\n-
+        98676 \"Webmin &lt; 1.850 Multiple Cross-Site Scripting Vulnerabilities\"\n-
+        98677 \"Webmin &lt; 1.830 Multiple Cross-Site Scripting Vulnerabilities\"\n-
+        98678 \"Webmin &lt; 1.760 xmlrpc.cgi Cross-Site Scripting Vulnerability\"\n-
+        98679 \"Webmin &lt; 1.730 Read Mail Symlink Vulnerability\"\n- 98680 \"CVS
+        Repository Detected\"\n- 98681 \"Sitemap.xml File Detected\"\n- 98682 \"PHP
+        7.3.x &lt; 7.3.9 Multiple Vulnerabilities\"\n- 98683 \"PHP 7.2.x &lt; 7.2.22
+        Multiple Vulnerabilities\"\n- 98684 \"PHP 7.1.x &lt; 7.1.32 Multiple Vulnerabilities\"\n-
+        98685 \"WordPress 3.7.x &lt; 3.7.30 Multiple Vulnerabilities\"\n- 98686 \"WordPress
+        3.8.x &lt; 3.8.30 Multiple Vulnerabilities\"\n- 98687 \"WordPress 3.9.x &lt;
+        3.9.28 Multiple Vulnerabilities\"\n- 98688 \"WordPress 4.0.x &lt; 4.0.27 Multiple
+        Vulnerabilities\"\n- 98689 \"WordPress 4.1.x &lt; 4.1.27 Multiple Vulnerabilities\"\n-
+        98690 \"WordPress 4.2.x &lt; 4.2.24 Multiple Vulnerabilities\"\n- 98691 \"WordPress
+        4.3.x &lt; 4.3.20 Multiple Vulnerabilities\"\n- 98692 \"WordPress 4.4.x &lt;
+        4.4.19 Multiple Vulnerabilities\"\n- 98693 \"WordPress 4.5.x &lt; 4.5.18 Multiple
+        Vulnerabilities\"\n- 98694 \"WordPress 4.6.x &lt; 4.6.15 Multiple Vulnerabilities\"\n-
+        98695 \"WordPress 4.7.x &lt; 4.7.14 Multiple Vulnerabilities\"\n- 98696 \"WordPress
+        4.8.x &lt; 4.8.10 Multiple Vulnerabilities\"\n- 98697 \"WordPress 4.9.x &lt;
+        4.9.11 Multiple Vulnerabilities\"\n- 98698 \"WordPress 5.0.x &lt; 5.0.6 Multiple
+        Vulnerabilities\"\n- 98699 \"WordPress 5.1.x &lt; 5.1.2 Multiple Vulnerabilities\"\n-
+        98700 \"WordPress 5.2.x &lt; 5.2.3 Multiple Vulnerabilities\"\n- 98701 \"JetBrains
+        .idea Directory Detected\"\n- 98702 \"Magento RSS Feed Brute Force\"\n- 98703
+        \"Magento API Anonymous Access\"\n- 98704 \"Drupal PHPUnit/Mailchimp Code
+        Execution Vulnerability\"\n- 98705 \"Robots.txt File Detected\"\n- 98706 \"Popup
+        Builder Plugin for WordPress &lt; 3.45 SQL Injection\"\n- 98707 \"Everest
+        Forms Plugin for WordPress &lt; 1.5.0 SQL Injection\"\n- 98708 \"Joomla! 3.0.x
+        &lt; 3.9.12 Cross-Site Scripting\"\n- 98709 \"FV Flowplayer Video Player Plugin
+        for WordPress &lt; 7.3.19.727 SQL Injection\"\n- 98710 \"Photo Gallery Plugin
+        for WordPress &lt; 1.5.31 SQL Injection\"\n- 98711 \"Email Subscribers &amp;
+        Newsletters Plugin for WordPress &lt; 4.1.8 SQL Injection\"\n- 98712 \"Blog2Social
+        Plugin for WordPress &lt; 5.6.0 SQL Injection\"\n- 98713 \"AdRotate Banner
+        Manager Plugin for WordPress &lt; 5.3 SQL Injection\"\n- 98714 \"NextGEN Gallery
+        Plugin for WordPress &lt; 3.2.11 SQL Injection\"\n- 98715 \"Permissive HTTP
+        Strict Transport Security Policy Detected\"\n- 98716 \"Rails Arbitrary File
+        Content Disclosure\"\n- 98717 \"PHP 7.3.x &lt; 7.3.10 Multiple Vulnerabilities\"\n-
+        98718 \"PHP 7.2.x &lt; 7.2.23 Multiple Vulnerabilities\"\n- 98719 \"Atlassian
+        JIRA 7.0.10 &lt; 7.6.16 Template Injection Vulnerability\"\n- 98720 \"Give
+        Plugin for WordPress &lt; 2.5.5 Authentication Bypass\"\n- 98721 \"Atlassian
+        JIRA 7.7.x &lt; 7.13.8 Template Injection Vulnerability\"\n- 98722 \"Atlassian
+        JIRA 8.1.x &lt; 8.1.3 Template Injection Vulnerability\"\n- 98723 \"Atlassian
+        JIRA 8.2.x &lt; 8.2.5 Template Injection Vulnerability\"\n- 98724 \"Atlassian
+        JIRA 8.3.x &lt; 8.3.4 Template Injection Vulnerability\"\n- 98725 \"Atlassian
+        JIRA 8.4.x &lt; 8.4.1 Template Injection Vulnerability\"\n- 98726 \"Atlassian
+        JIRA &lt; 8.4.0 Multiple Vulnerabilities\"\n- 98727 \"Atlassian Bitbucket
+        &lt; 5.16.10 Command Injection Vulnerability\"\n- 98728 \"Atlassian Bitbucket
+        6.0.x &lt; 6.0.10 Command Injection Vulnerability\"\n- 98729 \"Atlassian Bitbucket
+        6.1.x &lt; 6.1.8 Command Injection Vulnerability\"\n- 98730 \"Atlassian Bitbucket
+        6.2.x &lt; 6.2.6 Command Injection Vulnerability\"\n- 98731 \"Atlassian Bitbucket
+        6.3.x &lt; 6.3.5 Command Injection Vulnerability\"\n- 98732 \"Atlassian Bitbucket
+        6.4.x &lt; 6.4.3 Command Injection Vulnerability\"\n- 98733 \"Atlassian Bitbucket
+        6.5.x &lt; 6.5.2 Command Injection Vulnerability\"\n- 98734 \"Atlassian Bitbucket
+        5.13.x &lt; 5.13.6 Path Traversal Vulnerability\"\n- 98735 \"Atlassian Bitbucket
+        5.14.x &lt; 5.14.4 Path Traversal Vulnerability\"\n- 98736 \"Atlassian Bitbucket
+        5.15.x &lt; 5.15.3 Path Traversal Vulnerability\"\n- 98737 \"Atlassian Bitbucket
+        5.16.x &lt; 5.16.3 Path Traversal Vulnerability\"\n- 98738 \"Atlassian Bitbucket
+        6.0.x &lt; 6.0.3 Path Traversal Vulnerability\"\n- 98739 \"Atlassian Bitbucket
+        6.1.x &lt; 6.1.2 Path Traversal Vulnerability\"\n- 98740 \"Cross-Site Scripting
+        (XSS) in script src\"\n- 98741 \"All In One WP Security &amp; Firewall Plugin
+        for WordPress &lt; 4.4.2 Open Redirect\"\n- 98742 \"Atlassian JIRA Service
+        Desk &lt; 3.9.16 Path Traversal Vulnerability\"\n- 98743 \"Atlassian JIRA
+        Service Desk 3.10.x &lt; 3.16.8 Path Traversal Vulnerability\"\n- 98744 \"Atlassian
+        JIRA Service Desk 4.0.x &lt; 4.1.3 Path Traversal Vulnerability\"\n- 98745
+        \"Atlassian JIRA Service Desk 4.2.x &lt; 4.2.5 Path Traversal Vulnerability\"\n-
+        98746 \"Atlassian JIRA Service Desk 4.3.x &lt; 4.3.4 Path Traversal Vulnerability\"\n-
+        98747 \"Atlassian JIRA Service Desk 4.4.x &lt; 4.4.1 Path Traversal Vulnerability\"\n-
+        98748 \"WordPress 3.7.x &lt; 3.7.31 Multiple Vulnerabilities\"\n- 98749 \"WordPress
+        3.8.x &lt; 3.8.31 Multiple Vulnerabilities\"\n- 98750 \"WordPress 3.9.x &lt;
+        3.9.29 Multiple Vulnerabilities\"\n- 98751 \"WordPress 4.0.x &lt; 4.0.28 Multiple
+        Vulnerabilities\"\n- 98752 \"WordPress 4.1.x &lt; 4.1.28 Multiple Vulnerabilities\"\n-
+        98753 \"WordPress 4.2.x &lt; 4.2.25 Multiple Vulnerabilities\"\n- 98754 \"WordPress
+        4.3.x &lt; 4.3.21 Multiple Vulnerabilities\"\n- 98755 \"WordPress 4.4.x &lt;
+        4.4.20 Multiple Vulnerabilities\"\n- 98756 \"WordPress 4.5.x &lt; 4.5.19 Multiple
+        Vulnerabilities\"\n- 98757 \"WordPress 4.6.x &lt; 4.6.16 Multiple Vulnerabilities\"\n-
+        98758 \"WordPress 4.7.x &lt; 4.7.15 Multiple Vulnerabilities\"\n- 98759 \"WordPress
+        4.8.x &lt; 4.8.11 Multiple Vulnerabilities\"\n- 98760 \"WordPress 4.9.x &lt;
+        4.9.12 Multiple Vulnerabilities\"\n- 98761 \"WordPress 5.0.x &lt; 5.0.7 Multiple
+        Vulnerabilities\"\n- 98762 \"WordPress 5.1.x &lt; 5.1.3 Multiple Vulnerabilities\"\n-
+        98763 \"WordPress 5.2.x &lt; 5.2.4 Multiple Vulnerabilities\"\n- 98764 \"vBulletin
+        5.x &lt; 5.5.4 Patch Level 1 Remote Code Execution Vulnerability\"\n- 98765
+        \"Magento Cacheleak\"\n- 98766 \"PHP 7.3.x &lt; 7.3.11 Remote Code Execution
+        Vulnerability\"\n- 98767 \"PHP 7.2.x &lt; 7.2.24 Remote Code Execution Vulnerability\"\n-
+        98768 \"PHP 7.1.x &lt; 7.1.33 Remote Code Execution Vulnerability\"\n- 98769
+        \"Joomla! 3.2.x &lt; 3.9.13 Multiple Vulnerabilities\"\n- 98770 \"Email Subscribers
+        &amp; Newsletters Plugin for WordPress &lt; 4.3.1 Multiple Vulnerabilities\"\n-
+        98771 \"Give Plugin for WordPress &lt; 2.5.10 Multiple Vulnerabilities\"\n-
+        98772 \"XHR Detection\"\n- 98773 \"W3 Total Cache Plugin for WordPress &lt;
+        0.9.4 Arbitrary File Read\"\n- 98774 \"vBulletin 5.5.4 &lt; 5.5.4 Patch Level
+        2 Multiple Vulnerabilities\"\n- 98775 \"vBulletin 5.5.3 &lt; 5.5.3 Patch Level
+        2 Multiple Vulnerabilities\"\n- 98776 \"vBulletin 5.5.x &lt; 5.5.2 Patch Level
+        2 Multiple Vulnerabilities\"\n- 98777 \"vBulletin 5.4.3 Open Redirect Vulnerability\"\n-
+        98778 \"vBulletin &lt; 5.3.0 Server-Side Request Forgery Vulnerability\"\n-
+        98800 \"PHP 5.6.0 Development Releases CDF File NULL Pointer Dereference DoS\"\n-
+        98801 \"PHP 5.6.x &lt; 5.6.1 add_post_var() Code Execution\"\n- 98802 \"PHP
+        5.6.x &lt; 5.6.10 Multiple Vulnerabilities\"\n- 98803 \"PHP 5.6.x &lt; 5.6.11
+        Multiple Vulnerabilities (BACKRONYM)\"\n- 98804 \"PHP 5.6.x &lt; 5.6.12 Multiple
+        Vulnerabilities\"\n- 98805 \"PHP 5.6.x &lt; 5.6.13 Multiple Vulnerabilities\"\n-
+        98806 \"PHP 5.6.x &lt; 5.6.14 Multiple Vulnerabilities\"\n- 98807 \"PHP 5.6.x
+        &lt; 5.6.18 Multiple Vulnerabilities\"\n- 98808 \"PHP 5.6.x &lt; 5.6.19 Multiple
+        Vulnerabilities\"\n- 98809 \"PHP 5.6.x &lt; 5.6.2 Multiple Vulnerabilities\"\n-
+        98810 \"PHP 5.6.x &lt; 5.6.20 Multiple Vulnerabilities\"\n- 98811 \"PHP 5.6.x
+        &lt; 5.6.21 Multiple Vulnerabilities\"\n- 98812 \"PHP 5.6.x &lt; 5.6.22 Multiple
+        Vulnerabilities\"\n- 98813 \"PHP 5.6.x &lt; 5.6.23 Multiple Vulnerabilities\"\n-
+        98814 \"PHP 5.6.x &lt; 5.6.24 Multiple Vulnerabilities (httpoxy)\"\n- 98815
+        \"PHP 5.6.x &lt; 5.6.25 Multiple Vulnerabilities\"\n- 98816 \"PHP 5.6.x &lt;
+        5.6.26 Multiple Vulnerabilities\"\n- 98817 \"PHP 5.6.x &lt; 5.6.27 Multiple
+        Vulnerabilities\"\n- 98818 \"PHP 5.6.x &lt; 5.6.28 Multiple Vulnerabilities\"\n-
+        98819 \"PHP 5.6.x &lt; 5.6.29 Multiple Vulnerabilities\"\n- 98820 \"PHP 5.6.x
+        &lt; 5.6.3 donote DoS\"\n- 98821 \"PHP 5.6.x &lt; 5.6.30 Multiple DoS\"\n-
+        98822 \"PHP 5.6.x &lt; 5.6.31 Multiple Vulnerabilities\"\n- 98823 \"PHP 5.6.x
+        &lt; 5.6.32 Multiple Vulnerabilities\"\n- 98824 \"PHP 5.6.x &lt; 5.6.33 Multiple
+        Vulnerabilities\"\n- 98825 \"PHP 5.6.x &lt; 5.6.34 Stack Buffer Overflow\"\n-
+        98826 \"PHP 5.6.x &lt; 5.6.36 Multiple Vulnerabilities\"\n- 98827 \"PHP 5.6.x
+        &lt; 5.6.4 process_nested_data() RCE\"\n- 98828 \"PHP 5.6.x &lt; 5.6.5 Multiple
+        Vulnerabilities\"\n- 98829 \"PHP 5.6.x &lt; 5.6.6 Multiple Vulnerabilities
+        (GHOST)\"\n- 98830 \"PHP 5.6.x &lt; 5.6.7 Multiple Vulnerabilities\"\n- 98831
+        \"PHP 5.6.x &lt; 5.6.8 Multiple Vulnerabilities\"\n- 98832 \"PHP 5.6.x &lt;
+        5.6.9 Multiple Vulnerabilities\"\n- 98833 \"PHP 7.0.x &lt; 7.0.1 Multiple
+        Vulnerabilities\"\n- 98834 \"PHP 7.0.x &lt; 7.0.10 Multiple Vulnerabilities\"\n-
+        98835 \"PHP 7.0.x &lt; 7.0.11 Multiple Vulnerabilities\"\n- 98836 \"PHP 7.0.x
+        &lt; 7.0.12 Multiple Vulnerabilities\"\n- 98837 \"PHP 7.0.x &lt; 7.0.13 Multiple
+        Vulnerabilities\"\n- 98838 \"PHP 7.0.x &lt; 7.0.14 php_wddx_push_element()
+        Function Empty Boolean Element Decoding RCE\"\n- 98839 \"PHP 7.0.x &lt; 7.0.15
+        Multiple Vulnerabilities\"\n- 98840 \"PHP 7.0.x &lt; 7.0.16 Multiple Vulnerabilities\"\n-
+        98841 \"PHP 7.0.x &lt; 7.0.19 Multiple Vulnerabilities\"\n- 98842 \"PHP 7.x
+        &lt; 7.0.2 Multiple Vulnerabilities\"\n- 98843 \"PHP 7.0.x &lt; 7.0.20 Multiple
+        Vulnerabilities\"\n- 98844 \"PHP 7.0.x &lt; 7.0.21 Multiple Vulnerabilities\"\n-
+        98845 \"PHP 7.0.x &lt; 7.0.25 Multiple Vulnerabilities\"\n- 98846 \"PHP 7.0.x
+        &lt; 7.0.27 Multiple Vulnerabilities\"\n- 98847 \"PHP 7.0.x &lt; 7.0.28 Stack
+        Buffer Overflow\"\n- 98848 \"PHP 7.0.x &lt; 7.0.3 Multiple Vulnerabilities\"\n-
+        98849 \"PHP 7.0.x &lt; 7.0.30 Multiple Vulnerabilities\"\n- 98850 \"PHP 7.0.x
+        &lt; 7.0.4 Multiple Vulnerabilities\"\n- 98851 \"PHP 7.0.x &lt; 7.0.5 Multiple
+        Vulnerabilities\"\n- 98852 \"PHP 7.0.x &lt; 7.0.6 Multiple Vulnerabilities\"\n-
+        98853 \"PHP 7.0.x &lt; 7.0.7 Multiple Vulnerabilities\"\n- 98854 \"PHP 7.0.x
+        &lt; 7.0.8 Multiple Vulnerabilities\"\n- 98855 \"PHP 7.0.x &lt; 7.0.9 Multiple
+        Vulnerabilities (httpoxy)\"\n- 98856 \"PHP 7.1.x &lt; 7.1.1 Multiple Vulnerabilities\"\n-
+        98857 \"PHP 7.1.x &lt; 7.1.11 Multiple Vulnerabilities\"\n- 98858 \"PHP 7.1.x
+        &lt; 7.1.13 Multiple Vulnerabilities\"\n- 98859 \"PHP 7.1.x &lt; 7.1.15 Stack
+        Buffer Overflow\"\n- 98860 \"PHP 7.1.x &lt; 7.1.17 Multiple Vulnerabilities\"\n-
+        98861 \"PHP 7.1.x &lt; 7.1.2 Multiple Vulnerabilities\"\n- 98862 \"PHP 7.1.x
+        &lt; 7.1.5 Multiple Vulnerabilities\"\n- 98863 \"PHP 7.1.x &lt; 7.1.6 Multiple
+        Vulnerabilities\"\n- 98864 \"PHP 7.1.x &lt; 7.1.7 Multiple Vulnerabilities\"\n-
+        98865 \"PHP 7.2.x &lt; 7.2.1 Multiple Vulnerabilities\"\n- 98866 \"PHP 7.2.x
+        &lt; 7.2.3 Stack Buffer Overflow\"\n- 98867 \"PHP 7.2.x &lt; 7.2.4 Dumpable
+        FPM Child Processes\"\n- 98868 \"PHP 7.2.x &lt; 7.2.5 Multiple Vulnerabilities\"\n-
+        98869 \"PHP 5.6.x &lt; 5.6.38 Transfer-Encoding Parameter XSS Vulnerability\"\n-
+        98870 \"PHP 7.0.x &lt; 7.0.32 Transfer-Encoding Parameter XSS Vulnerability\"\n-
+        98871 \"PHP 7.1.x &lt; 7.1.22 Transfer-Encoding Parameter XSS Vulnerability\"\n-
+        98872 \"PHP 7.2.x &lt; 7.2.10 Transfer-Encoding Parameter XSS Vulnerability\"\n-
+        98873 \"PHP 5.6.x &lt; 5.6.17 Multiple Vulnerabilities\"\n- 98874 \"PHP 5.6.x
+        &lt; 5.6.37 exif_thumbnail_extract() DoS\"\n- 98875 \"PHP 7.1.x &lt; 7.1.20
+        exif_thumbnail_extract() DoS\"\n- 98876 \"PHP 7.0.x &lt; 7.0.23 Heap User
+        After Free Vulnerability\"\n- 98877 \"PHP 7.1.x &lt; 7.1.9 Heap User After
+        Free Vulnerability\"\n- 98878 \"PHP 7.0.x &lt; 7.0.31 Use After Free Arbitrary
+        Code Execution in EXIF\"\n- 98879 \"PHP 7.2.x &lt; 7.2.8 Use After Free Arbitrary
+        Code Execution in EXIF\"\n- 98880 \"PHP 5.6.x &lt; 5.6.39 Multiple vulnerabilities\"\n-
+        98881 \"PHP 7.0.x &lt; 7.0.33 Multiple vulnerabilities\"\n- 98882 \"PHP 7.1.x
+        &lt; 7.1.25 Multiple vulnerabilities\"\n- 98883 \"PHP 7.2.x &lt; 7.2.13 Multiple
+        vulnerabilities\"\n- 98884 \"PHP 7.3.x &lt; 7.3.0 Multiple vulnerabilities\"\n-
+        98900 \"Apache 2.4.x &lt; 2.4.2 'LD_LIBRARY_PATH' Insecure Library Loading\"\n-
+        98901 \"Apache 2.4.x &lt; 2.4.3 Multiple Vulnerabilities\"\n- 98902 \"Apache
+        2.4.x &lt; 2.4.4 Multiple XSS Vulnerabilities\"\n- 98903 \"Apache 2.4.x &lt;
+        2.4.6 Multiple Vulnerabilities\"\n- 98904 \"Apache 2.4.6 Remote DoS\"\n- 98905
+        \"Apache 2.4.x &lt; 2.4.9 Multiple Vulnerabilities\"\n- 98906 \"Apache 2.4.x
+        &lt; 2.4.10 Multiple Vulnerabilities\"\n- 98907 \"Apache 2.4.x &lt; 2.4.12
+        Multiple Vulnerabilities\"\n- 98908 \"Apache 2.4.x &lt; 2.4.16 Multiple Vulnerabilities\"\n-
+        98909 \"Apache 2.4.18 / 2.4.20 X.509 Certificate Authentication Bypass\"\n-
+        98910 \"Apache 2.4.x &lt; 2.4.25 Multiple Vulnerabilities (httpoxy)\"\n- 98911
+        \"Apache 2.4.x &lt; 2.4.26 Multiple Vulnerabilities\"\n- 98912 \"Apache 2.4.x
+        &lt; 2.4.27 Multiple Vulnerabilities\"\n- 98913 \"Apache 2.4.x &lt; 2.4.28
+        HTTP Vulnerability (OptionsBleed)\"\n- 98914 \"Apache 2.4.x &lt; 2.4.33 Multiple
+        Vulnerabilities\"\n- 98915 \"Apache 2.4.x &lt; 2.4.34 Multiple Vulnerabilities\"\n-
+        98916 \"Apache 2.4.x &lt; 2.4.35 Denial of Service\"\n- 98917 \"Apache 2.4.17
+        / 2.4.18 mod_http2 Denial of Service\"\n- 98950 \"nginx &lt; 1.4.1 ngx_http_proxy_module.c
+        Multiple Vulnerabilities\"\n- 98951 \"nginx &lt; 1.2.9 ngx_http_proxy_module.c
+        Multiple Vulnerabilities\"\n- 98952 \"nginx &lt; 1.5.7 ngx_parse_http Security
+        Bypass\"\n- 98953 \"nginx &lt; 1.4.4 ngx_parse_http Security Bypass\"\n- 98954
+        \"nginx 1.5.10 SPDY Memory Corruption\"\n- 98955 \"nginx &lt; 1.5.12 SPDY
+        Heap Buffer Overflow\"\n- 98956 \"nginx &lt; 1.4.7 SPDY Heap Buffer Overflow\"\n-
+        98957 \"nginx &lt; 1.7.4 SMTP STARTTLS Command Injection\"\n- 98958 \"nginx
+        &lt; 1.6.1 SMTP STARTTLS Command Injection\"\n- 98959 \"nginx &lt; 1.7.5 SSL
+        Session Reuse\"\n- 98960 \"nginx &lt; 1.6.2 SSL Session Reuse\"\n- 98961 \"nginx
+        1.9.x &lt; 1.9.6 HTTPv2 PRI Double-Free DoS\"\n- 98962 \"nginx &lt; 1.9.10
+        Multiple Vulnerabilities\"\n- 98963 \"nginx &lt; 1.8.1 Multiple Vulnerabilities\"\n-
+        98964 \"nginx &lt; 1.11.1 NULL Pointer Dereference\"\n- 98965 \"nginx &lt;
+        1.10.1 NULL Pointer Dereference\"\n- 98966 \"nginx &lt; 1.13.3 Integer Overflow\"\n-
+        98967 \"nginx &lt; 1.12.1 Integer Overflow\"\n- 112290 \"Apache Tomcat 9.0.0.M1
+        &lt; 9.0.10 Multiple Vulnerabilities\"\n- 112291 \"Apache Tomcat 9.0.0.M1
+        &lt; 9.0.8 Denial of Service\"\n- 112292 \"Apache Tomcat 9.0.0.M1 &lt; 9.0.5
+        Security Constraint Weakness\"\n- 112293 \"Apache Tomcat 9.0.0.M22 &lt; 9.0.2
+        Insecure CGI Servlet Search Algorithm Description Weakness\"\n- 112294 \"Apache
+        Tomcat 9.0.0.M1 &lt; 9.0.1 Remote Code Execution via JSP Upload\"\n- 112295
+        \"Apache Tomcat 9.0.0.M1 &lt; 9.0.0.M22 Multiple Vulnerabilities\"\n- 112296
+        \"Apache Tomcat 8.5.0 &lt; 8.5.32 Multiple Vulnerabilities\"\n- 112297 \"Apache
+        Tomcat 8.5.0 &lt; 8.5.31 Denial of Service\"\n- 112298 \"Apache Tomcat 8.5.x
+        &lt; 8.5.28 Security Constraint Weakness\"\n- 112299 \"Apache Tomcat 8.5.16
+        &lt; 8.5.24 Insecure CGI Servlet Search Algorithm Description Weakness\"\n-
+        112300 \"Apache Tomcat 8.5.x &lt; 8.5.23 Remote Code Execution via JSP Upload\"\n-
+        112301 \"Apache Tomcat 8.5.x &lt; 8.5.16 Multiple Vulnerabilities\"\n- 112302
+        \"Apache Tomcat 7.0.x &lt; 7.0.78 Remote Error Page Manipulation\"\n- 112303
+        \"Apache Tomcat 8.5.x &lt; 8.5.15 Remote Error Page Manipulation\"\n- 112304
+        \"Apache Tomcat 8.5.x &lt; 8.5.13 Multiple Vulnerabilities\"\n- 112305 \"Apache
+        Tomcat 7.0.25 &lt; 7.0.90 Multiple Vulnerabilities\"\n- 112306 \"Apache Tomcat
+        7.0.28 &lt; 7.0.88 Denial of Service\"\n- 112307 \"Apache Tomcat 7.0.0 &lt;
+        7.0.85 Security Constraint Weakness\"\n- 112308 \"Apache Tomcat 7.0.79 &lt;
+        7.0.84 Insecure CGI Servlet Search Algorithm Description Weakness\"\n- 112309
+        \"Apache Tomcat 7.0.x &lt; 7.0.82 Remote Code Execution via JSP Upload\"\n-
+        112310 \"Apache Tomcat 7.0.x &lt; 7.0.81 Multiple Vulnerabilities\"\n- 112311
+        \"Apache Tomcat 7.0.41 &lt; 7.0.79 Cache Poisoning Vulnerability\"\n- 112312
+        \"Apache Tomcat 7.0.x &lt; 7.0.77 Information Disclosure\"\n- 112313 \"Apache
+        Tomcat 9.0.0.M1 &lt; 9.0.12 Open Redirect\"\n- 112315 \"Apache Tomcat 7.0.23
+        &lt; 7.0.91 Open Redirect\"\n- 112316 \"Apache Tomcat 8.5.0 &lt; 8.5.34 Open
+        Redirect\"\n- 112350 \"Nginx Default Index Page\"\n- 112351 \"Apache Default
+        Index Page\"\n- 112352 \"Microsoft ASP.NET Application Tracing trace.axd Information
+        Disclosure\"\n- 112353 \"ASP.NET DEBUG Method Enabled\"\n- 112354 \"lighttpd
+        &lt; 1.4.28 Insecure Temporary File Creation\"\n- 112355 \"lighttpd &lt; 1.4.30
+        base64_decode Function Out-of-Bounds Read Error DoS\"\n- 112356 \"lighttpd
+        1.4.31 http_request_split_value Function Header Handling DoS\"\n- 112357 \"lighttpd
+        &lt; 1.4.34 Multiple Vulnerabilities\"\n- 112358 \"lighttpd &lt; 1.4.35 Multiple
+        Vulnerabilities\"\n- 112359 \"lighttpd &lt; 1.4.36 mod_auth Arbitrary Log
+        Entries Injection\"\n- 112360 \"Lighttpd Default Index Page\"\n- 112361 \"Lighttpd
+        Status Module Information Disclosure\"\n- 112362 \"lighttpd &lt; 1.4.50 Multiple
+        Vulnerabilities\"\n- 112363 \"lighttpd &lt; 1.4.51 Multiple Vulnerabilities\"\n-
+        112370 \"Apache Struts 2 DevMode Enabled\"\n- 112371 \"Apache Struts 2 OGNL
+        Console Detected\"\n- 112372 \"Bootstrap &lt; 2.1.0 Cross-Site Scripting\"\n-
+        112373 \"Bootstrap &lt; 3.4.0 Cross-Site Scripting\"\n- 112374 \"Bootstrap
+        4.0.0 &lt; 4.1.2 Cross-Site Scripting\"\n- 112375 \"Bootstrap &lt; 3.4.1 Cross-Site
+        Scripting\"\n- 112376 \"Bootstrap 4.3.x &lt; 4.3.1 Cross-Site Scripting\"\n-
+        112381 \"Modernizr 3.x &lt; 3.4.0 Marked Multiple Vulnerabilities\"\n- 112391
+        \"AngularJS &lt; 1.4.10 Cross-Site Scripting\"\n- 112392 \"AngularJS 1.3.0
+        &lt; 1.5.0-rc.2 Cross-Site Scripting\"\n- 112393 \"AngularJS &lt; 1.6.1 Cross-Site
+        Scripting\"\n- 112394 \"AngularJS 1.5.0 &lt; 1.5.9 Content Security Policy
+        Bypass\"\n- 112395 \"AngularJS &lt; 1.6.5 Cross-Site Scripting\"\n- 112396
+        \"AngularJS &lt; 1.6.7 Cross-Site Scripting\"\n- 112397 \"AngularJS &lt; 1.6.9
+        Cross-Site Scripting\"\n- 112411 \"YUI 2.4.0 &lt; 2.8.2 Cross-Site Scripting\"\n-
+        112412 \"YUI &lt; 2.9.0 Cross-Site Scripting\"\n- 112413 \"YUI 3.5.0-PR1 &lt;
+        3.5.1 Cross-Site Scripting\"\n- 112414 \"YUI 2.4.0 &lt; 3.0.0 Cross-Site Scripting\"\n-
+        112415 \"YUI 3.0.0 &lt; 3.10.0 Cross-Site Scripting\"\n- 112416 \"YUI 3.0.0
+        &lt; 3.10.1 Cross-Site Scripting\"\n- 112417 \"YUI 3.10.2 Cross-Site Scripting\"\n-
+        112431 \"jQuery &lt; 1.6.3 Cross-Site Scripting\"\n- 112432 \"jQuery 1.7.1
+        &lt; 1.9.0 Cross-Site Scripting\"\n- 112433 \"jQuery 1.4.2 &lt; 1.6.2 Cross-Site
+        Scripting\"\n- 112434 \"jQuery 1.4.0 &lt; 1.12.0 Cross-Site Scripting\"\n-
+        112435 \"jQuery 1.12.4 &lt; 3.0.0 Cross-Site Scripting\"\n- 112436 \"jQuery
+        3.0.0-rc.1 Denial of Service\"\n- 112445 \"Moment.js &lt; 2.11.2 Regular Expression
+        Denial of Service\"\n- 112446 \"Moment.js &lt; 2.19.3 Regular Expression Denial
+        of Service\"\n- 112456 \"jQuery File Upload &lt; 9.22.1 Arbitrary File Upload\"\n-
+        112457 \"jQuery File Upload &lt; 9.24.1 Arbitrary File Upload\"\n- 112458
+        \"jQuery File Upload &lt; 9.25.1 Potential Vulnerability With ImageMagick\"\n-
+        112461 \"Backbone.js &lt; 0.5.0 Cross-Site Scripting\"\n- 112470 \"Apache
+        Spark &lt; 2.1.3 / 2.2.x &lt; 2.2.2 / 2.3.x &lt; 2.3.1 XSS in UI\"\n- 112476
+        \"Prototype &lt; 1.6.0.2 Cross-Site Ajax Request\"\n- 112490 \"Telerik Reporting
+        &lt; 11.0.17.406 Cross-Site Scripting\"\n- 112491 \"SSL/TLS Certificate Information\"\n-
+        112493 \"SSL/TLS Certificate Expired\"\n- 112494 \"SSL Insecure Protocols\"\n-
+        112495 \"SSL/TLS Self-Signed Certificate\"\n- 112496 \"TLS 1.0 Weak Protocol\"\n-
+        112500 \"IIS Default Index Page\"\n- 112501 \"Sitefinity &lt; 10.0.6412.0
+        Multiple Vulnerabilities\"\n- 112502 \"Sitefinity &lt; 6.0.4230.0 Multiple
+        Vulnerabilities\"\n- 112503 \"Sitefinity 6.1.x &lt; 6.1.4720.0 Multiple Vulnerabilities\"\n-
+        112504 \"Sitefinity 6.2.x &lt; 6.2.4930.0 Multiple Vulnerabilities\"\n- 112505
+        \"Sitefinity 6.3.x &lt; 6.3.5050.0 Multiple Vulnerabilities\"\n- 112506 \"Sitefinity
+        7.0.x &lt; 7.0.5140.0 Multiple Vulnerabilities\"\n- 112507 \"Sitefinity 7.1.x
+        &lt; 7.1.5240.0 Multiple Vulnerabilities\"\n- 112508 \"Sitefinity 7.2.x &lt;
+        7.2.5350.0 Multiple Vulnerabilities\"\n- 112509 \"Sitefinity 7.3.x &lt; 7.3.5690.0
+        Multiple Vulnerabilities\"\n- 112510 \"Sitefinity 8.0.x &lt; 8.0.5770.0 Multiple
+        Vulnerabilities\"\n- 112511 \"Sitefinity 8.1.x &lt; 8.1.5860.0 Multiple Vulnerabilities\"\n-
+        112512 \"Sitefinity 8.2.x &lt; 8.2.5970.0 Multiple Vulnerabilities\"\n- 112513
+        \"Sitefinity 9.0.x &lt; 9.0.6060.0 Multiple Vulnerabilities\"\n- 112514 \"Sitefinity
+        9.1.x &lt; 9.1.6180.0 Multiple Vulnerabilities\"\n- 112515 \"Sitefinity 9.2.x
+        &lt; 9.2.6270.0 Multiple Vulnerabilities\"\n- 112516 \"Sitefinity 10.0.x &lt;
+        10.0.6415.0 Multiple Vulnerabilities\"\n- 112517 \"Sitefinity 10.1.x &lt;
+        10.1.6506.0 Multiple Vulnerabilities\"\n- 112518 \"Sitefinity 10.2.x &lt;
+        10.2.6604.0 Multiple Vulnerabilities\"\n- 112519 \"Sitefinity 11.x &lt; 11.0.6702.0
+        Multiple Vulnerabilities\"\n- 112526 \"Missing 'X-XSS-Protection' Header\"\n-
+        112527 \"Disabled 'X-XSS-Protection' Header\"\n- 112528 \"Sitefinity Adminstration
+        Panel Login Form Detected\"\n- 112529 \"Missing 'X-Content-Type-Options' Header\"\n-
+        112530 \"SSL/TLS Versions Supported\"\n- 112531 \"Git Repository Detected\"\n-
+        112536 \"SSL/TLS Anonymous Cipher Suites Supported\"\n- 112537 \"SSL/TLS Null
+        Cipher Suites Supported\"\n- 112538 \"SSL/TLS Insecure Cipher Suites Supported\"\n-
+        112539 \"SSL/TLS Weak Cipher Suites Supported\"\n- 112540 \"SSL/TLS Certificate
+        RSA Keys Less Than 2048 bits\"\n- 112541 \"SSL/TLS Certificate Common Name
+        Mismatch\"\n- 112542 \"SSL/TLS Certificate Signed Using Weak Hashing Algorithm\"\n-
+        112543 \"HTTPS Not Detected\"\n- 112544 \"HTTP to HTTPS Redirect Not Enabled\"\n-
+        112545 \"Oracle WebLogic Server Administration Console Detection\"\n- 112546
+        \"TLS 1.1 Deprecated Protocol\"\n- 112547 \"Apache Struts Config Browser Detected\"\n-
+        112550 \"Full Path Disclosure\"\n- 112551 \"Missing Content Security Policy\"\n-
+        112552 \"Deprecated Content Security Policy\"\n- 112553 \"Missing 'Cache-Control'
+        Header\"\n- 112554 \"Permissive Content Security Policy Detected\"\n- 112555
+        \"Report Only Content Security Policy Detected\"\n- 112556 \"MediaElement.js
+        &lt; 2.21.1 Cross-Site Scripting\"\n- 112564 \"ThinkPHP 5.0.x &lt; 5.0.23
+        / 5.1.x &lt; 5.1.31 Remote Code Execution\"\n- 112565 \"ThinkPHP 5.0.x &lt;
+        5.0.24 Remote Code Execution\"\n- 115491 \"SSL/TLS Cipher Suites Supported\"\n-
+        115540 \"Cookie Without SameSite Flag Detected\"</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98064\"
+        pluginName=\"Cookie Without Secure Flag Detected\" pluginFamily=\"Web Applications\"><description>When
+        the `secure` flag is set on a cookie, the browser will prevent it from being\n
+        \ sent over a clear text channel (HTTP) and only allow it to be sent when
+        an encrypted\n  channel is used (HTTPS).\n\n  The scanner discovered that
+        a cookie was set by the server without the secure flag\n  being set. Although
+        the initial setting of this cookie was via an HTTPS\n  connection, any HTTP
+        link to the same server will result in the cookie being\n  sent in clear text.\n\n
+        \ Note that if the cookie does not contain sensitive information, the risk
+        of this\n  vulnerability is mitigated.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cookie
+        Without Secure Flag Detected</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/SecureFlag</see_also><solution>If
+        the cookie contains sensitive information, then the server should ensure that
+        \  the cookie has the `secure` flag set.</solution><xref>cwe:614</xref><xref>owasp:2017-A3</xref><xref>owasp:2010-A9</xref><xref>owasp:2017-A2</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><xref>owasp:2010-A3</xref><plugin_output>https://google-gruyere.appspot.com/start
+        returned cookie 'GRUYERE_ID' without the Secure flag set.</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98050\"
+        pluginName=\"Interesting response\" pluginFamily=\"Web Applications\"><description>The
+        scanner identified some responses with a status code other than the usual
+        200 (OK), 301 (Moved Permanently), 302 (Found) and 404 (Not Found) codes.\n
+        \ These codes can provide useful insights into the behavior of the web application
+        and identify any unexpected responses to be addressed.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2018/05/09</plugin_modification_date><plugin_name>Interesting
+        response</plugin_name><risk_factor>Informational</risk_factor><see_also>http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html</see_also><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/start\n\n\nProof\n-------\nHTTP/1.1
+        405 Method Not Allowed\n\n\nRequest\n---------\n\nTRACE /start HTTP/1.1\n
+        | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n |
+        User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML,
+        like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | X-Tenable-Wasscan-Trace: 1\n | Cookie:
+        GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        405 Method Not Allowed\n | Content-Type: text/html; charset=UTF-8\n | Referrer-Policy:
+        no-referrer\n | Content-Length: 1595\n | Alt-Svc: quic=\":443\"; ma=2592000;
+        v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | \n
+        | &lt;!DOCTYPE html>\n&lt;html lang=en>\n  &lt;meta charset=utf-8>\n  &lt;meta
+        name=viewport content=\"initial-scale=1, minimum-scale=1, width=device-width\">\n
+        \ &lt;title>Error 405 (Method Not Allowed)!!1&lt;/title>\n  &lt;style>\n    *{margin:0;padding:0}html,code{font:15px/22px
+        arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7%
+        auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png)
+        100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a
+        img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png)
+        no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png)
+        no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png)
+        0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png)
+        no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}\n
+        \ &lt;/style>\n  &lt;a href=//www.google.com/>&lt;span id=logo aria-label=Google>&lt;/span>&lt;/a>\n
+        \ &lt;p>&lt;b>405.&lt;/b> &lt;ins>That?????????s an error.&lt;/ins>\n  &lt;p>The
+        request method &lt;code>TRACE&lt;/code> is inappropriate for the URL &lt;code>/start&lt;/code>.
+        \ &lt;ins>That?????????s all we know.&lt;/ins>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98083\"
+        pluginName=\"CAPTCHA Detection\" pluginFamily=\"Web Applications\"><description>Detects
+        any known CAPTCHA products being used on a page.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>CAPTCHA
+        Detection</plugin_name><risk_factor>Informational</risk_factor><plugin_output>A
+        Recaptcha CAPTCHA has been detected on https://google-gruyere.appspot.com/resetbutton/412569245047960484377262321708701598236
+        due to tag  &lt;div class=\"g-recaptcha\" data-sitekey=\"6LfKTycUAAAAAOLes3JooIZ0gi8BNy81n_mY3fdD\"></plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98104\"
+        pluginName=\"Cross-Site Scripting (XSS)\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  HTML element content.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS)</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/deletesnippet\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : index\n\nInjected Payload   : &lt;xss_6260103/>\n\n\n\nProof\n-------\n&lt;xss_6260103/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/deletesnippet?index=0%3Cxss_6260103%2F%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        fa1da30204a789d08032787f6b8c5e83\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:58:53 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        index (0&lt;xss_6260103/>)&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/deletesnippet\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/deletesnippet/%3E%22'%3E%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        5c30cc6cffc4f56212d3c15bca336ec4\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:59:57 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /deletesnippet/>\"'>&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html&gt;\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/dump.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/dump.gtl/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        cf700f569bb5c0b25bd2957cbf377c72\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:20:40 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head&gt;\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /dump.gtl/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98108\"
+        pluginName=\"Cross-Site Scripting (XSS) in event tag of HTML element\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  an HTML event
+        attribute. For example `&lt;div onmouseover=\"x=INJECTION_HERE\"&lt;/div>`,\n
+        \ where `INJECTION_HERE` represents the location where the scanner payload
+        was detected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in event tag of HTML element</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/412569245047960484377262321708701598236/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   :  script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n\n\n\nProof\n-------\n_refreshsnippets(\"412569245047960484377262321708701598236\",
+        \"cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\")\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/snippets.gtl?uid=cheddar%20script%3A%3Btenable_wasscan_xss_in_element_event%3D36b4c4a8-603d-435a-8d44-9ec90d4b9777%2F%2F
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        4d3d6717a3eae24bbf45c1a4e3058ab5\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:23:15 GMT\n | Server: Google Frontend\n | Content-Length: 1066\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/412569245047960484377262321708701598236/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n
+        \ \n\n\n&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"412569245047960484377262321708701598236\",
+        \"cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\")'\n
+        \ href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div class='content'>\n\n\n  \n    cheddar
+        script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n
+        \   is not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98063\"
+        pluginName=\"Cookie Without HttpOnly Flag Detected\" pluginFamily=\"Web Applications\"><description>The
+        HttpOnly flag assists in the prevention of client side-scripts (such as\n
+        \ JavaScript) from accessing and using the cookie.\n\n  This can help prevent
+        XSS attacks from targeting the cookies holding the client's\n  session token
+        (setting the HttpOnly flag does not prevent, nor safeguard against\n  XSS
+        vulnerabilities themselves).</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cookie
+        Without HttpOnly Flag Detected</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/HttpOnly</see_also><solution>The
+        initial step to remedy this would be to determine whether any client-side
+        \  scripts (such as JavaScript) need to access the cookie and if not, set
+        the   HttpOnly flag.\n  It should be noted that some older browsers are not
+        compatible with   the HttpOnly flag; therefore, setting this flag will not
+        protect those clients   against this form of attack.</solution><xref>owasp:2017-A3</xref><xref>owasp:2010-A9</xref><xref>owasp:2017-A2</xref><xref>cwe:1004</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>owasp:2010-A3</xref><plugin_output>http://google-gruyere.appspot.com/start
+        returned a cookie named 'GRUYERE_ID' that does not set the HttpOnly flag.</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\"
+        pluginName=\"Error Message\" pluginFamily=\"Data Exposure\"><description>An
+        error or warning message has been found on the remote web server. It may be
+        possible for an attacker to view sensitive information and conduct further
+        attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On http://google-gruyere.appspot.com/
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;B>WARNING:&lt;/B> Accessing or attacking a computer system
+        without authorization is illegal in many jurisdictions. While doing this codelab</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98083\"
+        pluginName=\"CAPTCHA Detection\" pluginFamily=\"Web Applications\"><description>Detects
+        any known CAPTCHA products being used on a page.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>CAPTCHA
+        Detection</plugin_name><risk_factor>Informational</risk_factor><plugin_output>A
+        Recaptcha CAPTCHA has been detected on http://google-gruyere.appspot.com/resetbutton/412569245047960484377262321708701598236
+        due to tag  &lt;div class=\"g-recaptcha\" data-sitekey=\"6LfKTycUAAAAAOLes3JooIZ0gi8BNy81n_mY3fdD\"></plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98108\"
+        pluginName=\"Cross-Site Scripting (XSS) in event tag of HTML element\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  an HTML event
+        attribute. For example `&lt;div onmouseover=\"x=INJECTION_HERE\"&lt;/div>`,\n
+        \ where `INJECTION_HERE` represents the location where the scanner payload
+        was detected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in event tag of HTML element</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   :  script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n\n\n\nProof\n-------\n_refreshsnippets(\"531899522745731123167764836993191970177\",
+        \"cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\")\n\n\nRequest\n---------\n\nGET
+        /531899522745731123167764836993191970177/snippets.gtl?uid=cheddar%20script%3A%3Btenable_wasscan_xss_in_element_event%3D36b4c4a8-603d-435a-8d44-9ec90d4b9777%2F%2F
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        b108b5202b55cc50b3665607494c2078\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 04:48:11 GMT\n | Server: Google Frontend\n | Content-Length: 1066\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/531899522745731123167764836993191970177/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/531899522745731123167764836993191970177/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/531899522745731123167764836993191970177/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/531899522745731123167764836993191970177/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n
+        \ \n\n\n&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"531899522745731123167764836993191970177\",
+        \"cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\")'\n
+        \ href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div class='content'>\n\n\n  \n    cheddar
+        script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n
+        \   is not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177/\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /531899522745731123167764836993191970177//%3E%22'%3E%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        fffc9eb9af42d185438126ec4c03ef23\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 04:48:21 GMT\n | Server: Google Frontend\n | Content-Length: 907\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/531899522745731123167764836993191970177/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/531899522745731123167764836993191970177/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/531899522745731123167764836993191970177/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: //>\"'>&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98526\"
+        pluginName=\"Missing Feature Policy\" pluginFamily=\"HTTP Security Header\"><description>Feature
+        Policy provides mechanisms to websites to restrict the use of browser features
+        in its own frame and in iframes that it embeds.\n\nNo Feature Policy header
+        has been detected.</description><plugin_publication_date>2019/03/27</plugin_publication_date><plugin_modification_date>2019/03/27</plugin_modification_date><plugin_name>Missing
+        Feature Policy</plugin_name><risk_factor>Informational</risk_factor><see_also>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy</see_also><solution>Configure
+        Feature Policy on your website by adding 'Feature-Policy' HTTP header.</solution><plugin_output>No
+        Feature-Policy headers were found on http://google-gruyere.appspot.com/652479776707981538544840512166060390157/</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"112527\"
+        pluginName=\"Disabled 'X-XSS-Protection' Header\" pluginFamily=\"HTTP Security
+        Header\"><description>The HTTP 'X-XSS-Protection' response header is a feature
+        of modern browsers that allows websites to control their XSS auditors.\n\nThe
+        server did not return a correct 'X-XSS-Protection' header, which means that
+        this website could be at risk of a Cross-Site Scripting (XSS) attack.</description><plugin_publication_date>2018/11/27</plugin_publication_date><plugin_modification_date>2018/11/27</plugin_modification_date><plugin_name>Disabled
+        'X-XSS-Protection' Header</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#xxxsp</see_also><solution>Configure
+        your web server to include an 'X-XSS-Protection' header with a value of '1;
+        mode=block'.</solution><xref>owasp:2010-A6</xref><xref>wasc:Application Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>cwe:693</xref><xref>owasp:2017-A6</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/\n\n\nProof\n-------\nHTTP/1.1
+        200 OK\n\n\nRequest\n---------\n\nGET /652479776707981538544840512166060390157/
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        0399f435f593ffed93624f1095f9ccf1\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:33:03 GMT\n | Server: Google Frontend\n | Content-Length: 1226\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Home&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/652479776707981538544840512166060390157/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'>Gruyere:
+        Home&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button' onclick='_refreshHome(\"652479776707981538544840512166060390157\")'
+        href='#'>Refresh&lt;/a>&lt;/div>\n&lt;/div>\n&lt;div class='content'>\n&lt;table
+        width='100%'>\n\n  &lt;tr>&lt;td colspan='3'>&lt;b>Most recent snippets:&lt;/b>&lt;/td>&lt;/tr>\n\n\n\n\n\n\n
+        \ &lt;tr>\n    &lt;td>\n     \n    &lt;/td>\n    &lt;td>\n      &lt;b>&lt;span
+        style='color:blue'>Cheddar Mac&lt;/span>&lt;/b>\n    &lt;/td>\n    &lt;td
+        width='100%'>&lt;span id='cheddar'>Gruyere is the cheesiest application on
+        the web.&lt;/span>\n    &lt;br>\n          &lt;a href='/652479776707981538544840512166060390157/snippets.gtl?uid=cheddar'>All
+        snippets&lt;/a>&amp;nbsp;\n      &lt;a href='https://images.google.com/?q=cheddar+cheese'>Homepage&lt;/a>\n
+        \   &lt;br>\n    &lt;br>\n    &lt;/td>\n  &lt;/tr>\n\n\n\n  &lt;tr>\n    &lt;td>\n
+        \    \n    &lt;/td>\n    &lt;td>\n      &lt;b>&lt;span style='color:red; text-decoration:underline'>Brie&lt;/span>&lt;/b>\n
+        \   &lt;/td>\n    &lt;td width='100%'>&lt;span id='brie'>Brie is the queen
+        of the cheeses&lt;span style=color:red>!!!&lt;/span>&lt;/span>\n    &lt;br>\n
+        \         &lt;a href='/652479776707981538544840512166060390157/snippets.gtl?uid=brie'>All
+        snippets&lt;/a>&amp;nbsp;\n      &lt;a href='https://news.google.com/news/search?q=brie'>Homepage&lt;/a>\n
+        \   &lt;br>\n    &lt;br>\n    &lt;/td>\n  &lt;/tr>\n\n\n&lt;/table>\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98060\"
+        pluginName=\"Missing 'X-Frame-Options' Header\" pluginFamily=\"HTTP Security
+        Header\"><description>Clickjacking (User Interface redress attack, UI redress
+        attack, UI redressing)\n  is a malicious technique of tricking a Web user
+        into clicking on something different\n  from what the user perceives they
+        are clicking on, thus potentially revealing\n  confidential information or
+        taking control of their computer while clicking on\n  seemingly innocuous
+        web pages.\n\n  The server didn't return an `X-Frame-Options` header which
+        means that this website\n  could be at risk of a clickjacking attack.\n\n
+        \ The `X-Frame-Options` HTTP response header can be used to indicate whether
+        or not\n  a browser should be allowed to render a page inside a frame or iframe.
+        Sites can\n  use this to avoid clickjacking attacks, by ensuring that their
+        content is not\n  embedded into other sites.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Missing
+        'X-Frame-Options' Header</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Clickjacking</see_also><solution>Configure
+        your web server to include an `X-Frame-Options` header.</solution><xref>owasp:2010-A6</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>cwe:693</xref><xref>owasp:2017-A6</xref><plugin_output>Page
+        http://google-gruyere.appspot.com/652479776707981538544840512166060390157/
+        has no X-Frame-Option header defined</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98047\"
+        pluginName=\"Allowed HTTP Methods\" pluginFamily=\"Web Applications\"><description>There
+        are a number of HTTP methods that can be used on a webserver (`OPTIONS`, `HEAD`,
+        `GET`, `POST`, `PUT`, `DELETE` etc.). Each of these methods perform a different
+        function and each have an associated level of risk when their use is permitted
+        on the webserver.\n\nBy sending an HTTP OPTIONS request and a direct HTTP
+        request for each method, the scanner discovered the methods that are allowed
+        by the server.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Allowed
+        HTTP Methods</plugin_name><risk_factor>Informational</risk_factor><see_also>http://httpd.apache.org/docs/2.2/mod/core.html#limitexcept</see_also><solution>It
+        is recommended that a whitelisting approach be taken to explicitly permit
+        only the   HTTP methods required by the application and block all others.</solution><plugin_output>http://google-gruyere.appspot.com/652479776707981538544840512166060390157/
+        allows requests made using the following HTTP methods (See attachment for
+        more information):\n- GET\n-  POST\n- POST\n- PATCH\n- PROPFIND\n- PROPPATCH\n-
+        MKCOL\n- COPY\n- MOVE\n- LOCK\n- UNLOCK\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98618\"
+        pluginName=\"HTTP Header Information Disclosure\" pluginFamily=\"HTTP Security
+        Header\"><description>The HTTP headers sent by the remote web server disclose
+        information that can aid an attacker, such as the server version and technologies
+        used by the web server.</description><plugin_publication_date>2019/06/12</plugin_publication_date><plugin_modification_date>2019/06/12</plugin_modification_date><plugin_name>HTTP
+        Header Information Disclosure</plugin_name><risk_factor>Low</risk_factor><see_also>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers</see_also><solution>Modify
+        the HTTP headers of the web server to not disclose detailed information about
+        the underlying web server.</solution><xref>owasp:2010-A6</xref><xref>owasp:2013-A5</xref><xref>cwe:200</xref><xref>wasc:Information
+        Leakage</xref><xref>owasp:2017-A6</xref><plugin_output>The following header
+        information disclosures have been detected on http://google-gruyere.appspot.com/652479776707981538544840512166060390157/:\n\n-
+        Server: Google Frontend\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"112491\" pluginName=\"SSL/TLS
+        Certificate Information\" pluginFamily=\"SSL/TLS\"><description>This plugin
+        displays information about the X.509 certificate extracted from the HTTPS
+        connection.</description><plugin_publication_date>2018/10/03</plugin_publication_date><plugin_modification_date>2019/02/04</plugin_modification_date><plugin_name>SSL/TLS
+        Certificate Information</plugin_name><risk_factor>Informational</risk_factor><plugin_output>Certificate
+        1\n=============\n\nCertificate:\n    Data:\n        Version: 3 (0x2)\n        Serial
+        Number:\n            d4:d7:72:f3:cd:5f:48:10:03:00:00:00:00:66:53:72\n    Signature
+        Algorithm: sha256WithRSAEncryption\n        Issuer: C=US, O=Google Trust Services,
+        CN=GTS CA 1O1\n        Validity\n            Not Before: Dec  3 14:40:31 2019
+        GMT\n            Not After : Feb 25 14:40:31 2020 GMT\n        Subject: C=US,
+        ST=California, L=Mountain View, O=Google LLC, CN=*.appspot.com\n        Subject
+        Public Key Info:\n            Public Key Algorithm: rsaEncryption\n                Public-Key:
+        (2048 bit)\n                Modulus:\n                    00:99:a0:85:5d:4e:05:96:b6:a3:99:48:11:6b:a7:\n
+        \                   d2:35:6a:58:94:d3:e9:99:14:da:99:cc:0a:13:93:\n                    28:05:ce:53:84:2b:51:38:36:b5:e0:55:94:9c:1b:\n
+        \                   a0:be:19:0e:3c:27:bf:bb:d8:43:ab:77:0d:af:aa:\n                    88:e5:e0:69:4e:32:e9:ff:ea:2c:13:91:e9:b9:63:\n
+        \                   9a:d6:4d:6d:25:93:98:4c:84:9f:14:3e:19:de:89:\n                    f1:53:ed:11:fa:8a:f4:dc:20:84:7c:f9:87:eb:2c:\n
+        \                   ca:bc:69:6c:3c:13:b7:e1:15:b1:6d:8e:1b:6f:fc:\n                    b6:9e:a5:82:79:3b:69:5d:a7:09:8a:cb:f3:e2:ba:\n
+        \                   c1:8d:ef:14:11:3e:74:02:2c:75:46:a4:08:e7:04:\n                    3c:8a:73:8d:fc:b6:80:ad:ea:fd:45:09:2d:16:98:\n
+        \                   27:a6:10:e7:68:fb:0c:6f:92:86:b7:0a:85:7b:69:\n                    da:b0:ca:36:94:3b:dc:f0:4b:2b:bf:b7:ff:51:38:\n
+        \                   33:34:87:6c:fd:5e:9c:e9:15:e3:55:0f:23:9f:06:\n                    55:e0:6d:ae:a6:f6:98:52:f6:2c:f7:0c:eb:d9:6f:\n
+        \                   00:bf:db:a5:47:3b:f6:39:48:23:c2:5f:29:5f:a7:\n                    5e:6e:45:bf:61:63:ea:5d:ad:fc:b5:62:1b:d6:ee:\n
+        \                   bc:2f\n                Exponent: 65537 (0x10001)\n        X509v3
+        extensions:\n            X509v3 Key Usage: critical\n                Digital
+        Signature, Key Encipherment\n            X509v3 Extended Key Usage: \n                TLS
+        Web Server Authentication\n            X509v3 Basic Constraints: critical\n
+        \               CA:FALSE\n            X509v3 Subject Key Identifier: \n                77:2F:FC:70:8C:E5:E2:FB:90:70:00:E9:10:04:6D:EB:5D:EE:24:3C\n
+        \           X509v3 Authority Key Identifier: \n                keyid:98:D1:F8:6E:10:EB:CF:9B:EC:60:9F:18:90:1B:A0:EB:7D:09:FD:2B\n\n
+        \           Authority Information Access: \n                OCSP - URI:http://ocsp.pki.goog/gts1o1\n
+        \               CA Issuers - URI:http://pki.goog/gsr2/GTS1O1.crt\n\n            X509v3
+        Subject Alternative Name: \n                DNS:*.appspot.com, DNS:*.an.r.appspot.com,
+        DNS:*.app.google, DNS:*.df.r.appspot.com, DNS:*.dt.r.appspot.com, DNS:*.el.r.appspot.com,
+        DNS:*.ew.r.appspot.com, DNS:*.ey.r.appspot.com, DNS:*.nn.r.appspot.com, DNS:*.nw.r.appspot.com,
+        DNS:*.oa.r.appspot.com, DNS:*.rj.r.appspot.com, DNS:*.thinkwithgoogle.com,
+        DNS:*.ts.r.appspot.com, DNS:*.uc.r.appspot.com, DNS:*.ue.r.appspot.com, DNS:*.uk.r.appspot.com,
+        DNS:*.withgoogle.com, DNS:*.withyoutube.com, DNS:*.wl.r.appspot.com, DNS:app.google,
+        DNS:appspot.com, DNS:thinkwithgoogle.com, DNS:withgoogle.com, DNS:withyoutube.com\n
+        \           X509v3 Certificate Policies: \n                Policy: 2.23.140.1.2.2\n
+        \               Policy: 1.3.6.1.4.1.11129.2.5.3\n\n            X509v3 CRL
+        Distribution Points: \n\n                Full Name:\n                  URI:http://crl.pki.goog/GTS1O1.crl\n\n
+        \           CT Precertificate SCTs: \n                Signed Certificate Timestamp:\n
+        \                   Version   : v1(0)\n                    Log ID    : B2:1E:05:CC:8B:A2:CD:8A:20:4E:87:66:F9:2B:B9:8A:\n
+        \                               25:20:67:6B:DA:FA:70:E7:B2:49:53:2D:EF:8B:90:5E\n
+        \                   Timestamp : Dec  3 15:40:35.712 2019 GMT\n                    Extensions:
+        none\n                    Signature : ecdsa-with-SHA256\n                                30:45:02:20:1A:D3:4F:11:40:33:B6:6D:AA:92:AB:E5:\n
+        \                               E9:07:A1:AE:43:8A:EA:63:81:DA:2F:1C:BC:16:68:3F:\n
+        \                               E2:0D:A0:9D:02:21:00:EF:58:21:F8:38:A4:0A:39:A4:\n
+        \                               A8:D1:C9:1F:C7:1C:92:A5:37:F0:39:2B:CF:4C:6E:01:\n
+        \                               C1:12:60:FA:F3:3C:84\n                Signed
+        Certificate Timestamp:\n                    Version   : v1(0)\n                    Log
+        ID    : 5E:A7:73:F9:DF:56:C0:E7:B5:36:48:7D:D0:49:E0:32:\n                                7A:91:9A:0C:84:A1:12:12:84:18:75:96:81:71:45:58\n
+        \                   Timestamp : Dec  3 15:40:35.910 2019 GMT\n                    Extensions:
+        none\n                    Signature : ecdsa-with-SHA256\n                                30:46:02:21:00:C4:DE:7E:1D:EA:BC:94:DA:DA:C2:8C:\n
+        \                               2F:EB:FC:40:3D:39:65:A9:8F:E6:4E:BD:AE:91:E9:F8:\n
+        \                               0A:0C:AB:C0:FB:02:21:00:8E:BB:26:A3:D1:0B:1B:B6:\n
+        \                               96:CF:22:E2:5B:6F:08:8E:E6:03:52:B7:DD:37:6D:4E:\n
+        \                               15:2B:78:BD:CB:B9:36:49\n    Signature Algorithm:
+        sha256WithRSAEncryption\n         25:cc:ca:db:09:86:61:3a:2a:84:6a:50:e5:a9:f1:8d:0d:0e:\n
+        \        5b:09:d0:39:b1:43:b7:bb:c5:27:74:c2:80:a0:e2:24:da:44:\n         75:ae:d2:96:bb:c1:84:63:ea:bf:15:5a:37:cb:00:53:5b:66:\n
+        \        75:e4:6d:e8:76:b7:a4:31:94:1b:90:be:e8:a0:fd:e8:8b:1d:\n         e8:ae:c8:ce:4c:50:4b:a0:6e:0e:24:a0:6e:7d:71:52:30:38:\n
+        \        56:63:7b:7e:7b:e5:be:72:63:26:d9:9f:e5:4d:0b:dc:d0:5c:\n         9f:e6:8f:6f:56:3e:1e:73:cb:2d:47:5b:57:58:0e:e7:ef:a4:\n
+        \        d6:10:7a:6d:49:5d:d1:d3:1a:3c:76:d3:a5:74:9d:64:a0:cd:\n         88:f7:80:3e:18:fa:aa:0c:aa:05:d0:d3:b6:fd:7b:89:96:5b:\n
+        \        dc:81:f0:fe:af:dc:1a:ea:da:a0:c8:71:50:0c:7b:d2:21:52:\n         21:2e:33:cc:30:47:78:42:9a:cd:49:99:44:a0:7a:f0:0f:88:\n
+        \        cb:34:49:18:4c:22:b1:c5:19:bf:53:f6:be:15:59:80:6c:ec:\n         6a:72:e1:ce:25:a6:d9:5c:20:a1:49:9f:57:7b:66:64:a4:97:\n
+        \        32:fc:44:7e:98:84:8d:06:31:43:03:87:6c:58:de:79:e3:b1:\n         13:02:29:1d\n\nCertificate
+        2\n=============\n\nCertificate:\n    Data:\n        Version: 3 (0x2)\n        Serial
+        Number:\n            01:e3:b4:9a:a1:8d:8a:a9:81:25:69:50:b8\n    Signature
+        Algorithm: sha256WithRSAEncryption\n        Issuer: OU=GlobalSign Root CA
+        - R2, O=GlobalSign, CN=GlobalSign\n        Validity\n            Not Before:
+        Jun 15 00:00:42 2017 GMT\n            Not After : Dec 15 00:00:42 2021 GMT\n
+        \       Subject: C=US, O=Google Trust Services, CN=GTS CA 1O1\n        Subject
+        Public Key Info:\n            Public Key Algorithm: rsaEncryption\n                Public-Key:
+        (2048 bit)\n                Modulus:\n                    00:d0:18:cf:45:d4:8b:cd:d3:9c:e4:40:ef:7e:b4:\n
+        \                   dd:69:21:1b:c9:cf:3c:8e:4c:75:b9:0f:31:19:84:\n                    3d:9e:3c:29:ef:50:0d:10:93:6f:05:80:80:9f:2a:\n
+        \                   a0:bd:12:4b:02:e1:3d:9f:58:16:24:fe:30:9f:0b:\n                    74:77:55:93:1d:4b:f7:4d:e1:92:82:10:f6:51:ac:\n
+        \                   0c:c3:b2:22:94:0f:34:6b:98:10:49:e7:0b:9d:83:\n                    39:dd:20:c6:1c:2d:ef:d1:18:61:65:e7:23:83:20:\n
+        \                   a8:23:12:ff:d2:24:7f:d4:2f:e7:44:6a:5b:4d:d7:\n                    50:66:b0:af:9e:42:63:05:fb:e0:1c:c4:63:61:af:\n
+        \                   9f:6a:33:ff:62:97:bd:48:d9:d3:7c:14:67:dc:75:\n                    dc:2e:69:e8:f8:6d:78:69:d0:b7:10:05:b8:f1:31:\n
+        \                   c2:3b:24:fd:1a:33:74:f8:23:e0:ec:6b:19:8a:16:\n                    c6:e3:cd:a4:cd:0b:db:b3:a4:59:60:38:88:3b:ad:\n
+        \                   1d:b9:c6:8c:a7:53:1b:fc:bc:d9:a4:ab:bc:dd:3c:\n                    61:d7:93:15:98:ee:81:bd:8f:e2:64:47:20:40:06:\n
+        \                   4e:d7:ac:97:e8:b9:c0:59:12:a1:49:25:23:e4:ed:\n                    70:34:2c:a5:b4:63:7c:f9:a3:3d:83:d1:cd:6d:24:\n
+        \                   ac:07\n                Exponent: 65537 (0x10001)\n        X509v3
+        extensions:\n            X509v3 Key Usage: critical\n                Digital
+        Signature, Certificate Sign, CRL Sign\n            X509v3 Extended Key Usage:
+        \n                TLS Web Server Authentication, TLS Web Client Authentication\n
+        \           X509v3 Basic Constraints: critical\n                CA:TRUE, pathlen:0\n
+        \           X509v3 Subject Key Identifier: \n                98:D1:F8:6E:10:EB:CF:9B:EC:60:9F:18:90:1B:A0:EB:7D:09:FD:2B\n
+        \           X509v3 Authority Key Identifier: \n                keyid:9B:E2:07:57:67:1C:1E:C0:6A:06:DE:59:B4:9A:2D:DF:DC:19:86:2E\n\n
+        \           Authority Information Access: \n                OCSP - URI:http://ocsp.pki.goog/gsr2\n\n
+        \           X509v3 CRL Distribution Points: \n\n                Full Name:\n
+        \                 URI:http://crl.pki.goog/gsr2/gsr2.crl\n\n            X509v3
+        Certificate Policies: \n                Policy: 2.23.140.1.2.2\n                  CPS:
+        https://pki.goog/repository/\n\n    Signature Algorithm: sha256WithRSAEncryption\n
+        \        1a:80:3e:36:79:fb:f3:2e:a9:46:37:7d:5e:54:16:35:ae:c7:\n         4e:08:99:fe:bd:d1:34:69:26:52:66:07:3d:0a:ba:49:cb:62:\n
+        \        f4:f1:1a:8e:fc:11:4f:68:96:4c:74:2b:d3:67:de:b2:a3:aa:\n         05:8d:84:4d:4c:20:65:0f:a5:96:da:0d:16:f8:6c:3b:db:6f:\n
+        \        04:23:88:6b:3a:6c:c1:60:bd:68:9f:71:8e:ee:2d:58:34:07:\n         f0:d5:54:e9:86:59:fd:7b:5e:0d:21:94:f5:8c:c9:a8:f8:d8:\n
+        \        f2:ad:cc:0f:1a:f3:9a:a7:a9:04:27:f9:a3:c9:b0:ff:02:78:\n         6b:61:ba:c7:35:2b:e8:56:fa:4f:c3:1c:0c:ed:b6:3c:b4:4b:\n
+        \        ea:ed:cc:e1:3c:ec:dc:0d:8c:d6:3e:9b:ca:42:58:8b:cc:16:\n         21:17:40:bc:a2:d6:66:ef:da:c4:15:5b:cd:89:aa:9b:09:26:\n
+        \        e7:32:d2:0d:6e:67:20:02:5b:10:b0:90:09:9c:0c:1f:9e:ad:\n         d8:3b:ea:a1:fc:6c:e8:10:5c:08:52:19:51:2a:71:bb:ac:7a:\n
+        \        b5:dd:15:ed:2b:c9:08:2a:2c:8a:b4:a6:21:ab:63:ff:d7:52:\n         49:50:d0:89:b7:ad:f2:af:fb:50:ae:2f:e1:95:0d:f3:46:ad:\n
+        \        9d:9c:f5:ca\n\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98705\" pluginName=\"Robots.txt
+        File Detected\" pluginFamily=\"Web Servers\"><description>The remote host
+        contains a file named 'robots.txt' that is intended to prevent web 'robots'
+        from visiting certain directories in a website for maintenance or indexing
+        purposes. A malicious user may also be able to use the contents of this file
+        to learn of sensitive documents or directories on the affected site and either
+        retrieve them directly or target them for other attacks.</description><plugin_publication_date>2019/09/19</plugin_publication_date><plugin_modification_date>2019/09/19</plugin_modification_date><plugin_name>Robots.txt
+        File Detected</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.robotstxt.org</see_also><solution>Review
+        the contents of the site's robots.txt file, use Robots META tags instead of
+        entries in the robots.txt file, and/or adjust the web server's access controls
+        to limit access to sensitive material.</solution><plugin_output>A robots.txt
+        file was detected at http://google-gruyere.appspot.com/robots.txt containing
+        the following entries.\nhttp://google-gruyere.appspot.com/0\nhttp://google-gruyere.appspot.com/1\nhttp://google-gruyere.appspot.com/2\nhttp://google-gruyere.appspot.com/3\nhttp://google-gruyere.appspot.com/4\nhttp://google-gruyere.appspot.com/5\nhttp://google-gruyere.appspot.com/6\nhttp://google-gruyere.appspot.com/7\nhttp://google-gruyere.appspot.com/8\nhttp://google-gruyere.appspot.com/9\nhttp://google-gruyere.appspot.com/start\nhttp://google-gruyere.appspot.com/resetbutton\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"112530\"
+        pluginName=\"SSL/TLS Versions Supported\" pluginFamily=\"SSL/TLS\"><description>This
+        plugin displays information about the SSL/TLS versions supported by remote
+        server for HTTPS connection.</description><plugin_publication_date>2018/10/03</plugin_publication_date><plugin_modification_date>2018/10/03</plugin_modification_date><plugin_name>SSL/TLS
+        Versions Supported</plugin_name><risk_factor>Informational</risk_factor><plugin_output>\n
+        \   Protocol   Supported\n    ---------------------\n    SSLv2      No\n    SSLv3
+        \     No\n    TLS 1.0    Yes\n    TLS 1.1    Yes\n    TLS 1.2    Yes</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"2\" pluginID=\"112496\"
+        pluginName=\"TLS 1.0 Weak Protocol\" pluginFamily=\"SSL/TLS\"><description>The
+        remote server offers deprecated TLS 1.0 protocol which can lead to weaknesses.</description><plugin_publication_date>2018/10/03</plugin_publication_date><plugin_modification_date>2019/02/13</plugin_modification_date><plugin_name>TLS
+        1.0 Weak Protocol</plugin_name><risk_factor>Medium</risk_factor><see_also>https://webkit.org/blog/8462/deprecation-of-legacy-tls-1-0-and-1-1-versions/</see_also><solution>Reconfigure
+        the affected application, if possible to avoid the use of deprecated TLS 1.0
+        protocol.</solution><xref>owasp:2010-A9</xref><xref>owasp:2017-A3</xref><xref>cwe:327</xref><xref>owasp:2013-A6</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><plugin_output>\n    Protocol   Supported\n
+        \   ---------------------\n    TLS 1.0    Yes</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"112546\"
+        pluginName=\"TLS 1.1 Deprecated Protocol\" pluginFamily=\"SSL/TLS\"><description>The
+        remote server offers deprecated TLS 1.1 protocol.</description><plugin_publication_date>2018/02/13</plugin_publication_date><plugin_modification_date>2019/02/13</plugin_modification_date><plugin_name>TLS
+        1.1 Deprecated Protocol</plugin_name><risk_factor>Informational</risk_factor><see_also>https://webkit.org/blog/8462/deprecation-of-legacy-tls-1-0-and-1-1-versions/</see_also><solution>Reconfigure
+        the affected application, if possible to avoid the use of deprecated TLS 1.1
+        protocol versions and enable TLS 1.2 or later.</solution><plugin_output>\n
+        \   Protocol   Supported\n    ---------------------\n    TLS 1.1    Yes</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98081\"
+        pluginName=\"Password field with auto-complete\" pluginFamily=\"Authentication
+        &amp; Session\"><description>In typical form-based web applications, it is
+        common practice for developers to\n  allow `autocomplete` within the HTML
+        form to improve the usability of the page.\n  With `autocomplete` enabled
+        (default), the browser is allowed to cache previously\n  entered form values.\n\n
+        \ For legitimate purposes, this allows the user to quickly re-enter the same
+        data\n  when completing the form multiple times.\n\n  When `autocomplete`
+        is enabled on either/both the username and password fields,\n  this could
+        allow a cyber-criminal with access to the victim's computer the ability\n
+        \ to have the victim's credentials automatically entered as the cyber-criminal\n
+        \ visits the affected page.\n\n  Scanner has discovered that the affected
+        page contains a form containing a\n  password field that has not disabled
+        `autocomplete`.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Password
+        field with auto-complete</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)</see_also><solution>The
+        `autocomplete` value can be configured in two different locations.\n  The
+        first and most secure location is to disable the `autocomplete` attribute
+        on   the `&lt;form>` HTML tag. This will disable `autocomplete` for all inputs
+        within that form.   An example of disabling `autocomplete` within the form
+        tag is `&lt;form autocomplete=off>`.\n  The second slightly less desirable
+        option is to disable the `autocomplete` attribute   for a specific `&lt;input>`
+        HTML tag.   While this may be the less desired solution from a security perspective,
+        it may   be preferred method for usability reasons, depending on size of the
+        form.   An example of disabling the `autocomplete` attribute within a password
+        input tag   is `&lt;input type=password autocomplete=off>`.</solution><xref>owasp:2010-A6</xref><xref>cwe:16</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        following form has been found to have not restricted Password Auto Complete:\n\n&lt;form
+        method=\"get\" action=\"/652479776707981538544840512166060390157/saveprofile\">\n
+        \ &lt;input type=\"hidden\" name=\"action\" value=\"new\">\n  &lt;/input>\n
+        \ &lt;input type=\"text\" name=\"uid\" value=\"\" maxlength=\"16\">\n  &lt;/input>\n
+        \ &lt;input type=\"password\" name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"hidden\"
+        name=\"is_author\" value=\"True\">\n  &lt;/input>\n  &lt;input type=\"submit\"
+        value=\"Create account\">\n  &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\"
+        pluginName=\"Error Message\" pluginFamily=\"Data Exposure\"><description>An
+        error or warning message has been found on the remote web server. It may be
+        possible for an attacker to view sensitive information and conduct further
+        attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On http://google-gruyere.appspot.com/start
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;b>WARNING: Gruyere is not secure.</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98105\"
+        pluginName=\"Cross-Site Scripting (XSS) in HTML tag\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert content directly into an HTML\n  tag. For example
+        `&lt;INJECTION_HERE href=.......etc>` where `INJECTION_HERE`\n  represents
+        the location where the scanner payload was detected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in HTML tag</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : ' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n\n\n\nProof\n-------\n' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n\n\nRequest\n---------\n\nGET /531899522745731123167764836993191970177/snippets.gtl?uid=cheddar%27%20tenable_wasscan_xss_in_tag%3D%2736b4c4a8-603d-435a-8d44-9ec90d4b9777%27%20blah%3D%27
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        e7cad51cd986affbec737490ed6757e0\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 04:48:58 GMT\n | Server: Google Frontend\n | Content-Length: 1061\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/531899522745731123167764836993191970177/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/531899522745731123167764836993191970177/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/531899522745731123167764836993191970177/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/531899522745731123167764836993191970177/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n  \n\n\n&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"531899522745731123167764836993191970177\",
+        \"cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\")'\n  href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div class='content'>\n\n\n
+        \ \n    cheddar' tenable_wasscan_xss_in_tag='36b4c4a8-603d-435a-8d44-9ec90d4b9777'
+        blah='\n    is not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\"
+        pluginName=\"Error Message\" pluginFamily=\"Data Exposure\"><description>An
+        error or warning message has been found on the remote web server. It may be
+        possible for an attacker to view sensitive information and conduct further
+        attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On https://google-gruyere.appspot.com/
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;B>WARNING:&lt;/B> Accessing or attacking a computer system
+        without authorization is illegal in many jurisdictions. While doing this codelab</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/%3E%3C\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/%3E%3C/%3E%22'%3E%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        56363431e8d3b19e35e7b31743455084\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:24:54 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: />&lt;/>\"'>&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98136\"
+        pluginName=\"Target Information\" pluginFamily=\"General\"><description>Publishes
+        the target information of the starting url as evaluated by the scan.</description><plugin_publication_date>2017/07/27</plugin_publication_date><plugin_modification_date>2017/07/27</plugin_modification_date><plugin_name>Target
+        Information</plugin_name><risk_factor>Informational</risk_factor><plugin_output>FQDN
+        'google-gruyere.appspot.com' resolves as 172.217.25.52</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98003\"
+        pluginName=\"OS Detection\" pluginFamily=\"General\"><description>This is
+        an informational notice that by investigating the response headers from the
+        remote host,\n  it is possible to guess the name of the remote operating system
+        in use.\n  It is also possible sometimes to guess the version of the operating
+        system.</description><plugin_publication_date>2018/03/01</plugin_publication_date><plugin_modification_date>2018/03/01</plugin_modification_date><plugin_name>OS
+        Detection</plugin_name><risk_factor>Informational</risk_factor><plugin_output>Operating
+        system has been guessed as '' from http://google-gruyere.appspot.com/652479776707981538544840512166060390157/
+        response contents.</plugin_output></ReportItem><ReportItem port=\"80\" svc_name=\"http\"
+        protocol=\"TCP\" severity=\"1\" pluginID=\"112551\" pluginName=\"Missing Content
+        Security Policy\" pluginFamily=\"HTTP Security Header\"><description>Content
+        Security Policy (CSP) is a web security standard that helps to mitigate attacks
+        like cross-site scripting (XSS), clickjacking or mixed content issues.\nCSP
+        provides mechanisms to websites to restrict content that browsers will be
+        allowed to load.\n\nNo CSP header has been detected on this host. This URL
+        is flagged as an specific example.</description><plugin_publication_date>2019/02/14</plugin_publication_date><plugin_modification_date>2019/02/14</plugin_modification_date><plugin_name>Missing
+        Content Security Policy</plugin_name><risk_factor>Low</risk_factor><see_also>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy</see_also><solution>Configure
+        Content Security Policy on your website by adding 'Content-Security-Policy'
+        HTTP header or meta tag http-equiv='Content-Security-Policy'.</solution><xref>owasp:2010-A6</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>cwe:693</xref><xref>owasp:2017-A6</xref><plugin_output>http://google-gruyere.appspot.com/652479776707981538544840512166060390157/</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98050\"
+        pluginName=\"Interesting response\" pluginFamily=\"Web Applications\"><description>The
+        scanner identified some responses with a status code other than the usual
+        200 (OK), 301 (Moved Permanently), 302 (Found) and 404 (Not Found) codes.\n
+        \ These codes can provide useful insights into the behavior of the web application
+        and identify any unexpected responses to be addressed.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2018/05/09</plugin_modification_date><plugin_name>Interesting
+        response</plugin_name><risk_factor>Informational</risk_factor><see_also>http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html</see_also><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/tenable-wasscan-36b4c4a8-603d-435a-8d44-9ec90d4b9777\n\n\nProof\n-------\nHTTP/1.1
+        405 Method Not Allowed\n\n\nRequest\n---------\n\nPUT /652479776707981538544840512166060390157/tenable-wasscan-36b4c4a8-603d-435a-8d44-9ec90d4b9777
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Content-Length: 68\n | \n | Created
+        by Tenable WAS scan. PUT36b4c4a8-603d-435a-8d44-9ec90d4b9777\n\nResponse\n----------\n\nHTTP/1.1
+        405 Method Not Allowed\n | Allow: GET, POST\n | Content-Type: text/html; charset=UTF-8\n
+        | Content-Encoding: gzip\n | X-Cloud-Trace-Context: 856d8c7784418aa5f80e6dca14dbae1d\n
+        | Vary: Accept-Encoding\n | Date: Tue, 07 Jan 2020 03:33:35 GMT\n | Server:
+        Google Frontend\n | Cache-Control: private\n | Content-Length: 141\n | \n
+        | &lt;html>\n &lt;head>\n  &lt;title>405 Method Not Allowed&lt;/title>\n &lt;/head>\n
+        &lt;body>\n  &lt;h1>405 Method Not Allowed&lt;/h1>\n  The method PUT is not
+        allowed for this resource. &lt;br />&lt;br />\n\n &lt;/body>\n&lt;/html></plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98108\"
+        pluginName=\"Cross-Site Scripting (XSS) in event tag of HTML element\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  an HTML event
+        attribute. For example `&lt;div onmouseover=\"x=INJECTION_HERE\"&lt;/div>`,\n
+        \ where `INJECTION_HERE` represents the location where the scanner payload
+        was detected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in event tag of HTML element</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   :  script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n\n\n\nProof\n-------\n_refreshsnippets(\"652479776707981538544840512166060390157\",
+        \"cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\")\n\n\nRequest\n---------\n\nGET
+        /652479776707981538544840512166060390157/snippets.gtl?uid=cheddar%20script%3A%3Btenable_wasscan_xss_in_element_event%3D36b4c4a8-603d-435a-8d44-9ec90d4b9777%2F%2F
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        5c75998dd48cbc5c1acd225155cc334d\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:34:42 GMT\n | Server: Google Frontend\n | Content-Length: 1064\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/652479776707981538544840512166060390157/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n
+        \ \n\n\n&lt;/h2>\n&lt;div class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"652479776707981538544840512166060390157\",
+        \"cheddar script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\")'\n
+        \ href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div class='content'>\n\n\n  \n    cheddar
+        script:;tenable_wasscan_xss_in_element_event=36b4c4a8-603d-435a-8d44-9ec90d4b9777//\n
+        \   is not an author.\n  \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98081\"
+        pluginName=\"Password field with auto-complete\" pluginFamily=\"Authentication
+        &amp; Session\"><description>In typical form-based web applications, it is
+        common practice for developers to\n  allow `autocomplete` within the HTML
+        form to improve the usability of the page.\n  With `autocomplete` enabled
+        (default), the browser is allowed to cache previously\n  entered form values.\n\n
+        \ For legitimate purposes, this allows the user to quickly re-enter the same
+        data\n  when completing the form multiple times.\n\n  When `autocomplete`
+        is enabled on either/both the username and password fields,\n  this could
+        allow a cyber-criminal with access to the victim's computer the ability\n
+        \ to have the victim's credentials automatically entered as the cyber-criminal\n
+        \ visits the affected page.\n\n  Scanner has discovered that the affected
+        page contains a form containing a\n  password field that has not disabled
+        `autocomplete`.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Password
+        field with auto-complete</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)</see_also><solution>The
+        `autocomplete` value can be configured in two different locations.\n  The
+        first and most secure location is to disable the `autocomplete` attribute
+        on   the `&lt;form>` HTML tag. This will disable `autocomplete` for all inputs
+        within that form.   An example of disabling `autocomplete` within the form
+        tag is `&lt;form autocomplete=off>`.\n  The second slightly less desirable
+        option is to disable the `autocomplete` attribute   for a specific `&lt;input>`
+        HTML tag.   While this may be the less desired solution from a security perspective,
+        it may   be preferred method for usability reasons, depending on size of the
+        form.   An example of disabling the `autocomplete` attribute within a password
+        input tag   is `&lt;input type=password autocomplete=off>`.</solution><xref>owasp:2010-A6</xref><xref>cwe:16</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        following form has been found to have not restricted Password Auto Complete:\n\n&lt;form
+        method=\"get\" action=\"/412569245047960484377262321708701598236/saveprofile\">\n
+        \ &lt;input type=\"hidden\" name=\"action\" value=\"new\">\n  &lt;/input>\n
+        \ &lt;input type=\"text\" name=\"uid\" value=\"\" maxlength=\"16\">\n  &lt;/input>\n
+        \ &lt;input type=\"password\" name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"hidden\"
+        name=\"is_author\" value=\"True\">\n  &lt;/input>\n  &lt;input type=\"submit\"
+        value=\"Create account\">\n  &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"2\" pluginID=\"98082\"
+        pluginName=\"Unencrypted password form\" pluginFamily=\"Authentication &amp;
+        Session\"><description>The HTTP protocol by itself is clear text, meaning
+        that any data that is\n  transmitted via HTTP can be captured and the contents
+        viewed.\n\n  To keep data private, and prevent it from being intercepted,
+        HTTP is often\n  tunnelled through either Secure Sockets Layer (SSL), or Transport
+        Layer Security\n  (TLS).\n  When either of these encryption standards are
+        used it is referred to as HTTPS.\n\n  Cyber-criminals will often attempt to
+        compromise credentials passed from the\n  client to the server using HTTP.\n
+        \ This can be conducted via various different Man-in-The-Middle (MiTM) attacks
+        or\n  through network packet captures.\n\n  Scanner discovered that the affected
+        page contains a `password` input, however,\n  the value of the field is not
+        sent to the server utilising HTTPS. Therefore it\n  is possible that any submitted
+        credential may become compromised.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Unencrypted
+        password form</plugin_name><risk_factor>Medium</risk_factor><see_also>http://www.owasp.org/index.php/Top_10_2010-A9-Insufficient_Transport_Layer_Protection</see_also><solution>The
+        affected site should be secured utilising the latest and most secure encryption
+        \  protocols.   These include SSL version 3.0 and TLS version 1.2. While TLS
+        1.2 is the latest   and the most preferred protocol, not all browsers will
+        support this encryption   method. Therefore, the more common SSL is included.
+        Older protocols such as SSL   version 2, and weak ciphers (&lt; 128 bit) should
+        also be disabled.</solution><xref>owasp:2017-A3</xref><xref>owasp:2010-A9</xref><xref>cwe:319</xref><xref>owasp:2017-A2</xref><xref>cwe:523</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><xref>owasp:2010-A3</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/412569245047960484377262321708701598236/login\n\n\nProof\n-------\n&lt;form
+        method=\"get\" action=\"/412569245047960484377262321708701598236/login\">\n
+        \ &lt;input type=\"text\" name=\"uid\">\n  &lt;/input>\n  &lt;input type=\"password\"
+        name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"submit\" value=\"Login\">\n
+        \ &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98104\" pluginName=\"Cross-Site
+        Scripting (XSS)\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  HTML element content.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS)</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/feed.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : &lt;/textarea>-->&lt;xss_4904659/>&lt;!--&lt;textarea>\n\n\n\nProof\n-------\n&lt;xss_4904659/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/feed.gtl?uid=value%3C%2Ftextarea%3E--%3E%3Cxss_4904659%2F%3E%3C%21--%3Ctextarea%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        25c79c806e90ea92a1f322d4b9625f79\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:46:17 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | \n_feed((\n\n\n[\n\"value&lt;/textarea>-->&lt;xss_4904659/>&lt;!--&lt;textarea>\"\n\n]\n\n\n\n))\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98106\"
+        pluginName=\"Cross-Site Scripting (XSS) in script context\" pluginFamily=\"Cross
+        Site Scripting\"><description>Client-side scripts are used extensively by
+        modern web applications.\n  They perform from simple functions (such as the
+        formatting of text) up to full\n  manipulation of client-side data and Operating
+        System interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject
+        scripts into a request and\n  have the server return the script to the client
+        in the response. This occurs\n  because the application is taking untrusted
+        data (in this example, from the client)\n  and reusing it without performing
+        any validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to force the page to execute custom\n  JavaScript code.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in script context</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/deletesnippet\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : index\n\nInjected Payload   : &lt;/script>&lt;script>window.top._tenable_wasscan_js_namespace_taint_tracer.log_execution_flow_sink()&lt;/script>\n\n\n\nProof\n-------\n&lt;/script>&lt;script>window.top._tenable_wasscan_js_namespace_taint_tracer.log_execution_flow_sink()&lt;/script>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/RESET\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/RESET/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        2c50189f6bde6aa3f9cf8675755d4641\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:13:54 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /RESET/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98104\"
+        pluginName=\"Cross-Site Scripting (XSS)\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  HTML element content.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS)</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/412569245047960484377262321708701598236/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : &lt;xss_4199042/>\n\n\n\nProof\n-------\n&lt;xss_4199042/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/snippets.gtl?uid=cheddar%3Cxss_4199042%2F%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        95a919f340ce50261d19449c3b74f079\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:21:59 GMT\n | Server: Google Frontend\n | Content-Length: 1012\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/412569245047960484377262321708701598236/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar&lt;xss_4199042/>\n  \n\n\n&lt;/h2>\n&lt;div
+        class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"412569245047960484377262321708701598236\",
+        \"cheddar&lt;xss_4199042/>\")'\n  href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div
+        class='content'>\n\n\n  \n    cheddar&lt;xss_4199042/>\n    is not an author.\n
+        \ \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\"
+        pluginName=\"Error Message\" pluginFamily=\"Data Exposure\"><description>An
+        error or warning message has been found on the remote web server. It may be
+        possible for an attacker to view sensitive information and conduct further
+        attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On http://google-gruyere.appspot.com/531899522745731123167764836993191970177/newaccount.gtl
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;b>WARNING: Gruyere is not secure.</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\"
+        pluginName=\"Error Message\" pluginFamily=\"Data Exposure\"><description>An
+        error or warning message has been found on the remote web server. It may be
+        possible for an attacker to view sensitive information and conduct further
+        attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On https://google-gruyere.appspot.com/part1
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;B>WARNING:&lt;/B> Because Gruyere is very vulnerable</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98033\"
+        pluginName=\"Login Form Detected\" pluginFamily=\"Authentication &amp; Session\"><description>This
+        is an informational notice that the scanner identified a potential login form
+        that could be used by the scanner to authenticate and have access to additional
+        pages for extending its coverage.</description><plugin_publication_date>2018/02/08</plugin_publication_date><plugin_modification_date>2018/02/08</plugin_modification_date><plugin_name>Login
+        Form Detected</plugin_name><risk_factor>Informational</risk_factor><solution>Edit
+        scan policy and add login form authentication credentials to allow scanner
+        to authenticate to the web application.</solution><plugin_output>Potential
+        login form has been identified in URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/login'
+        with following fields:\n- uid (TEXT)\n- pw (PASSWORD)\nTo perform authenticated
+        scan, configure your scan and add 'Login Form' authentication, with the URL
+        associated to this plugin and as login parameters values for the above non-hidden
+        fields.</plugin_output></ReportItem><ReportItem port=\"80\" svc_name=\"http\"
+        protocol=\"TCP\" severity=\"1\" pluginID=\"98081\" pluginName=\"Password field
+        with auto-complete\" pluginFamily=\"Authentication &amp; Session\"><description>In
+        typical form-based web applications, it is common practice for developers
+        to\n  allow `autocomplete` within the HTML form to improve the usability of
+        the page.\n  With `autocomplete` enabled (default), the browser is allowed
+        to cache previously\n  entered form values.\n\n  For legitimate purposes,
+        this allows the user to quickly re-enter the same data\n  when completing
+        the form multiple times.\n\n  When `autocomplete` is enabled on either/both
+        the username and password fields,\n  this could allow a cyber-criminal with
+        access to the victim's computer the ability\n  to have the victim's credentials
+        automatically entered as the cyber-criminal\n  visits the affected page.\n\n
+        \ Scanner has discovered that the affected page contains a form containing
+        a\n  password field that has not disabled `autocomplete`.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Password
+        field with auto-complete</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/Testing_for_Vulnerable_Remember_Password_(OTG-AUTHN-005)</see_also><solution>The
+        `autocomplete` value can be configured in two different locations.\n  The
+        first and most secure location is to disable the `autocomplete` attribute
+        on   the `&lt;form>` HTML tag. This will disable `autocomplete` for all inputs
+        within that form.   An example of disabling `autocomplete` within the form
+        tag is `&lt;form autocomplete=off>`.\n  The second slightly less desirable
+        option is to disable the `autocomplete` attribute   for a specific `&lt;input>`
+        HTML tag.   While this may be the less desired solution from a security perspective,
+        it may   be preferred method for usability reasons, depending on size of the
+        form.   An example of disabling the `autocomplete` attribute within a password
+        input tag   is `&lt;input type=password autocomplete=off>`.</solution><xref>owasp:2010-A6</xref><xref>cwe:16</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>owasp:2017-A6</xref><plugin_output>The
+        following form has been found to have not restricted Password Auto Complete:\n\n&lt;form
+        method=\"get\" action=\"/652479776707981538544840512166060390157/login\">\n
+        \ &lt;input type=\"text\" name=\"uid\">\n  &lt;/input>\n  &lt;input type=\"password\"
+        name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"submit\" value=\"Login\">\n
+        \ &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"2\" pluginID=\"98082\" pluginName=\"Unencrypted
+        password form\" pluginFamily=\"Authentication &amp; Session\"><description>The
+        HTTP protocol by itself is clear text, meaning that any data that is\n  transmitted
+        via HTTP can be captured and the contents viewed.\n\n  To keep data private,
+        and prevent it from being intercepted, HTTP is often\n  tunnelled through
+        either Secure Sockets Layer (SSL), or Transport Layer Security\n  (TLS).\n
+        \ When either of these encryption standards are used it is referred to as
+        HTTPS.\n\n  Cyber-criminals will often attempt to compromise credentials passed
+        from the\n  client to the server using HTTP.\n  This can be conducted via
+        various different Man-in-The-Middle (MiTM) attacks or\n  through network packet
+        captures.\n\n  Scanner discovered that the affected page contains a `password`
+        input, however,\n  the value of the field is not sent to the server utilising
+        HTTPS. Therefore it\n  is possible that any submitted credential may become
+        compromised.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Unencrypted
+        password form</plugin_name><risk_factor>Medium</risk_factor><see_also>http://www.owasp.org/index.php/Top_10_2010-A9-Insufficient_Transport_Layer_Protection</see_also><solution>The
+        affected site should be secured utilising the latest and most secure encryption
+        \  protocols.   These include SSL version 3.0 and TLS version 1.2. While TLS
+        1.2 is the latest   and the most preferred protocol, not all browsers will
+        support this encryption   method. Therefore, the more common SSL is included.
+        Older protocols such as SSL   version 2, and weak ciphers (&lt; 128 bit) should
+        also be disabled.</solution><xref>owasp:2017-A3</xref><xref>owasp:2010-A9</xref><xref>cwe:319</xref><xref>owasp:2017-A2</xref><xref>cwe:523</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><xref>owasp:2010-A3</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/login\n\n\nProof\n-------\n&lt;form
+        method=\"get\" action=\"/652479776707981538544840512166060390157/login\">\n
+        \ &lt;input type=\"text\" name=\"uid\">\n  &lt;/input>\n  &lt;input type=\"password\"
+        name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"submit\" value=\"Login\">\n
+        \ &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\" pluginName=\"Cross-Site
+        Scripting (XSS) in path\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  the requested PATH and have it returned in the server's
+        response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`, where `INJECTION_HERE`\n
+        \ represents the location where the scanner payload was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/newaccount.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /652479776707981538544840512166060390157/newaccount.gtl/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        67bd36db14f3b6612d103622d06c9535\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:41:17 GMT\n | Server: Google Frontend\n | Content-Length: 904\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /newaccount.gtl/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"112526\"
+        pluginName=\"Missing 'X-XSS-Protection' Header\" pluginFamily=\"HTTP Security
+        Header\"><description>The HTTP 'X-XSS-Protection' response header is a feature
+        of modern browsers that allows websites to control their XSS auditors.\n\nThe
+        server is not configured to return a 'X-XSS-Protection' header which means
+        that any pages on this website could be at risk of a Cross-Site Scripting
+        (XSS) attack. This URL is flagged as an specific example.</description><plugin_publication_date>2018/11/27</plugin_publication_date><plugin_modification_date>2018/11/27</plugin_modification_date><plugin_name>Missing
+        'X-XSS-Protection' Header</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/OWASP_Secure_Headers_Project#xxxsp</see_also><solution>Configure
+        your web server to include an 'X-XSS-Protection' header with a value of '1;
+        mode=block' on all pages.</solution><xref>owasp:2010-A6</xref><xref>wasc:Application
+        Misconfiguration</xref><xref>owasp:2013-A5</xref><xref>cwe:693</xref><xref>owasp:2017-A6</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/0\n\n\nProof\n-------\nHTTP/1.1
+        200 OK\n\n\nRequest\n---------\n\nGET /0 HTTP/1.1\n | Host: google-gruyere.appspot.com\n
+        | Accept-Encoding: gzip, deflate\n | User-Agent: Mozilla/5.0 (Windows NT 10.0;
+        Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n
+        | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Pragma: no-cache\n | Content-Type: text/html;
+        charset=utf-8\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context: 80fe3cea93ccc7a83c1b09602128ff15\n
+        | Vary: Accept-Encoding\n | Date: Tue, 07 Jan 2020 03:44:58 GMT\n | Server:
+        Google Frontend\n | Content-Length: 247\n | \n | \n    &lt;HTML>\n  &lt;STYLE>\n
+        \ body, th, td, form {\n    font-family: Verdana, Arial, Helvetica, sans-serif;\n
+        \   font-size: 12px;\n  }\n  h1 { color: #dd0000; }\n  &lt;/STYLE>\n    &lt;TITLE>Gruyere
+        Error&lt;/TITLE>\n    &lt;BODY>\n    &lt;H1>Gruyere Error&lt;/H1>\n    That
+        instance does not exist.\n    &lt;H2>&lt;A href=\"/\">Home&lt;/A>&lt;/H2>\n
+        \   &lt;H2>&lt;A href=\"/start\">Start&lt;/A>&lt;/H2>\n    &lt;/BODY>&lt;/HTML></plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"115540\"
+        pluginName=\"Cookie Without SameSite Flag Detected\" pluginFamily=\"Web Applications\"><description>When
+        the SameSite flag is set on a cookie, the browser will prevent it from being
+        sent along with cross-site requests.\n  This can help prevent Cross-Site Request
+        Forgery (CSRF) attacks.</description><plugin_publication_date>2018/12/14</plugin_publication_date><plugin_modification_date>2019/01/04</plugin_modification_date><plugin_name>Cookie
+        Without SameSite Flag Detected</plugin_name><risk_factor>Low</risk_factor><see_also>https://www.owasp.org/index.php/SameSite</see_also><solution>If
+        the cookie contains sensitive information, then the server should ensure that
+        the cookie has the SameSite flag set.   This flag can have two values: strict
+        or lax. With the strict value the cookie will only be sent if the request
+        originates from the same website.   With the lax value the cookie will only
+        be sent for GET requests.</solution><xref>wasc:Cross-Site Request Forgery</xref><xref>cwe:352</xref><xref>owasp:2013-A8</xref><xref>owasp:2010-A5</xref><plugin_output>http://google-gruyere.appspot.com/start
+        returned a cookie named 'GRUYERE_ID' that does not set the SameSite cookie
+        flag correctly.</plugin_output></ReportItem><ReportItem port=\"80\" svc_name=\"http\"
+        protocol=\"TCP\" severity=\"0\" pluginID=\"98050\" pluginName=\"Interesting
+        response\" pluginFamily=\"Web Applications\"><description>The scanner identified
+        some responses with a status code other than the usual 200 (OK), 301 (Moved
+        Permanently), 302 (Found) and 404 (Not Found) codes.\n  These codes can provide
+        useful insights into the behavior of the web application and identify any
+        unexpected responses to be addressed.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2018/05/09</plugin_modification_date><plugin_name>Interesting
+        response</plugin_name><risk_factor>Informational</risk_factor><see_also>http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html</see_also><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/\n\n\nProof\n-------\nHTTP/1.1
+        400 Bad Request\n\n\nRequest\n---------\n\nGET / HTTP/1.1\n | Accept-Encoding:
+        gzip, deflate\n | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Host: google-gruyere.appspot.com';.\")\n
+        | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        400 Bad Request\n | Content-Length: 54\n | Content-Type: text/html; charset=UTF-8\n
+        | Date: Tue, 07 Jan 2020 04:13:19 GMT\n | Connection: close\n | \n | &lt;html>&lt;title>Error
+        400 (Bad Request)!!1&lt;/title>&lt;/html></plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /531899522745731123167764836993191970177/%3E%22'%3E%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        207aa979d075bc34a97b33127ba431d2\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 04:16:29 GMT\n | Server: Google Frontend\n | Content-Length: 906\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/531899522745731123167764836993191970177/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/531899522745731123167764836993191970177/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/531899522745731123167764836993191970177/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: />\"'>&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98611\"
+        pluginName=\"Error Message\" pluginFamily=\"Data Exposure\"><description>An
+        error or warning message has been found on the remote web server. It may be
+        possible for an attacker to view sensitive information and conduct further
+        attacks.</description><plugin_publication_date>2019/05/26</plugin_publication_date><plugin_modification_date>2019/05/26</plugin_modification_date><plugin_name>Error
+        Message</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/Error_Handling</see_also><solution>Disable
+        all notice, warning and error displaying. Configure the application to log
+        such messages in a file.</solution><plugin_output>On http://google-gruyere.appspot.com/part1
+        debug error messages were detected. Please see the attached response for full
+        details.&#xd;\n&lt;B>WARNING:&lt;/B> Because Gruyere is very vulnerable</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98647\"
+        pluginName=\"Missing Subresource Integrity (SRI)\" pluginFamily=\"Web Applications\"><description>Subresource
+        Integrity (SRI) is a web security standard that enables browsers to verify
+        that resources hosted by third parties (CDN for example) are delivered without
+        unexpected manipulation.\n\nSRI works by comparing a cryptographic hash declared
+        in the integrity attribute of resource tag (like script) used to fetch the
+        resource and the calculated hash value of this resource.\n\nNo SRI have been
+        detected for one or more resources.</description><plugin_publication_date>2019/08/01</plugin_publication_date><plugin_modification_date>2019/08/01</plugin_modification_date><plugin_name>Missing
+        Subresource Integrity (SRI)</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/3rd_Party_Javascript_Management_Cheat_Sheet#Subresource_Integrity</see_also><solution>Add
+        integrity attribute to the resource tag with prefixed and base64 encoded hash
+        of the resource.</solution><plugin_output>Subresource Integrity missing from
+        following resource: \n\n- https://www.google.com/recaptcha/api.js\n\nScript
+        tag Source: \n\n- &lt;script src=\"https://www.google.com/recaptcha/api.js\"
+        async defer>&lt;/script>\n\n\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98647\" pluginName=\"Missing
+        Subresource Integrity (SRI)\" pluginFamily=\"Web Applications\"><description>Subresource
+        Integrity (SRI) is a web security standard that enables browsers to verify
+        that resources hosted by third parties (CDN for example) are delivered without
+        unexpected manipulation.\n\nSRI works by comparing a cryptographic hash declared
+        in the integrity attribute of resource tag (like script) used to fetch the
+        resource and the calculated hash value of this resource.\n\nNo SRI have been
+        detected for one or more resources.</description><plugin_publication_date>2019/08/01</plugin_publication_date><plugin_modification_date>2019/08/01</plugin_modification_date><plugin_name>Missing
+        Subresource Integrity (SRI)</plugin_name><risk_factor>Informational</risk_factor><see_also>https://www.owasp.org/index.php/3rd_Party_Javascript_Management_Cheat_Sheet#Subresource_Integrity</see_also><solution>Add
+        integrity attribute to the resource tag with prefixed and base64 encoded hash
+        of the resource.</solution><plugin_output>Subresource Integrity missing from
+        following resource: \n\n- https://www.google.com/recaptcha/api.js\n\nScript
+        tag Source: \n\n- &lt;script src=\"https://www.google.com/recaptcha/api.js\"
+        async defer>&lt;/script>\n\n\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\" pluginName=\"Cross-Site
+        Scripting (XSS) in path\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  the requested PATH and have it returned in the server's
+        response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`, where `INJECTION_HERE`\n
+        \ represents the location where the scanner payload was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/invalid\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/invalid/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        4bc91fa387e483e352e7bf613957fffc\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:22:11 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /invalid/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/&amp;amp\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/&amp;amp/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        61df760b9b398e70114ac43146dc2d43\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:33:10 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body&gt;\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /&amp;amp/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/%20ADw-%20AD4-\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/%20ADw-%20AD4-/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        7f45c85e752fce03ad09c5a6f4be14ac\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:39:22 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: / ADw- AD4-/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/feed.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/feed.gtl/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        f2bf977e9f1aa1a37b3f032f940ad214\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:44:49 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head&gt;\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /feed.gtl/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttps://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236/saveprofile/%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        f59beba5eeec0956f2b64c21651d1d7f;o=1\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 05:50:10 GMT\n | Server: Google Frontend\n | Alt-Svc: quic=\":443\";
+        ma=2592000; v=\"46,43\",h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\";
+        ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000\n | Transfer-Encoding:
+        chunked\n | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: /saveprofile/&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98107\"
+        pluginName=\"Cross-Site Scripting (XSS) in path\" pluginFamily=\"Cross Site
+        Scripting\"><description>Client-side scripts are used extensively by modern
+        web applications.\n  They perform from simple functions (such as the formatting
+        of text) up to full\n  manipulation of client-side data and Operating System
+        interaction.\n\n  Cross Site Scripting (XSS) allows clients to inject scripts
+        into a request and\n  have the server return the script to the client in the
+        response. This occurs\n  because the application is taking untrusted data
+        (in this example, from the client)\n  and reusing it without performing any
+        validation or sanitisation.\n\n  If the injected script is returned immediately
+        this is known as reflected XSS.\n  If the injected script is stored by the
+        server and returned to any client visiting\n  the affected page, then this
+        is known as persistent XSS (also stored XSS).\n\n  Scanner has discovered
+        that it is possible to insert script content directly into\n  the requested
+        PATH and have it returned in the server's response.\n  For example `HTTP://yoursite.com/INJECTION_HERE/`,
+        where `INJECTION_HERE`\n  represents the location where the scanner payload
+        was injected.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS) in path</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/412569245047960484377262321708701598236/\n\n\nDetection
+        Information\n-----------------------\nInput Type         : path\n\n\nProof\n-------\n&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>\n\n\nRequest\n---------\n\nGET
+        /412569245047960484377262321708701598236//%3Cmy_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/%3E/%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n | Cookie: GRUYERE_ID=412569245047960484377262321708701598236\n\nResponse\n----------\n\nHTTP/1.1
+        200 OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma:
+        no-cache\n | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        8bd52eec84a30d3ae6628c266dbf84fa\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 06:23:20 GMT\n | Server: Google Frontend\n | Content-Length: 904\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Error&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;/head>\n\n&lt;body>\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/412569245047960484377262321708701598236/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/412569245047960484377262321708701598236/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/412569245047960484377262321708701598236/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n\n\n&lt;div class='message'>Invalid
+        request: //&lt;my_tag_36b4c4a8-603d-435a-8d44-9ec90d4b9777/>/>&lt;/div>\n\n\n&lt;/body>\n\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"2\" pluginID=\"98082\"
+        pluginName=\"Unencrypted password form\" pluginFamily=\"Authentication &amp;
+        Session\"><description>The HTTP protocol by itself is clear text, meaning
+        that any data that is\n  transmitted via HTTP can be captured and the contents
+        viewed.\n\n  To keep data private, and prevent it from being intercepted,
+        HTTP is often\n  tunnelled through either Secure Sockets Layer (SSL), or Transport
+        Layer Security\n  (TLS).\n  When either of these encryption standards are
+        used it is referred to as HTTPS.\n\n  Cyber-criminals will often attempt to
+        compromise credentials passed from the\n  client to the server using HTTP.\n
+        \ This can be conducted via various different Man-in-The-Middle (MiTM) attacks
+        or\n  through network packet captures.\n\n  Scanner discovered that the affected
+        page contains a `password` input, however,\n  the value of the field is not
+        sent to the server utilising HTTPS. Therefore it\n  is possible that any submitted
+        credential may become compromised.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Unencrypted
+        password form</plugin_name><risk_factor>Medium</risk_factor><see_also>http://www.owasp.org/index.php/Top_10_2010-A9-Insufficient_Transport_Layer_Protection</see_also><solution>The
+        affected site should be secured utilising the latest and most secure encryption
+        \  protocols.   These include SSL version 3.0 and TLS version 1.2. While TLS
+        1.2 is the latest   and the most preferred protocol, not all browsers will
+        support this encryption   method. Therefore, the more common SSL is included.
+        Older protocols such as SSL   version 2, and weak ciphers (&lt; 128 bit) should
+        also be disabled.</solution><xref>owasp:2017-A3</xref><xref>owasp:2010-A9</xref><xref>cwe:319</xref><xref>owasp:2017-A2</xref><xref>cwe:523</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><xref>owasp:2010-A3</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/531899522745731123167764836993191970177/login\n\n\nProof\n-------\n&lt;form
+        method=\"get\" action=\"/531899522745731123167764836993191970177/login\">\n
+        \ &lt;input type=\"text\" name=\"uid\">\n  &lt;/input>\n  &lt;input type=\"password\"
+        name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"submit\" value=\"Login\">\n
+        \ &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem port=\"80\"
+        svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98138\" pluginName=\"Screenshot\"
+        pluginFamily=\"General\"><description>Screenshot of the target web page, see
+        attached image. This screenshot should show you the target page we are launching
+        the scan against.\n  If the image is not of the intended target page, please
+        check the provided url in the scan configuration.</description><plugin_publication_date>2018/01/23</plugin_publication_date><plugin_modification_date>2018/02/14</plugin_modification_date><plugin_name>Screenshot</plugin_name><risk_factor>Informational</risk_factor><plugin_output>WAS
+        Scanner has taken a screenshot of the page at url 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/'
+        with dimensions 1600x1200.\n\nPlease see the attachment for the screenshot
+        image.</plugin_output></ReportItem><ReportItem port=\"80\" svc_name=\"http\"
+        protocol=\"TCP\" severity=\"2\" pluginID=\"112544\" pluginName=\"HTTP to HTTPS
+        Redirect Not Enabled\" pluginFamily=\"SSL/TLS\"><description>HTTPS is enabled
+        on the website however HTTP requests are not redirected to HTTPS. Communications
+        are not encrypted if users doesn't explicitly access to HTTPS version of the
+        website.</description><plugin_publication_date>2019/02/12</plugin_publication_date><plugin_modification_date>2019/02/12</plugin_modification_date><plugin_name>HTTP
+        to HTTPS Redirect Not Enabled</plugin_name><risk_factor>Medium</risk_factor><see_also>https://www.owasp.org/index.php/HTTP_Strict_Transport_Security_Cheat_Sheet</see_also><solution>Enable
+        HTTP to HTTPS redirect for all requests. Besides redirects if HTTP Strict
+        Transport Security (HSTS) is not implemented it's highly recommended to enable
+        it.</solution><xref>owasp:2010-A9</xref><xref>owasp:2017-A3</xref><xref>owasp:2013-A6</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><plugin_output>The Scanner was unable to
+        detect a HTTPS redirect on URL: http://google-gruyere.appspot.com/652479776707981538544840512166060390157/</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98527\"
+        pluginName=\"Missing Referrer Policy\" pluginFamily=\"HTTP Security Header\"><description>Referrer
+        Policy provides mechanisms to websites to restrict referrer information (sent
+        in the referer header) that browsers will be allowed to add.\n\nNo Referrer
+        Policy header or metatag configuration has been detected.</description><plugin_publication_date>2019/04/02</plugin_publication_date><plugin_modification_date>2019/04/02</plugin_modification_date><plugin_name>Missing
+        Referrer Policy</plugin_name><risk_factor>Informational</risk_factor><see_also>https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy</see_also><solution>Configure
+        Referrer Policy on your website by adding 'Referrer-Policy' HTTP header or
+        meta tag referrer in HTML.</solution><plugin_output>No Referrer-Policy headers
+        or body meta tags were found on http://google-gruyere.appspot.com/652479776707981538544840512166060390157/</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98050\"
+        pluginName=\"Interesting response\" pluginFamily=\"Web Applications\"><description>The
+        scanner identified some responses with a status code other than the usual
+        200 (OK), 301 (Moved Permanently), 302 (Found) and 404 (Not Found) codes.\n
+        \ These codes can provide useful insights into the behavior of the web application
+        and identify any unexpected responses to be addressed.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2018/05/09</plugin_modification_date><plugin_name>Interesting
+        response</plugin_name><risk_factor>Informational</risk_factor><see_also>http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html</see_also><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/\n\n\nProof\n-------\nHTTP/1.1
+        405 Method Not Allowed\n\n\nRequest\n---------\n\nOPTIONS /652479776707981538544840512166060390157/
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 405
+        Method Not Allowed\n | Allow: GET, POST\n | Content-Type: text/html; charset=UTF-8\n
+        | Content-Encoding: gzip\n | X-Cloud-Trace-Context: 3ec615a8287591c02004d5ea2a2fcab7\n
+        | Vary: Accept-Encoding\n | Date: Tue, 07 Jan 2020 03:33:29 GMT\n | Server:
+        Google Frontend\n | Cache-Control: private\n | Content-Length: 145\n | \n
+        | &lt;html>\n &lt;head>\n  &lt;title>405 Method Not Allowed&lt;/title>\n &lt;/head>\n
+        &lt;body>\n  &lt;h1>405 Method Not Allowed&lt;/h1>\n  The method OPTIONS is
+        not allowed for this resource. &lt;br />&lt;br />\n\n &lt;/body>\n&lt;/html></plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"3\" pluginID=\"98104\"
+        pluginName=\"Cross-Site Scripting (XSS)\" pluginFamily=\"Cross Site Scripting\"><description>Client-side
+        scripts are used extensively by modern web applications.\n  They perform from
+        simple functions (such as the formatting of text) up to full\n  manipulation
+        of client-side data and Operating System interaction.\n\n  Cross Site Scripting
+        (XSS) allows clients to inject scripts into a request and\n  have the server
+        return the script to the client in the response. This occurs\n  because the
+        application is taking untrusted data (in this example, from the client)\n
+        \ and reusing it without performing any validation or sanitisation.\n\n  If
+        the injected script is returned immediately this is known as reflected XSS.\n
+        \ If the injected script is stored by the server and returned to any client
+        visiting\n  the affected page, then this is known as persistent XSS (also
+        stored XSS).\n\n  Scanner has discovered that it is possible to insert script
+        content directly into\n  HTML element content.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Cross-Site
+        Scripting (XSS)</plugin_name><risk_factor>High</risk_factor><see_also>http://projects.webappsec.org/w/page/13246920/Cross%20Site%20Scripting</see_also><solution>To
+        remedy XSS vulnerabilities, it is important to never use untrusted or unfiltered
+        \  data within the code of a HTML page.\n  Untrusted data can originate not
+        only form the client but potentially a third   party or previously uploaded
+        file etc.\n  Filtering of untrusted data typically involves converting special
+        characters to   their HTML entity encoded counterparts (however, other methods
+        do exist, see references).   These special characters include:\n  * `&amp;`
+        \  * `&lt;`   * `>`   * `'`   * `'`   * `/`\n  An example of HTML entity encoding
+        is converting `&lt;` to `&amp;lt;`.\n  Although it is possible to filter untrusted
+        input, there are five locations   within an HTML page where untrusted input
+        (even if it has been filtered) should   never be placed:\n  1. Directly in
+        a script.   2. Inside an HTML comment.   3. In an attribute name.   4. In
+        a tag name.   5. Directly in CSS.\n  Each of these locations have their own
+        form of escaping and filtering.\n  _Because many browsers attempt to implement
+        XSS protection, any manual verification   of this finding should be conducted
+        using multiple different browsers and browser   versions._</solution><xref>wasc:Cross-Site
+        Scripting</xref><xref>cwe:79</xref><xref>owasp:2017-A7</xref><xref>owasp:2013-A3</xref><xref>owasp:2010-A2</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/652479776707981538544840512166060390157/snippets.gtl\n\n\nDetection
+        Information\n-----------------------\nInput Type         : link\nInput Name
+        \        : uid\n\nInjected Payload   : &lt;xss_1685010/>\n\n\n\nProof\n-------\n&lt;xss_1685010/>\n\n\nRequest\n---------\n\nGET
+        /652479776707981538544840512166060390157/snippets.gtl?uid=cheddar%3Cxss_1685010%2F%3E
+        HTTP/1.1\n | Host: google-gruyere.appspot.com\n | Accept-Encoding: gzip, deflate\n
+        | User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+        (KHTML, like Gecko) Chrome/77.0.3865.90 Safari/537.36\n | Accept:  text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\n
+        | Accept-Language:  en-US,en;q=0.5\n\nResponse\n----------\n\nHTTP/1.1 200
+        OK\n | Cache-Control: no-cache\n | Content-type: text/html\n | Pragma: no-cache\n
+        | X-XSS-Protection: 0\n | Content-Encoding: gzip\n | X-Cloud-Trace-Context:
+        5f6255fdd2a9efa6155123ce5ab35a12\n | Vary: Accept-Encoding\n | Date: Tue,
+        07 Jan 2020 03:33:35 GMT\n | Server: Google Frontend\n | Content-Length: 1011\n
+        | \n | &lt;!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">\n&lt;!--
+        Copyright 2017 Google Inc. -->\n&lt;html>\n&lt;head>\n&lt;title>Gruyere: Snippets&lt;/title>\n&lt;style>\n/*
+        Copyright 2017 Google Inc. */\n\nbody, html, td, span, div, input, textarea
+        {\n  font-family: sans-serif;\n  font-size: 14pt;\n}\n\nbody {\n  background:
+        url('cheese.png') top center repeat;\n  text-align: center;\n  opacity: 0.80;\n}\n\nh2
+        {\n  text-align: center;\n  font-size: 30pt;\n  font-weight: bold;\n}\n\ntd
+        {\n  vertical-align: top;\n  padding: 5px;\n}\n\na, a:hover {\n  text-decoration:
+        underline;\n  color: #0000bb;\n}\n\na:visited {\n  color: #bb0000;\n}\n\na.button:visited
+        {\n  color: #0000bb;\n}\n\n.content {\n  text-align: left;\n  margin-left:
+        auto;\n  margin-right: auto;\n  width: 90%;\n  background: #ffffcc;\n  padding:
+        20px;\n  border: 3px solid #ffb149;\n}\n\n.menu {\n  text-align: left;\n  padding:
+        10px 20px 35px 20px;\n  margin-left: auto;\n  margin-right: auto;\n  margin-top:
+        20px;\n  width: 90%;\n  background: #ffffcc;\n  border: 3px solid #ffb149;\n}\n\n.menu-user
+        {\n  color: #000000;\n  font-weight: bold;\n}\n\n#menu-left {\n  float: left;\n}\n\n#menu-left
+        a, #menu-left a:hover, #menu-left a:visited {\n  color: #000000;\n}\n\n#menu-right
+        {\n  float: right;\n}\n\n#menu-right a, #menu-right a:hover, #menu-right a:visited
+        {\n  color: #000000;\n}\n\n.message {\n  width: 50%;\n  color: #ff0000;\n
+        \ background: #ffdddd;\n  border: 2px solid #ff0000;\n  border-radius: 1em;\n
+        \ -moz-border-radius: 1em;\n  padding: 10px;\n  font-weight: bold;\n  text-align:
+        center;\n  margin: auto;\n  margin-top: 20px;\n  margin-bottom: 20px;\n}\n\ninput,
+        textarea {\n  background-color: #ffffff;\n}\n\n.refresh {\n  float: center;\n
+        \ width: 90%;\n  text-align: right;\n  margin: auto;\n  padding-top: 0;\n
+        \ padding-bottom: 2pt;\n  margin-top: 0;\n  margin-bottom: 0;\n}\n\n.h2-with-refresh
+        {\n  margin-bottom: 0;\n}\n\n&lt;/style>\n\n&lt;script src=\"/652479776707981538544840512166060390157/lib.js\"
+        text=\"text/javascript\">\n&lt;/script>\n&lt;/head>\n\n&lt;body>\n\n\n&lt;div
+        class='menu'>\n  &lt;span id='menu-left'>\n    &lt;a href='/652479776707981538544840512166060390157/'>Home&lt;/a>\n
+        \     \n  &lt;/span>\n  &lt;span id='menu-right'>\n      \n      \n      &lt;a
+        href='/652479776707981538544840512166060390157/login'>Sign in&lt;/a>\n      |
+        &lt;a href='/652479776707981538544840512166060390157/newaccount.gtl'>Sign
+        up&lt;/a>\n      \n  &lt;/span>\n&lt;/div>\n\n&lt;div>\n&lt;h2 class='has-refresh'
+        id=\"user_name\">\n\n  cheddar&lt;xss_1685010/>\n  \n\n\n&lt;/h2>\n&lt;div
+        class='refresh'>&lt;a class='button'\n  onclick='_refreshSnippets(\"652479776707981538544840512166060390157\",
+        \"cheddar&lt;xss_1685010/>\")'\n  href='#'>Refresh&lt;/a>&lt;/div>\n&lt;div
+        class='content'>\n\n\n  \n    cheddar&lt;xss_1685010/>\n    is not an author.\n
+        \ \n  \n\n\n\n&lt;/div>\n&lt;/body>\n&lt;/html>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"2\" pluginID=\"98082\"
+        pluginName=\"Unencrypted password form\" pluginFamily=\"Authentication &amp;
+        Session\"><description>The HTTP protocol by itself is clear text, meaning
+        that any data that is\n  transmitted via HTTP can be captured and the contents
+        viewed.\n\n  To keep data private, and prevent it from being intercepted,
+        HTTP is often\n  tunnelled through either Secure Sockets Layer (SSL), or Transport
+        Layer Security\n  (TLS).\n  When either of these encryption standards are
+        used it is referred to as HTTPS.\n\n  Cyber-criminals will often attempt to
+        compromise credentials passed from the\n  client to the server using HTTP.\n
+        \ This can be conducted via various different Man-in-The-Middle (MiTM) attacks
+        or\n  through network packet captures.\n\n  Scanner discovered that the affected
+        page contains a `password` input, however,\n  the value of the field is not
+        sent to the server utilising HTTPS. Therefore it\n  is possible that any submitted
+        credential may become compromised.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Unencrypted
+        password form</plugin_name><risk_factor>Medium</risk_factor><see_also>http://www.owasp.org/index.php/Top_10_2010-A9-Insufficient_Transport_Layer_Protection</see_also><solution>The
+        affected site should be secured utilising the latest and most secure encryption
+        \  protocols.   These include SSL version 3.0 and TLS version 1.2. While TLS
+        1.2 is the latest   and the most preferred protocol, not all browsers will
+        support this encryption   method. Therefore, the more common SSL is included.
+        Older protocols such as SSL   version 2, and weak ciphers (&lt; 128 bit) should
+        also be disabled.</solution><xref>owasp:2017-A3</xref><xref>owasp:2010-A9</xref><xref>cwe:319</xref><xref>owasp:2017-A2</xref><xref>cwe:523</xref><xref>owasp:2013-A6</xref><xref>owasp:2013-A2</xref><xref>wasc:Insufficient
+        Transport Layer Protection</xref><xref>owasp:2010-A3</xref><plugin_output>URL\n-----\nhttp://google-gruyere.appspot.com/412569245047960484377262321708701598236/newaccount.gtl\n\n\nProof\n-------\n&lt;form
+        method=\"get\" action=\"/412569245047960484377262321708701598236/saveprofile\">\n
+        \ &lt;input type=\"hidden\" name=\"action\" value=\"new\">\n  &lt;/input>\n
+        \ &lt;input type=\"text\" name=\"uid\" value=\"\" maxlength=\"16\">\n  &lt;/input>\n
+        \ &lt;input type=\"password\" name=\"pw\">\n  &lt;/input>\n  &lt;input type=\"hidden\"
+        name=\"is_author\" value=\"True\">\n  &lt;/input>\n  &lt;input type=\"submit\"
+        value=\"Create account\">\n  &lt;/input>\n&lt;/form>\n</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"1\" pluginID=\"98077\"
+        pluginName=\"Private IP address disclosure\" pluginFamily=\"Data Exposure\"><description>Private,
+        or non-routable, IP addresses are generally used within a home or\n  company
+        network and are typically unknown to anyone outside of that network.\n\n  Cyber-criminals
+        will attempt to identify the private IP address range being used\n  by their
+        victim, to aid in collecting further information that could then lead\n  to
+        a possible compromise.\n\n  Scanner discovered that the affected page returned
+        a RFC 1918 compliant private\n  IP address and therefore could be revealing
+        sensitive information.\n\n  This finding typically requires manual verification
+        to ensure the context is\n  correct, as any private IP address within the
+        HTML body will trigger it.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/10/16</plugin_modification_date><plugin_name>Private
+        IP address disclosure</plugin_name><risk_factor>Low</risk_factor><see_also>http://projects.webappsec.org/w/page/13246936/Information%20Leakage</see_also><solution>Identifying
+        the context in which the affected page displays a Private IP   address is
+        necessary.\n  If the page is publicly accessible and displays the Private
+        IP of the affected   server (or supporting infrastructure), then measures
+        should be put in place to   ensure that the IP address is removed from any
+        response.</solution><xref>owasp:2010-A6</xref><xref>owasp:2013-A5</xref><xref>cwe:200</xref><xref>wasc:Information
+        Leakage</xref><xref>owasp:2017-A6</xref><plugin_output>Number of Private IP
+        Addresses Collected: 1\n\nListed below are each private ip address:\n127.0.0.1
+        found on 2 URLs\n</plugin_output></ReportItem><ReportItem port=\"80\" svc_name=\"http\"
+        protocol=\"TCP\" severity=\"0\" pluginID=\"98019\" pluginName=\"Network Timeout
+        Encountered\" pluginFamily=\"General\"><description>Provides a report of network
+        timeouts encountered during the scan, showing URLs and the number of timeouts
+        for each URL.\n\n  Note that assessment will stop on any URLs in timeout state,
+        and timeouts may increase significantly the overal duration of the scan.</description><plugin_publication_date>2017/09/25</plugin_publication_date><plugin_modification_date>2017/09/25</plugin_modification_date><plugin_name>Network
+        Timeout Encountered</plugin_name><risk_factor>Informational</risk_factor><solution>Check
+        your web application logs and verify that it is functioning as expected and
+        can handle significant amounts of traffic generated by the scanner.\n  Additionally,
+        the scan policy may be edited to optimize the performance settings.</solution><plugin_output>1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=37&amp;pw=nessus_was_textny4bc6h7&amp;is_author=%2Fboot.ini'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=file%3A%2F%2F%2Fboot.ini%00.&amp;uid=53&amp;pw=nessus_was_textyisx0wpi&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=file%3A%2F%2F%2Fboot.ini&amp;uid=53&amp;pw=nessus_was_textyisx0wpi&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=file%3A%2F%2F%2Fboot.ini&amp;pw=nessus_was_text1zhkevc2&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=88&amp;pw=file%3A%2F%2F%2Fboot.ini%00.&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=88&amp;pw=file%3A%2F%2F%2Fboot.ini&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=23&amp;pw=nessus_was_textsvuay82r&amp;is_author=file%3A%2F%2F%2Fboot.ini%00.'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=c%3A%2Fboot.ini%00.&amp;uid=18&amp;pw=nessus_was_textckb62mw3&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=c%3A%2Fboot.ini%00.&amp;pw=nessus_was_textatg4zixm&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=c%3A%2Fboot.ini&amp;pw=nessus_was_textatg4zixm&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=94&amp;pw=c%3A%2Fboot.ini%00.&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=94&amp;pw=c%3A%2Fboot.ini&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=2&amp;pw=nessus_was_textgwzcc9l8&amp;is_author=c%3A%2Fboot.ini'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=file%3A%2F%2Fc%3A%2Fboot.ini&amp;uid=60&amp;pw=nessus_was_text4ar7o0wi&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=file%3A%2F%2Fc%3A%2Fboot.ini%00.&amp;pw=nessus_was_text5mps5vwb&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=file%3A%2F%2Fc%3A%2Fboot.ini&amp;pw=nessus_was_text5mps5vwb&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=89&amp;pw=nessus_was_texttp9krgze&amp;is_author=file%3A%2F%2Fc%3A%2Fboot.ini%00.'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=file%3A%2F%2F%5Cboot.ini%00.&amp;uid=78&amp;pw=nessus_was_text4yyeuokd&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=42&amp;pw=%2Fwinnt%2Fwin.ini%00.&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=%2F..%2F..%2Fwindows%2Fwin.ini&amp;uid=70&amp;pw=nessus_was_text74mq9ptr&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=%2F..%2F..%2F..%2Fwinnt%2Fwin.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................%00.&amp;uid=108&amp;pw=nessus_was_textj3tmxo55&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=%2F..%2F..%2F..%2F..%2Fwinnt%2Fwin.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................&amp;uid=99&amp;pw=nessus_was_textafpdyro4&amp;is_author=True'\n6
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/newaccount.gtl'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=sleep%204&amp;uid=27&amp;pw=nessus_was_texttzuk11yj&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=118&amp;pw=nessus_was_textstig3bbg&amp;is_author=True%3Bselect%20pg_sleep%282%29%3B%20--%20%27%3Bselect%20pg_sleep%282%29%3B%20--%20%22%3Bselect%20pg_sleep%282%29%3B%20--%20'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=32&amp;pw=nessus_was_text56v1muqd&amp;is_author=10001839%20or%201%3D2'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/652479776707981538544840512166060390157/saveprofile?action=new&amp;uid=67&amp;pw=1%22%20limit%200%2C%201386%20--%20&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/8'\n11 timeouts
+        encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177'\n14
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/part3'\n4
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236'\n7
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/.git/336f80f2467903512f6cbb78dc02094ad68bb151/'\n3
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/invalid'\n2
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/&amp;amp'\n8
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/%20ADw-%20AD4-'\n1
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/%3Cscript%3Ealert(1)%3C/script%3E'\n2
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/feed.gtl'\n7
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=update&amp;is_admin=True'\n1
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=update&amp;is_admin=True&amp;uid=username'\n7
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/quitserver'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/.idea/cf67632f9e08730b36fe11586c6136007532d4c5'\n3
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/.idea/ace85f7e7eaa8fe6dd0e091c5e741d7365f62b71.a26'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/snippets.gtl?uid=-1839'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=5&amp;pw=%22%20%7C%20type%20%25SystemDrive%25%5C%5Cboot.ini%20%7C%20%22&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=6&amp;pw=nessus_was_textl04mnwl3&amp;is_author=%22%20%7C%20type%20%25SystemDrive%25%5C%5Cboot.ini%20%7C%20%22'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=%22%20%3B%20type%20%25SystemDrive%25%5C%5Cboot.ini%20%3B%20%22&amp;uid=10&amp;pw=nessus_was_textuh9j124m&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=%22%20%3B%20type%20%25SystemDrive%25%5C%5Cboot.ini%20%3B%20%22&amp;pw=nessus_was_textqnikwx4m&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=%60%20type%20%25SystemDrive%25%5C%5Cboot.ini%60&amp;pw=nessus_was_text8jbri1o7&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=15&amp;pw=%60%20type%20%25SystemDrive%25%5C%5Cboot.ini%60&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=type%20%25SystemRoot%25%5C%5Cwin.ini&amp;uid=24&amp;pw=nessus_was_textu33qp8h4&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=type%20%25SystemRoot%25%5C%5Cwin.ini&amp;pw=nessus_was_text1dhge1jl&amp;is_author=True'\n40
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/newaccount.gtl'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=%3Bsleep%284000%2F1000%29%3B&amp;uid=63&amp;pw=nessus_was_texts2qk5a27&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=%3Bsleep%284000%2F1000%29%3B&amp;pw=nessus_was_text1xclbwbx&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=12&amp;pw=nessus_was_text7brywos8&amp;is_author=%3Bsleep%284000%2F1000%29%3B'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=%22%3Bsleep%284000%2F1000%29%3B%23&amp;uid=84&amp;pw=nessus_was_textlgiex3ji&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=%22%3Bsleep%284000%2F1000%29%3B%23&amp;pw=nessus_was_textzlbdz4uw&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=43&amp;pw=%22%3Bsleep%284000%2F1000%29%3B%23&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=%27%3Bsleep%284000%2F1000%29%3B%23&amp;pw=nessus_was_textu65furj7&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=65&amp;pw=%27%3Bsleep%284000%2F1000%29%3B%23&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile?action=new&amp;uid=%20import%20time%3Btime.sleep%284000%2F1000%29%3B&amp;pw=nessus_was_texthzz31uc0&amp;is_author=True'\n6
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/code/data.py'\n8
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/'\n10
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236'\n2
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/login'\n45
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/newaccount.gtl'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/code/resources/menubar.gtl'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/login?uid=&amp;pw='\n10
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/login'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................%00.&amp;uid=115&amp;pw=nessus_was_textf0m4c5td&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=60&amp;pw=nessus_was_textwuzz66ej&amp;is_author=%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................%00.'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=60&amp;pw=nessus_was_textwuzz66ej&amp;is_author=%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=file%3A%2F%2F%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................%00.&amp;uid=36&amp;pw=nessus_was_text1eqqoxut&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=file%3A%2F%2F%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................&amp;pw=nessus_was_text721qetb6&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=3&amp;pw=file%3A%2F%2F%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................%00.&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=3&amp;pw=file%3A%2F%2F%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=15&amp;pw=nessus_was_textu8uwr2j5&amp;is_author=file%3A%2F%2F%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=%5Cboot.ini%00.&amp;pw=nessus_was_textpk3ruc5p&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=19&amp;pw=%5Cboot.ini%00.&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=19&amp;pw=%5Cboot.ini&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=108&amp;pw=nessus_was_textt1pubj3f&amp;is_author=%5Cboot.ini%00.'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=108&amp;pw=nessus_was_textt1pubj3f&amp;is_author=%5Cboot.ini'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=file%3A%2F%2F%5Cboot.ini&amp;uid=100&amp;pw=nessus_was_textk09twb36&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=file%3A%2F%2F%5Cboot.ini%00.&amp;pw=nessus_was_texttzovjin2&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=5&amp;pw=nessus_was_textekjdd7e2&amp;is_author=%22%20%7C%20type%20%25SystemRoot%25%5C%5Cwin.ini%20%7C%20%22'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=%22%20%3B%20type%20%25SystemRoot%25%5C%5Cwin.ini%20%3B%20%22&amp;pw=nessus_was_text4yzf8gr8&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=61&amp;pw=nessus_was_textmqkmei9i&amp;is_author=%22%20%3B%20type%20%25SystemRoot%25%5C%5Cwin.ini%20%3B%20%22'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=%60%20type%20%25SystemRoot%25%5C%5Cwin.ini%60&amp;pw=nessus_was_textcn8v4kvd&amp;is_author=True'\n28
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/newaccount.gtl'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=%2F..%2F..%2F..%2F..%2Fboot.ini%00.&amp;uid=122&amp;pw=nessus_was_textrr5zlyop&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=%2F..%2F..%2F..%2F..%2Fboot.ini%00.&amp;pw=nessus_was_textq7m4r9ko&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=%2F..%2F..%2F..%2F..%2Fboot.ini&amp;pw=nessus_was_textq7m4r9ko&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=1&amp;pw=nessus_was_text2tft7j2a&amp;is_author=%2F..%2F..%2F..%2F..%2Fboot.ini%00.'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=file%3A%2F%2F%2F..%2F..%2F..%2F..%2Fboot.ini%00.&amp;uid=86&amp;pw=nessus_was_textvfq1rlvg&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=file%3A%2F%2F%2F..%2F..%2F..%2F..%2Fboot.ini&amp;uid=86&amp;pw=nessus_was_textvfq1rlvg&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=file%3A%2F%2F%2F..%2F..%2F..%2F..%2Fboot.ini%00.&amp;pw=nessus_was_textd4pw0f4y&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=88&amp;pw=file%3A%2F%2F%2F..%2F..%2F..%2F..%2Fboot.ini&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=0&amp;pw=nessus_was_text5v2thevh&amp;is_author=file%3A%2F%2F%2F..%2F..%2F..%2F..%2Fboot.ini'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=%2F..%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................%00.&amp;uid=117&amp;pw=nessus_was_text88lf5i1r&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=%2F..%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................&amp;uid=117&amp;pw=nessus_was_text88lf5i1r&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=%2F..%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................%00.&amp;pw=nessus_was_textze5rsyin&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=%2F..%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................&amp;pw=nessus_was_textze5rsyin&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=32&amp;pw=%2F..%2Fboot.ini............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=94%27%20tenable_wasscan_xss_in_tag%3D%2736b4c4a8-603d-435a-8d44-9ec90d4b9777%27%20blah%3D%27&amp;pw=nessus_was_textrkp6khep&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=51&amp;pw=nessus_was_text41trsj8c&amp;is_author=True%27%20tenable_wasscan_xss_in_tag%3D%2736b4c4a8-603d-435a-8d44-9ec90d4b9777%27%20blah%3D%27'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=javascript%3Awindow.top._tenable_wasscan_js_namespace_taint_tracer.log_execution_flow_sink%28%29&amp;uid=50&amp;pw=nessus_was_textb3dpulpf&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=javascript%3Awindow.top._tenable_wasscan_js_namespace_taint_tracer.log_execution_flow_sink%28%29%2F%2F&amp;uid=34&amp;pw=nessus_was_textj01xyg2r&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=javascript%3Awindow.top._tenable_wasscan_js_namespace_taint_tracer.log_execution_flow_sink%28%29%2F%2F&amp;pw=nessus_was_textcivh30si&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=72&amp;pw=nessus_was_text6qvbrcqg&amp;is_author=javascript%3Awindow.top._tenable_wasscan_js_namespace_taint_tracer.log_execution_flow_sink%28%29%2F%2F'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=%27%3Bwindow.top._tenable_wasscan_js_namespace_taint_tracer.log_execution_flow_sink%28%29%27&amp;uid=8&amp;pw=nessus_was_textrd4aqo6h&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=new&amp;uid=52&amp;pw=%27%3Bwindow.top._tenable_wasscan_js_namespace_taint_tracer.log_execution_flow_sink%28%29%27%2F%2F&amp;is_author=True'\n1
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile?action=%22%20%7C%20ping%20-n%204%20localhost%20%7C%20%22&amp;uid=105&amp;pw=nessus_was_text31a22qzl&amp;is_author=True'\n8
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/531899522745731123167764836993191970177/saveprofile'\n5
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/code/resources/upload2.gtl'\n2
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/code/gtl.py'\n1
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/code/resources/manage.gtl'\n40
+        timeouts encountered for URL 'https://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile'\n28
+        timeouts encountered for URL 'http://google-gruyere.appspot.com/412569245047960484377262321708701598236/saveprofile'</plugin_output></ReportItem><ReportItem
+        port=\"80\" svc_name=\"http\" protocol=\"TCP\" severity=\"0\" pluginID=\"98009\"
+        pluginName=\"Web Application Sitemap\" pluginFamily=\"General\"><description>Publishes
+        the sitemap of the web application as seen by the scan.</description><plugin_publication_date>2017/03/31</plugin_publication_date><plugin_modification_date>2017/06/16</plugin_modification_date><plugin_name>Web
+        Application Sitemap</plugin_name><risk_factor>Informational</risk_factor><plugin_output>The
+        scan has discovered 234 distinct URLs, 143 of which are in the target scope.\n\nFrom
+        these 143 URLs, 167 have been effectively crawled.\n- 29 with error \"Timeout
+        was reached\"\n\nResponse times ranged between 0.003538s and 3.5411s.\n\nHere
+        is the distribution of URL types for this web application:\n- 142 as \"text/html\"\n-
+        14 as \"image/png\"\n- 4 as \"application/javascript\"\n- 2 as \"text/css\"\n-
+        2 as \"application/zip\"\n- 1 as \"image/gif\"\n- 2 as \"text/javascript\"\n\nYou
+        can access the complete list of URLs with the information collected by the
+        scan as an attachment to this plugin.</plugin_output></ReportItem></ReportHost></Report></NessusClientData_v2>"
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename=gruyere.nessus
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 09 Jan 2020 01:26:58 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=ap-syd-1; path=/; HttpOnly; Secure
+      - nginx-cloud-site-id=ap-syd-1; path=/; HttpOnly; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Accel-Buffering:
+      - 'no'
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-uhhl3-ap-southeast-1-prod
+      X-Request-Uuid:
+      - a314bdee8378b9c1cf21c7938634d919
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/test_scans.py
+++ b/tests/io/test_scans.py
@@ -424,6 +424,15 @@ def test_scan_export_filter_type_unexpectedvalueerror(api):
         api.scans.export(1, filter_type='nothing')
 
 @pytest.mark.vcr()
+def test_scan_export_was_typeerror(api):
+    with pytest.raises(UnexpectedValueError):
+      api.scans.export(SCAN_ID_WITH_RESULTS, scan_type='bad-value')
+
+@pytest.mark.vcr()
+def test_scan_export_was(api):
+    api.scans.export(SCAN_ID_WITH_RESULTS, scan_type='web-app')
+
+@pytest.mark.vcr()
 def test_scan_export_bytesio(api):
     from io import BytesIO
     from tenable.reports.nessusv2 import NessusReportv2


### PR DESCRIPTION
# Description

Pass through the scan type to allow the exporting of WAS data.
Named the parameter `scan_type` to make it a little clearer than the
raw API param: https://developer.tenable.com/reference#was-scans-export-status

This is not a very abstract design, but I didn't want to touch too much.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested via unit tests locally. VCR recording included.

**Test Configuration**:
* Python Version(s) Tested: `3.8.1`

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
