### PR TITLE
tenable io timeout handling

### DIFF
--- a/tenable/base.py
+++ b/tenable/base.py
@@ -473,6 +473,10 @@ class APISession(object):
                 self._log.error('Connection Reset {}'.format(str(err)))
                 time.sleep(0.1)
                 retries += 1
+            except RequestsTimeoutError as err:
+                self._log.error('Connection Timeout {}'.format(str(err)))
+                time.sleep(0.1)
+                retries += 1
             else:
                 # If there is a Request UUID then we will want to log the UUID
                 # just incase we may need it for tracking down what happened

--- a/tenable/io/__init__.py
+++ b/tenable/io/__init__.py
@@ -269,7 +269,7 @@ class TenableIO(APISession):
 
     def __init__(self, access_key=None, secret_key=None, url=None, retries=None,
                  backoff=None, ua_identity=None, session=None, proxies=None,
-                 vendor=None, product=None, build=None):
+                 vendor=None, product=None, build=None, timeout=None):
         if access_key:
             self._access_key = access_key
         else:
@@ -291,7 +291,8 @@ class TenableIO(APISession):
             proxies=proxies,
             vendor=vendor,
             product=product,
-            build=build
+            build=build,
+            timeout=timeout
         )
 
     def _retry_request(self, response, retries, kwargs):


### PR DESCRIPTION
# Description

pyTenable hangs after a connection is established and no response is received from the server. 
The error was seen in production environments and replicated by having netcat listen to a local port.  The connection would not timeout and retry, and only keep running.

Per the Requests module, the timeout value is not set by default.

Further, the wait times between retries was increased from 0.1 seconds to 1.0 seconds, and additional logging was added to capture more errors related to requests.

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


- [ ] Issue Replication
  - [ ] In lieue of using SSL, tenable/io/__init__.py was temporarily modified to use `_url=http://cloud.tenable.com` instead of `_url=https://cloud.tenable.com`
  - [ ] /etc/hosts was modified to include:
        `127.0.0.1   cloud.tenable.com`
  - [ ] netcat listener was started to listen on port 80 and keep alive for multiple connections
        `sudo nc -C -v -l -k 80`
  - [ ] pytenable was executed using a simple script
         [test-uuid.txt](https://github.com/tenable/pyTenable/files/4298591/test-uuid.txt)
  - [ ] script failed to error and/or terminate

- [ ] Implement changes
  - [ ] check out the io_timeout_handling branch and rerun the script
      - [ ] parameter of timeout=1 (or other number) can be used to force a shorter timeout in the test script
      [test-uuid-timeout.txt](https://github.com/tenable/pyTenable/files/4298593/test-uuid-timeout.txt)
  - [ ] tailing the log file should show timeout errors and retries, resulting in an exiting of the script after five retries
      
**Test Configuration**:
* Python Version(s) Tested:  2.7.17/3.7.6
* Tenable.sc version (if necessary): n/a

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

