### PR TITLE
Update docs for filtering categories

### DIFF
--- a/tenable/io/tags.py
+++ b/tenable/io/tags.py
@@ -364,7 +364,7 @@ class TagsAPI(TIOEndpoint):
         Args:
             *filters (tuple, optional):
                 A defined filter tuple consisting of the name, operator, and
-                value.  Example: ``('category_name', 'eq', 'Location')``.
+                value.  Example: ``('name', 'eq', 'Location')``.
             filter_type (str, optional):
                 If multiple filters are defined, the filter_type toggles the
                 behavior as to how these filters are used.  Either all of the
@@ -395,7 +395,7 @@ class TagsAPI(TIOEndpoint):
             Return all of the Tags of the Location category:
 
             >>> for tag in tio.tags.list_categories(
-            ...   ('category_name', 'eq', 'Location')):
+            ...   ('name', 'eq', 'Location')):
             ...     pprint(tag)
         '''
         query = self._tag_list_constructor(filters, self._filterset_categories,


### PR DESCRIPTION
# Description

A minor change that updates the docs. Previously the docs referenced a category list filter of `category_name`. This is actually a tag list filter. When trying to filter categories, the filter value is simply `name`.  See https://developer.tenable.com/reference#tags-list-tag-categories. 

Fixes # None

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?
No Code Changes

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
