### PR TITLE
Add environment marker

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         'requests>=2.19',
         'python-dateutil>=2.6',
         'semver>=2.8.1',
-        'ipaddress>=1.0.22',
+        'ipaddress>=1.0.22;python_version<"3.2"',
         'restfly>=1.3.5',
         'marshmallow>=3.6',
         'python-box>=4.0',


### PR DESCRIPTION
# Description

`ipaddress` is a Python standard module > 3.2. A complete removal could be considered as well as Python 2.x adn Python 3.2 is EOL for quite some time now.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is a packaging issue. Fedora has a dependency generator for its RPM packages. During the build process all requirements are collected, thus `ipaddress` shows up.

**Test Configuration**:
* Python Version(s) Tested: 3.8.5
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
