### PR TITLE
Fix raise APIError.

### DIFF
--- a/tenable/sc/__init__.py
+++ b/tenable/sc/__init__.py
@@ -286,7 +286,7 @@ class TenableSC(APISession):
             try:
                 d = response.json()
                 if d['error_code']:
-                    raise APIError(d['error_code'], d['error_msg'])
+                    raise APIError(response)
             except ValueError:
                 pass
         return response


### PR DESCRIPTION
# Description

You pass too many arguments to APIError and code is probably never reached (due to use retry class).

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ x ] Bug fix (non-breaking change which fixes an issue)
