### PR TITLE
Use `is not None` over `!= None`

### DIFF
--- a/tenable/io/exports.py
+++ b/tenable/io/exports.py
@@ -240,7 +240,7 @@ class ExportsAPI(TIOEndpoint):
                        'last_fixed', 'first_scan_time',
                        'last_authenticated_scan_time', 'last_assessed']:
             self._api._log.debug(f'{option}={kw.get(option)}')
-            if self._check(option, kw.get(option), int) != None:
+            if self._check(option, kw.get(option), int) is not None:
                 payload['filters'][option] = kw[option]
 
         payload['num_assets'] = str(self._check('num_assets',


### PR DESCRIPTION
# Description

A custom class could have a meaningful comparison against None that returns True for the `!=` operator. `is not` avoids this and checks type directly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Performs as expected

**Test Configuration**:
* Python Version(s) Tested: 3.8.5

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
