### PR TITLE
fix documentation referencing scan zones in invalid locations

### DIFF
--- a/tenable/sc/asset_lists.py
+++ b/tenable/sc/asset_lists.py
@@ -586,7 +586,7 @@ class AssetListAPI(SCEndpoint):
 
     def list(self, fields=None):
         '''
-        Retrieves the list of scan zone definitions.
+        Retrieves the list of asset list definitions.
 
         :sc-api:`asset-list: list <Asset.html#AssetRESTReference-/asset>`
 

--- a/tenable/sc/audit_files.py
+++ b/tenable/sc/audit_files.py
@@ -293,7 +293,7 @@ class AuditFileAPI(SCEndpoint):
 
     def list(self, fields=None):
         '''
-        Retrieves the list of scan zone definitions.
+        Retrieves the list of audit file definitions.
 
         :sc-api:`audit file: list <AuditFile.html#AuditFileRESTReference-/auditFile>`
 

--- a/tenable/sc/credentials.py
+++ b/tenable/sc/credentials.py
@@ -917,7 +917,7 @@ class CredentialAPI(SCEndpoint):
 
     def list(self, fields=None):
         '''
-        Retrieves the list of scan zone definitions.
+        Retrieves the list of credential definitions.
 
         + :sc-api:`credential: list <Credential.html#CredentialRESTReference-/credential>`
 

--- a/tenable/sc/groups.py
+++ b/tenable/sc/groups.py
@@ -182,7 +182,7 @@ class GroupAPI(SCEndpoint):
 
     def list(self, fields=None):
         '''
-        Retrieves the list of scan zone definitions.
+        Retrieves the list of group definitions.
 
         :sc-api:`group: list <Group.html#group_GET>`
 

--- a/tenable/sc/roles.py
+++ b/tenable/sc/roles.py
@@ -246,7 +246,7 @@ class RoleAPI(SCEndpoint):
 
         Returns:
             :obj:`dict`:
-                The newly updated scan zone.
+                The newly updated role.
 
         Examples:
             >>> role = sc.roles.create()
@@ -277,7 +277,7 @@ class RoleAPI(SCEndpoint):
 
     def list(self, fields=None):
         '''
-        Retrieves the list of scan zone definitions.
+        Retrieves the list of role definitions.
 
         :sc-api:`role: list <Role.html#role_GET>`
 
@@ -287,7 +287,7 @@ class RoleAPI(SCEndpoint):
 
         Returns:
             :obj:`list`:
-                A list of scan zone resources.
+                A list of role resources.
 
         Examples:
             >>> for role in sc.roles.list():

--- a/tenable/sc/users.py
+++ b/tenable/sc/users.py
@@ -374,7 +374,7 @@ class UserAPI(SCEndpoint):
 
     def list(self, fields=None):
         '''
-        Retrieves the list of scan zone definitions.
+        Retrieves the list of user definitions.
 
         :sc-api:`user: list <User.html#user_GET>`
 


### PR DESCRIPTION
# Description

In several places in the documentation, "scan zones" are referenced, as opposed to the object actually in question.  Updated documentation to reflect the object in question, vs "scan zones".

Fixes #217 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

No tests performed.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
