### PR TITLE
Remove integer type checking from missed scan_id

### DIFF
--- a/tenable/io/scans.py
+++ b/tenable/io/scans.py
@@ -631,8 +631,7 @@ class ScansAPI(TIOEndpoint):
 
         # The first thing that we need to do is make the request and get the
         # File id for the job.
-        fid = self._api.post('scans/{}/export'.format(
-            self._check('scan_id', scan_id, int)),
+        fid = self._api.post('scans/{}/export'.format(scan_id),
             params=params, json=payload).json()['file']
         self._api._log.debug('Initiated scan export {}'.format(fid))
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Removes type checking for scan_id that was missed in commit 8ea5d8aca31a419804161596188b2f5ca6e7e925

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Called the function to export things

**Test Configuration**:
* Python Version(s) Tested: 3.85
* Tenable.sc version (if necessary): 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
