### PR TITLE
patch str function for UTF-8 european characters

### DIFF
--- a/examples/io/asset_export_csv_writer/csvexport.py
+++ b/examples/io/asset_export_csv_writer/csvexport.py
@@ -2,7 +2,9 @@
 from tenable.io import TenableIO
 from csv import DictWriter
 import collections, click, logging
-
+#https://www.b-list.org/weblog/2007/nov/10/unicode/
+from akismet import Akismet
+from django.utils.encoding import smart_str
 
 def flatten(d, parent_key='', sep='.'):
     '''
@@ -75,7 +77,9 @@ def export_assets_to_csv(fobj, assets, *fields):
         flat = flatten(asset)
         for k, v in flat.items():
             if isinstance(v, list):
-                flat[k] = '|'.join([str(i) for i in v])
+		flat[k] = '|'.join([smart_str(i) for i in v])
+		#utf-8 hostnames break str function 
+		#flat[k] = '|'.join([str(i) for i in v])
             if k == 'tags':
                 flat[k] = '|'.join(['{}:{}'.format(i['key'], i['value']) for i in v])
 


### PR DESCRIPTION
# Description

I have hosts in tenable with UTF-8 names which break the python2 code using str function.

Fixes # UnicodeEncodeError: 'ascii' codec can't encode character u'\ufffd' in position 42: ordinal not in range(128)

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Testing UTF-8 patch

$ /usr/local/bin/python pyTenable/examples/io/asset_export_csv_writer/csvexport.py --tio-access-key mykey1 --tio-secret-key mykey2 output
Traceback (most recent call last):
  File "pyTenable/examples/io/asset_export_csv_writer/csvexport.py", line 147, in <module>
    cli()
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "pyTenable/examples/io/asset_export_csv_writer/csvexport.py", line 142, in cli
    total = export_assets_to_csv(output, assets, *fields)
  File "pyTenable/examples/io/asset_export_csv_writer/csvexport.py", line 78, in export_assets_to_csv
    flat[k] = '|'.join([str(i) for i in v])
UnicodeEncodeError: 'ascii' codec can't encode character u'\ufffd' in position 42: ordinal not in range(128)

patch csvexport.py

rerun
/usr/local/bin/python pyTenable/examples/io/asset_export_csv_writer/csvexport.py --tio-access-key mykey1 --tio-secret-key mykey2 output
Processed 10 Assets


**Test Configuration**: mac homebrew python 
* Python Version(s) Tested: Python 2.7.16
* Tenable.sc version (if necessary): current git checkout

# Checklist:

- [ ] I used django.utils.encoding import smart_str instead of python str which breaks with utf-8 host names like are found in Europe.
