### PR TITLE
bugfix 262: export iterator self restart

### DIFF
--- a/tenable/io/exports.py
+++ b/tenable/io/exports.py
@@ -136,8 +136,8 @@ class ExportsIterator(APIResultsIterator):
         # If we have worked through the current page of records then we should
         # query the next page of records.
         if self.page_count >= len(self.page):
-            self.page_count = 0
             self._get_page()
+            self.page_count = 0
 
         # Get the relevant record, increment the counters, and return the
         # record.


### PR DESCRIPTION
# Description
fixing `ExportsIterator` self restarts after it raises `StopIteration`.

Fixes #262 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

You can test it with:
```python
vulns_iterator = tios.vulns.exports()
all_vulns = list(vulns_iteartor)
again_all_vulns = list(vulns_iterator)  # this is now empty.
```
I'm not sure how to add tests with vcrpy, because I don't really have working env right now.
