### PR TITLE
tenableio.credentials: add upload function

### DIFF
--- a/tenable/io/credentials.py
+++ b/tenable/io/credentials.py
@@ -16,6 +16,7 @@ Methods available on ``tio.credentials``:
     .. automethod:: edit
     .. automethod:: list
     .. automethod:: types
+    .. automethod:: upload
 '''
 from tenable.utils import dict_merge
 from .base import TIOEndpoint, TIOIterator
@@ -370,3 +371,29 @@ class CredentialsAPI(TIOEndpoint):
             _resource='credentials'
         )
 
+    def upload(self, fobj):
+        '''
+        Uploads a file for use with a managed credential.
+
+        :devportal:`credentials: upload <file-upload>`
+
+        Args:
+            fobj (FileObject):
+                The file object intended to be uploaded into Tenable.io.
+
+        Returns:
+            :obj:`str`:
+                The fileuploaded attribute
+        '''
+
+        # We will attempt to discover the name of the file stored within the
+        # file object.  If the name of the file is successfully discovered, we
+        # will generate a random uuid string and append it to the name.
+        # Otherwise, we will generate a random uuid string to use instead.
+        kw = {
+            'files': {
+                'Filedata': fobj
+            }
+        }
+
+        return self._api.post('credentials/files', **kw).json()['fileuploaded']

--- a/tests/io/cassettes/test_credentials_upload.yaml
+++ b/tests/io/cassettes/test_credentials_upload.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: !!python/unicode "--24bf4db24a949d463f594df69276bbc0\r\nContent-Disposition:
+      form-data; name=\"no_enc\"\r\n\r\n0\r\n--24bf4db24a949d463f594df69276bbc0\r\nContent-Disposition:
+      form-data; name=\"Filedata\"; filename=\"7774d97e-dd27-4897-90aa-467f86e7011a\"\r\n\r\nExampleDataGoesHere\r\n--24bf4db24a949d463f594df69276bbc0--\r\n"
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['283']
+      Content-Type: [multipart/form-data; boundary=24bf4db24a949d463f594df69276bbc0]
+      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
+      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+    method: POST
+    uri: https://cloud.tenable.com/credentials/files
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWSsvMSS0tyMlPTElNUbJSMjc3N0mxNE/VTUkxMtc1sbA017U0SEzUNTEzT7Mw
+        SzU3MDRMVKoFAH+IIPM3AAAA
+    headers:
+      cache-control: [no-cache]
+      connection: [keep-alive]
+      content-encoding: [gzip]
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 06 Dec 2018 23:20:13 GMT']
+      expires: ['0']
+      pragma: ['']
+      server: [tenable.io]
+      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
+          path=/; HttpOnly]
+      strict-transport-security: [max-age=63072000; includeSubDomains]
+      transfer-encoding: [chunked]
+      vary: [accept-encoding]
+      x-content-type-options: [nosniff]
+      x-frame-options: [DENY]
+      x-gateway-site-id: [nginx-router-c-prod-us-east-2]
+      x-request-uuid: [4b6032427548b9bbb48a4224b58f4b6a]
+      x-xss-protection: [mode=block]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/io/test_credentials.py
+++ b/tests/io/test_credentials.py
@@ -264,3 +264,7 @@ def test_credentials_list(api):
         check(c, 'permission', int)
         check(c, 'user_permissions', int)
     assert count == credentials.total
+
+@pytest.mark.vcr()
+def test_credentials_upload(api):
+    api.credentials.upload('ExampleDataGoesHere')


### PR DESCRIPTION
The `upload` method allows users to upload credential files to tenable.io so they can reference it when creating or updating
managed credentials.

# Description

This adds an `upload` method to `tenableio.credentials`. The upload method uses the ["Upload credentials file"](https://developer.tenable.com/reference#credentials-file-upload) api. Users can use this method to upload credential files and reference them when creating or updating tenable.io credentials. There already exists a method to upload files to tenable.io. However, when files uploaded with this method are referenced during managed credential creation, the call fails:

```python
private_key_id = tio.files.upload(io.StringIO("secret"))
tio.credentials.create('SSH Account', 'SSH',
        auth_method='public key',
        username='user',
        private_key=private_key_id,
        escalation_account='root',
        elevate_privileges_with='sudo',
)
```

```bash
POST https://cloud.tenable.com/credentials >> 0c0409f56973e2ad8a97ee06fbdaae65:400 {"error":"Bad Request","statusCode":400,"message":["setting 'username' is required","value provided for file setting 'private_key' does not exist"]}
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/joseph.sirak/repo/pyTenable/tenable/io/credentials.py", line 136, in create
    return self._api.post('credentials', json={
  File "/Users/joseph.sirak/repo/pyTenable/tenable/base/v1.py", line 578, in post
    return self._request('POST', path, **kwargs)
  File "/Users/joseph.sirak/repo/pyTenable/tenable/base/v1.py", line 531, in _request
    raise self._error_codes[status](resp)
tenable.errors.InvalidInputError: 0c0409f56973e2ad8a97ee06fbdaae65:400 {"error":"Bad Request","statusCode":400,"message":["setting 'username' is required","value provided for file setting 'private_key' does not exist"]}
```

When files uploaded using the ["Upload credentials file"](https://developer.tenable.com/reference#credentials-file-upload) api are referenced during managed credential creation, the call succeeds. We have also tried to get around this issue by using the "Upload credentials file" api directly in our code. For some reason, the call fails with a `400` error when run on our local computer. The exact same code succeeds when run from the [Tenable API Explorer](https://developer.tenable.com/reference#credentials-file-upload) with the same credentials. However, using the tenable.io python library with the changes in this PR works:

```python
private_key_id = tio.credentials.upload(io.StringIO("secret"))
response = tio.credentials.create('SSH Account', 'SSH',
        auth_method='public key',
        username='user',
        private_key=private_key_id,
        escalation_account='root',
        elevate_privileges_with='sudo',
)
print(response)
```

```bash
50842166-47e3-481a-96b9-94a687eeef04
```

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A: Create a unit test for `tenableio.credetnials.upload`. This test is mostly copied from the `tenableio.files.upload` unit test since the two methods have the exact same definition.
- [X] Test B: Install the `pyTenable` with these changes included, run the `tenableio.credetnials.upload` method against my current tenable.io account and confirm that the file was successfully uploaded by printing out the returned value. Then, reference the returned value when creating a managed SSH credential and confirm that the managed credential is successfully created.

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
