### PR TITLE
Bugfix 254

### DIFF
--- a/tenable/io/editor.py
+++ b/tenable/io/editor.py
@@ -93,7 +93,7 @@ class EditorAPI(TIOEndpoint):
                         })
         return resp
 
-    def parse_plugins(self, families, id, callfmt='editor/{id}/families/{fam}'):
+    def parse_plugins(self, families, id, callfmt='editor/scan/{id}/families/{fam}'):
         '''
         Walks through the plugin settings and will return the the configured
         settings for a given scan/policy

--- a/tenable/io/editor.py
+++ b/tenable/io/editor.py
@@ -93,7 +93,7 @@ class EditorAPI(TIOEndpoint):
                         })
         return resp
 
-    def parse_plugins(self, families, id, callfmt='editor/scan/{id}/families/{fam}'):
+    def parse_plugins(self, etype, families, id, callfmt='editor/{etype}/{id}/families/{fam}'):
         '''
         Walks through the plugin settings and will return the the configured
         settings for a given scan/policy
@@ -114,7 +114,7 @@ class EditorAPI(TIOEndpoint):
                 # dictionary of plugin_id:status.
                 plugins = dict()
                 plugs = self._api.get(callfmt.format(
-                    id=id, fam=families[family]['id'])).json()['plugins']
+                    etype=etype, id=id, fam=families[family]['id'])).json()['plugins']
                 for plugin in plugs:
                     plugins[plugin['id']] = plugin['status']
                 resp[family] = {
@@ -337,7 +337,7 @@ class EditorAPI(TIOEndpoint):
             # if the plugins sub-document exists, then lets walk down the
             # plugins dataset.
             obj['plugins'] = self._api.editor.parse_plugins(
-                editor['plugins']['families'], id)
+                etype, editor['plugins']['families'], id)
 
         # We next need to do a little post-parsing of the ACLs to find the
         # owner and put owner_id attribute into the appropriate location.


### PR DESCRIPTION
# Description

With this fix, it should be now be possible to:

-  successfully retrieve scan details for such scans, where only select plugins are enabled.
-  successfully retrieve policy details for such policies, where only select plugins are enabled.

This fix changes the API call https://cloud.tenable.com/editor/xxxx/families/20  to:

https://cloud.tenable.com/editor/**scan**/xxxx/families/20
Or
https://cloud.tenable.com/editor/**policy**/xxxx/families/20

Fixes (https://github.com/tenable/pyTenable/issues/254)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Created a new **_scan_** with `Advanced Network Scan` template and enabled only a limited plugins (any plugin); just disabled all plugin families and enabled a select few plugins. With the fix, I can now successfully retrieve scan details using `editor.details('scan',scan_id)`
- [x] Created a new policy using `Advanced Network Scan` template with only a limited plugins (any plugin) enabled; just disabled all plugin families and enabled a select few plugins. With the fix, I can now successfully retrieve policy details using `editor.details('policy',policy_id)`

**Test Configuration**:
* Python Version(s) Tested: 3.6.9

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules