### PR TITLE
Refactored agent exclusion create and edit method

### DIFF
--- a/tenable/io/agent_exclusions.py
+++ b/tenable/io/agent_exclusions.py
@@ -17,7 +17,7 @@ Methods available on ``tio.agent_exclusions``:
     .. automethod:: list
 '''
 from .base import TIOEndpoint
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 class AgentExclusionsAPI(TIOEndpoint):
     def create(self, name, scanner_id=1, start_time=None, end_time=None,
@@ -57,7 +57,7 @@ class AgentExclusionsAPI(TIOEndpoint):
                 The day of the month to repeat a **MONTHLY** frequency rule on.
                 The default is today.
             enabled (bool, optional):
-                Is the exclusion enabled?  The default is ``True``
+                enable/disable exclusion. The default is ``True``
 
         Returns:
             dict: Dictionary of the newly minted exclusion.
@@ -148,8 +148,10 @@ class AgentExclusionsAPI(TIOEndpoint):
             'description': self._check('description', description, str, default=''),
             'schedule': {
                 'enabled': self._check('enabled', enabled, bool, default=True),
-                'starttime': self._check('start_time', start_time, datetime).strftime('%Y-%m-%d %H:%M:%S'),
-                'endtime': self._check('end_time', end_time, datetime).strftime('%Y-%m-%d %H:%M:%S'),
+                'starttime': self._check('start_time', start_time, datetime).strftime('%Y-%m-%d %H:%M:%S')
+                    if enabled is True else datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S'),
+                'endtime': self._check('end_time', end_time, datetime).strftime('%Y-%m-%d %H:%M:%S')
+                    if enabled is True else (datetime.utcnow() + timedelta(hours=1)).strftime('%Y-%m-%d %H:%M:%S'),
                 'timezone': self._check('timezone', timezone, str,
                     choices=self._api._tz,
                     default='Etc/UTC'),

--- a/tenable/io/agent_exclusions.py
+++ b/tenable/io/agent_exclusions.py
@@ -16,6 +16,7 @@ Methods available on ``tio.agent_exclusions``:
     .. automethod:: edit
     .. automethod:: list
 '''
+from restfly.utils import dict_merge, dict_clean
 from .base import TIOEndpoint
 from datetime import date, datetime, timedelta
 
@@ -244,6 +245,8 @@ class AgentExclusionsAPI(TIOEndpoint):
                 Default values: ``['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA']``
             day_of_month (int, optional):
                 The day of the month to repeat a **MONTHLY** frequency rule on.
+            enabled (bool, optional):
+                enable/disable exclusion.
 
         Returns:
             dict: Dictionary of the newly minted exclusion.
@@ -264,41 +267,62 @@ class AgentExclusionsAPI(TIOEndpoint):
         if enabled is not None:
             payload['schedule']['enabled'] = self._check('enabled', enabled, bool)
 
-        if start_time:
-            payload['schedule']['starttime'] = self._check(
-                'start_time', start_time, datetime).strftime('%Y-%m-%d %H:%M:%S')
+        if payload['schedule']['enabled']:
+            frequency = self._check('frequency', frequency, str,
+                                    choices=['ONETIME', 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'],
+                                    default=payload['schedule']['rrules']['freq'],
+                                    case='upper')
 
-        if end_time:
-            payload['schedule']['endtime'] = self._check(
-                'end_time', end_time, datetime).strftime('%Y-%m-%d %H:%M:%S')
+            rrules = {
+                'freq': frequency,
+                'interval': payload['schedule']['rrules']['interval'],
+                'byweekday': None,
+                'bymonthday': None,
+            }
 
-        if timezone:
-            payload['schedule']['timezone'] = self._check(
-                'timezone', timezone, str, choices=self._api._tz)
+            # frequency default value is designed for weekly and monthly based on below conditions
+            # - if schedule rrules is not None and not defined in edit params,
+            #   and byweekday/bymonthday key already exist, assign old values
+            # - if schedule rrules is not None and not defined in edit params
+            #   and byweekday/bymonthday key not already exist, assign default values
+            # - if schedule rrules is not None and defined in edit params, assign new values
+            if frequency == 'WEEKLY':
+                rrules['byweekday'] = ','.join(self._check(
+                    'weekdays', weekdays, list,
+                    choices=['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'],
+                    default=payload['schedule']['rrules'].get('byweekday', '').split()
+                            or ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'],
+                    case='upper'))
+                # In the same vein as the frequency check, we're accepting
+                # case-insensitive input, comparing it to our known list of
+                # acceptable responses, then joining them all together into a
+                # comma-separated string.
 
-        if frequency:
-            payload['schedule']['rrules']['freq'] = self._check(
-                'frequency', frequency, str,
-                choices=['ONETIME', 'DAILY', 'WEEKLY', 'MONTHLY', 'YEARLY'],
-                case='upper')
+            if frequency == 'MONTHLY':
+                rrules['bymonthday'] = self._check(
+                    'day_of_month', day_of_month, int, choices=list(range(1, 32)),
+                    default=payload['schedule']['rrules'].get('bymonthday', datetime.today().day))
 
-        if interval:
-            payload['schedule']['rrules']['interval'] = self._check(
-                'interval', interval, int)
+            # update new rrules in existing payload
+            dict_merge(payload['schedule']['rrules'], rrules)
+            # remove null values from payload
+            payload = dict_clean(payload)
 
-        if weekdays:
-            payload['schedule']['rrules']['byweekday'] = ','.join(self._check(
-                'weekdays', weekdays, list,
-                choices=['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'],
-                case='upper'))
-            # In the same vein as the frequency check, we're accepting
-            # case-insensitive input, comparing it to our known list of
-            # acceptable responses, then joining them all together into a
-            # comma-separated string.
+            if start_time:
+                payload['schedule']['starttime'] = self._check(
+                    'start_time', start_time, datetime).strftime('%Y-%m-%d %H:%M:%S')
 
-        if day_of_month is not None:
-            payload['schedule']['rrules']['bymonthday'] = self._check(
-                'day_of_month', day_of_month, int, choices=list(range(1,32)))
+            if end_time:
+                payload['schedule']['endtime'] = self._check(
+                    'end_time', end_time, datetime).strftime('%Y-%m-%d %H:%M:%S')
+
+            if interval:
+                payload['schedule']['rrules']['interval'] = self._check(
+                    'interval', interval, int)
+
+            if timezone:
+                payload['schedule']['timezone'] = self._check(
+                    'timezone', timezone, str, choices=self._api._tz)
 
         # Lets check to make sure that the scanner_id  and exclusion_id are
         # integers as the API documentation requests and if we don't raise an

--- a/tests/io/cassettes/test_agentexclusions_create_daily_exclusion.yaml
+++ b/tests/io/cassettes/test_agentexclusions_create_daily_exclusion.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,175 +52,242 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:32 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [22a1e839d51ef80c42bf01f184d3f81a]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:27 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 48442919d107490c78e4115a256ec850
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:17:32", "enabled": true, "rrules": {"freq": "DAILY", "interval": 1}, "starttime":
-      "2018-12-06 23:17:32"}, "name": "682124c1-1803-487f-9cdd-5dc4dfa552ba", "description":
-      null}'
+    body: '{"name": "f5c3ca6e-bafe-4066-b112-4545652baa1c", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:34:26", "endtime": "2021-03-17
+      11:34:26", "timezone": "Etc/UTC", "rrules": {"freq": "DAILY", "interval": 1}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['237']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '235'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPPU8EIRiE/8rlrSHy8rGLdMazMLHUwurCAZsj4dgTWAsv998FY2ViN8nMM5O5
-        QnWn4LcUwFwhZN/iuUvgDDVFTtm8Y8zgbAQH0n17TMGDaWULBErpXB3gUsJHp/YPzy/vPRdzC+XT
-        JjB4IzAqv9Y8ap+au3t7feyR2mxpf8emHRe/Y51LtrbDefVxic62uOaDt63nUUmJQnMlCLgS/rN8
-        qK7Ey3DB5C0lAtn+7E2aI5cOKWomqNTzQu+d91R5J/1ileJHO170o5NEefsGdlxk/SUBAAA=
+        H4sIAAAAAAAAA3WPu07EMBBFfwW5joXHr7DpEFAgUUJBFY3tidYimyyOQ8Eq/86EBgrorLlnzh1f
+        RKIllnyueZ5EJ0QjJjwRvwYXTURPMuBA0irvZQDQ0jrrvNMBESLT65oT0xG1SQaMDAoGaXUgeRON
+        k6CsHizysE1Mx0K4N/UJK5eAB3doW+3bRoy41P40pzzk+B+zV4Fy7uBYNRfq1/MOLX0Y5/hGnNay
+        UiOWeKS0jrx9EUvFUmv+/pNWGqQyEtorUJ2xnfZ8FE3pjxx+5RjGH3kpbF529VDonbfubx+fXpnL
+        U6XygSOPQGyN2KWf87SLH2q8fnm+E9v2BQk+0VhxAQAA
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:33 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [bd853fed3be7485168c4f6f7f2b00237]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:27 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 230ad1e553df614e1119fac0eee19215
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6414
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105595
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:17:34 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [800498d6d79806604c6552eb4f0409e7]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:34:28 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - e1ae91f16fd232bf7f2a09612ca023dd
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/cassettes/test_agentexclusions_create_enabled_false_exclusion.yaml
+++ b/tests/io/cassettes/test_agentexclusions_create_enabled_false_exclusion.yaml
@@ -1,0 +1,294 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 07:51:49 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - d71a6e47d94bab30824457743b709990
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "9b379792-82a6-4dc7-995b-31d3d95594ae", "description": "", "schedule":
+      {"enabled": false, "starttime": "2021-03-17 07:51:43", "endtime": "2021-03-17
+      08:51:43", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '238'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPsVLEIBCGX8WhDiOEEEJaJ4WF2px1ZgPLyJhLTiAW3ty7u1hZaMEMw//t9y9X
+        5jG7FC8l7hsbGWvYBmekm12Usca2fGih5513hlurF66kV95qbTtAoo8jeqL9IAOEynRu4XQst74X
+        vMVBKnQhgBREu4RQm2YPhUpkL7XtjRa2YSvkMp93H0N0/zG1SgqtzUCqPeF8XCqU52Xd3TtSWtKB
+        DcvuDf2x0vSV5QKplPjzp1a0kgvFpbkTZtRy7BQthZv/Ix9+5bCsVR5gzWRPidS5ukPCDxp7eZ5O
+        j08ToXErmD5hpUfJbg2r3q99q+6puPvX0wO73b4BmRjopXQBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 07:51:49 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - ce34b538bf9178d5dd4184d098f4eb9c
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105578
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 07:51:50 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 80f59d724fbbd590cf04bf973fda1f3a
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_create_monthly_exclusion.yaml
+++ b/tests/io/cassettes/test_agentexclusions_create_monthly_exclusion.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,176 +52,243 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:36 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [ef5cf9f64f37693f74c39b55bdbc80c6]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:10 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 4557b519432cf1a55d3eb4cb402a98ec
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:17:36", "enabled": true, "rrules": {"freq": "MONTHLY", "interval": 1, "bymonthday":
-      15}, "starttime": "2018-12-06 23:17:36"}, "name": "1ad7801d-fa68-498b-b4e1-6b435203a06b",
-      "description": null}'
+    body: '{"name": "265b2cc0-400c-49de-a938-643b943284e9", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:34:10", "endtime": "2021-03-17
+      11:34:10", "timezone": "Etc/UTC", "rrules": {"freq": "MONTHLY", "interval":
+      1, "bymonthday": 15}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['257']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '255'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPPWvDMBCG/0q4WaKSLcuu1lLI0I8lHTqFk3UmAllOZbmQhvz3SqVTodsd7z33
-        8F5hHU/ktkBgrkDRZT+XERohBy4bLvqdEEb2ptXASo42kAOT00YMUircWsEp0Uehnl9fDvun93Lp
-        Y6b0iQGMZGAv8xLzyeGlrN2NQZV8LbGKHvN493Z4KMiaMeW/er1r2l994QKu+Tgvzk9+xOyXeHSY
-        qT5VSrZD0/UMxkT/RY7WMflzTcHELQQGEX98El0/COn4hHrg6n6w3CqSXFvVdo1oUWhbW5XqWkl9
-        +wbHIFLmNwEAAA==
+        H4sIAAAAAAAAA3WPPW/DIBRF/0rFbFQwYOysUaUO/VjSoZPFp4JqQwq4Uhrlv/ehDu3QbvDueefC
+        BVlXTA6nGlJEO4Q6FNXq4NQPQvfGEMwJMZhP1mE1sREPnOmJs37kbgJ624IFWjOmiDQSM2895oZr
+        rLwfsRTMa8HIqKgF2mSnWtNsVYUSOlAxSdkL2qFFlTqvyQYfzH9Mq6JEiImBKmU3b6cGlVkvybw5
+        SGveXIeKOTq7LbB9QaWqXGv4/hPpKSYMU3lDyY5xkMGjXLR/5PRXrvTyI88ZzKWpfXbvsPX4/HS4
+        f3gFMsTq8odaYEjhqs9rivVo1bkNBLp2qBV9ptjK7qq5fTns0fX6BbvXm9eFAQAA
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:37 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [d1889cb2b351999aee2e3d0b1fe953ad]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:11 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - c53bf30324708087aac056f5008564c4
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6416
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105593
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:17:38 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [14ba5e2d3489e702076e3e0370e308a3]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:34:12 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 686faa6284bf3815068576742d895dd9
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/cassettes/test_agentexclusions_create_onetime_exclusion.yaml
+++ b/tests/io/cassettes/test_agentexclusions_create_onetime_exclusion.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,175 +52,243 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:31 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [f8f557803a51e3a80e362cd5b08ea5e4]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:34 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - ff631e3bc4d8177b55f8e1a7c247dde4
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:17:31", "enabled": true, "rrules": {"freq": "ONETIME", "interval": 1}, "starttime":
-      "2018-12-06 23:17:31"}, "name": "5f587902-a533-4076-bea5-bc850055588e", "description":
-      null}'
+    body: '{"name": "5469a60b-9b32-467f-a1d1-f0de78155e54", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:34:33", "endtime": "2021-03-17
+      11:34:33", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['239']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPPW/DIBiE/0r0zqDyYWzKWnnIkHZJ5wjDaxWJ4BZwh0b574WqU6VuJ909d7ob
-        FPeGfo8I5gaYfA3XJkEwrikXlE0HxgyfjORAmm+XiB5MzTsSyLlxpYNrxo9GvTzP5+NpbsmQKuZP
-        G8HwO4Fe+rWlXjxX9/B6fmqRUm2uf+fGg5C/c42LttTLdfNhDc7WsKWLt7XluRoGLrVQnIDL+J/l
-        sbgc3rsLJu0xEkj2Z0+tSk+PTFCrpKQDm0a6oFV0cVoxppTSGvuLdnVsdfdvUCoUZycBAAA=
+        H4sIAAAAAAAAA3WPu07EMBBFfwW5joXHzyQtSkEBNEsdOfZEa5FNFtuhYJV/x6aBArrR3DPn2jfi
+        MbkYrjlsK+kJachqL1gmJXVnNZtoNwlOpTYzteCBzsyjaUEpVLLQ+x58pSecGWeOAqu0AqCW85Zq
+        KTrpOGutcIV2EW1tGr3NpQQ0qM4YbmRDFpvyeNl8mIP7j6lVwJTqdFFtEcf9WqE0Tsvm3rCkOe7Y
+        kOTO6PelXN9IyjbmHL7/xBkHygQFcwesF7IXojwKV/9HDr9yOy0/8hiLOVX1HPG9XL08D6fHp6GQ
+        Yc0YP+xSlkCOhlTt57ZW9ZDd/evpgRzHF7g+pq1zAQAA
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:31 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [91e53575e7cbf00911634dc09e3d85eb]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:34 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - f309348fae9089ac422f8b1d278ab691
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6413
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105596
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:17:32 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [f5f04bbecc23b8057d80abce07df964b]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:34:35 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 160bef9c095d46357627a0cddeb54482
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/cassettes/test_agentexclusions_create_weekly_exclusion.yaml
+++ b/tests/io/cassettes/test_agentexclusions_create_weekly_exclusion.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,176 +52,243 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:34 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [f8ac1b78491915a7ac9dc92b1ff3c74f]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:20 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - faea747ef7c61ac68cb5ae9d31645f61
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:17:34", "enabled": true, "rrules": {"freq": "WEEKLY", "interval": 1, "byweekday":
-      "MO,WE,FR"}, "starttime": "2018-12-06 23:17:34"}, "name": "4d042f12-13a1-4735-b31c-529b75b869ec",
-      "description": null}'
+    body: '{"name": "e9036fec-3394-4c2f-b774-1728aa4f4e7c", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:34:19", "endtime": "2021-03-17
+      11:34:19", "timezone": "Etc/UTC", "rrules": {"freq": "WEEKLY", "interval": 1,
+      "byweekday": "MO,WE,FR"}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['263']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '261'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WQTUvEMBCG/8oy5xSbr7ab61IvKoIoi6clTaYYzKaapsq67H93Kp4EbwPv+/DM
-        zBlm94J+iQjmDJh8CUcaQdS8q7io6nZT14a3RipglNshogdT8oIMciZuXsEx4ztR+76/uX2mYkgF
-        84eNYDiD4fSJ+OrtiRp392zfs+sHuDBYVV9TWnV9cVdPjzsi52Jz+btEsxHydwniop3L4Tj5MAZn
-        S5jSwdtCfa6V4rITWjNwGf+LPM4uh7c1BZOWGBkk++NTvlZiJCGXlleqlboaJHeVFtuh1UPXbNGt
-        x9EDGsX15Rt/dnkFPQEAAA==
+        H4sIAAAAAAAAA3WPQU/EIBCF/4rhXCJQKKXXTb2oMTGajaeGwhDJdtuVUs266X936kUPepuZ9817
+        MxfiYXYpnnKcRtIQUpDRHgErMKysAjhalkZS6USgvdaSci1qa2WQoB3SyxI90o4Hw1StKDhvqBRB
+        U6N9TT14paB2VWUt0i6B3ZI6bzOG8Ioro7WoWEEGO+fuOPkYovuP2aI4U8pItJoSdMtpg+auHyZ3
+        AFRzWqAgs3sFvwy4fSFztinn+P2TYIJTVuIPV5w1pWy4waNg9H/o/Jdu++HHPCV0njfrkOANt/Zt
+        e3v3gmAcM6R3O+CMY9ufPwAO3p6xv38o9m1x80jWgmxhn9O4BbbZXT8/7ci6fgGCnwgBiQEAAA==
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:35 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [3a8b627d33e859f40ee6b9bf1b7e0803]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:20 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - e0e6ac1e74a259ea729d16fcebeaed30
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6415
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105594
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:17:36 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [9b2278c6068f50947991d84523f341cb]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:34:21 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - d098108341c3d7e7086e4b0e43fe9eb6
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/cassettes/test_agentexclusions_create_yearly_exclusion.yaml
+++ b/tests/io/cassettes/test_agentexclusions_create_yearly_exclusion.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,175 +52,242 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:38 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [d017ace9214b114a17e52d60dc5f5172]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:04 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 72713b25dc72adb338388a4c946b0792
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:17:38", "enabled": true, "rrules": {"freq": "YEARLY", "interval": 1}, "starttime":
-      "2018-12-06 23:17:38"}, "name": "4b726e16-61b5-4ddd-9297-4bb8861a01a1", "description":
-      null}'
+    body: '{"name": "1f581a91-2696-45bd-950c-75fc12086c5f", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:34:03", "endtime": "2021-03-17
+      11:34:03", "timezone": "Etc/UTC", "rrules": {"freq": "YEARLY", "interval": 1}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['238']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '236'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPMW/DIBSE/0r0ZlB5GIPNVlXZOlXtkCkCQxQkghPAHRrlvxeqTpW6nXT33enu
-        UJazd1v0oO/gk6vh0iRwhhNFTpnaMaZR6WEC0nxjo3ega948gZwbVzp4yv7WqMP++e310IIhVZ8/
-        TQSNDwK982tNvXdfl6eP95cWKdXk+ndN7vjwu9a4aEo9XlYXTmExNazp6ExteRyFwGHi40xgyf4/
-        y/my5HDtLui0xUggmZ89YRWXHiWVaEcqnHN05rOiwtppkmgYGuwv2lMpUD2+AcIaQbQmAQAA
+        H4sIAAAAAAAAA3WQwU7EIBCGX8VwLpGhUEpvxuzNk9HDnho6TLPEbrsC9eBm313woge9TfJ/8/0D
+        V+YpYQyXHLaVDYw1bHVnKhPMugdngcvOdlzpyXOrBXKjZwQp+g71XOh9D77QOHutveg5OQKuvFPc
+        GrTc9M5anHpFDguNkVxtGr3LpQQ60NYYqVTDFpfyeN58mAP+x9QqEFpbWVRbpHG/VCiN07LhG5U0
+        x50alvBEfl/K9pWl7GLO4ftNUkjgouVg7kAMrRpEW46i1f+Rw6/cTcuPPMZiTlU9R3ovW8fDw/PT
+        sYBhzRQ/3FJ/j90aVq2f21rNh4z3ry+P7Hb7AmnElQhyAQAA
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:17:39 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [443a25a2b99385680b53a534cb41de3f]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:34:04 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 414a6d2394d2e03126b412392e712689
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6417
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105592
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:17:40 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-d-prod-us-east-2]
-      x-request-uuid: [506ef6bd4aa279f9e510611b8951e821]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:34:05 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - fd8bc43f916e749d0dd07e842eb11ffb
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_dayofmonth_typerror.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_dayofmonth_typerror.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,213 +52,304 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:06 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [6f87b0e42346686ec541a66d117d5520]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:22 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 1b3f3741e7aedfae1a6cd8d845210a22
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:27:06", "enabled": true, "rrules": {"freq": "ONETIME", "interval": 1}, "starttime":
-      "2018-12-06 23:27:06"}, "name": "46fed5a3-e6b1-400c-ad9e-69ecfb9591e7", "description":
-      null}'
+    body: '{"name": "67e5c5be-acbb-45ed-ad3c-25c5124234e1", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:33:21", "endtime": "2021-03-17
+      11:33:21", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['239']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPMW/DIBSE/0r0ZqMCxmCzVh4ytF3SOcLwrCAR3ADu0Cj/vVB1qtTtpLvvTneH
-        bC/o9oCg74DRFX+tEjhlI2GcUHWgVHOlqYSu+mYJ6ECXtGMHKVUuN3BNeKvU2+t8Or7MNeljwfRp
-        Amj26KCVfm2xFc/FPr2fnmskF5PK3zl54P3vXOWCyeV83ZxfvTXFb/HsTKl5NgjB+nHkqgOb8D/L
-        YbbJfzQXdNxD6CCanz0hV3SD6QnKhRFBqSXGTUjkhHZdpmFiqNqLelUKoR7f79SUHicBAAA=
+        H4sIAAAAAAAAA3WPsU7EMAyGXwVlbkSTNE3bFXVgAJZjrpzE1UX02iNJGTj13XFYYIDN8v/5++Ub
+        85hcDNcctpUNjFVshQvS1BrUTlvk4KzljUbPwSvHJW2FbKRqUBC978ETDXOjOqtbbqTpeWPR8s51
+        wOfZ+g4NQiuBaBcRStPkIVOJaIXujZG1rNgCKU+XzYc5uP+YUiVqrfuaVFvEab8WKE122dwbUprj
+        jhVL7ox+X+j6xlKGmHP4/okkgteKC3Mn6kGpQZYXcPV/5OJXDnb5kcdI5lTUc8R3unp5Hk+PTyOR
+        Yc0YP2ChpWBHxYr2c1uLeszu/vX0wI7jCwyNVs9zAQAA
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:07 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [38a5c3ce0cdffa717c5011990a3789aa]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:23 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 32b7afa29f08efd99876d1ffb7d92f10
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6447
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105590
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPMW/DIBSE/0r0ZqMCxmCzVh4ytF3SOcLwrCAR3ADu0Cj/vVB1qtTtpLvvTneH
-        bC/o9oCg74DRFX+tEjhlI2GcUHWgVHOlqYSu+mYJ6ECXtGMHKVUuN3BNeKvU2+t8Or7MNeljwfRp
-        Amj26KCVfm2xFc/FPr2fnmskF5PK3zl54P3vXOWCyeV83ZxfvTXFb/HsTKl5NgjB+nHkqgOb8D/L
-        YbbJfzQXdNxD6CCanz0hV3SD6QnKhRFBqSXGTUjkhHZdpmFiqNqLelUKoR7f79SUHicBAAA=
+        H4sIAAAAAAAAA3WPsU7EMAyGXwVlbkSTNE3bFXVgAJZjrpzE1UX02iNJGTj13XFYYIDN8v/5++Ub
+        85hcDNcctpUNjFVshQvS1BrUTlvk4KzljUbPwSvHJW2FbKRqUBC978ETDXOjOqtbbqTpeWPR8s51
+        wOfZ+g4NQiuBaBcRStPkIVOJaIXujZG1rNgCKU+XzYc5uP+YUiVqrfuaVFvEab8WKE122dwbUprj
+        jhVL7ox+X+j6xlKGmHP4/okkgteKC3Mn6kGpQZYXcPV/5OJXDnb5kcdI5lTUc8R3unp5Hk+PTyOR
+        Yc0YP2ChpWBHxYr2c1uLeszu/vX0wI7jCwyNVs9zAQAA
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:08 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [90fa3d29273c28652b7ec0256447b141]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:23 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 6e707f09936b3bb74c3762335c403e62
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6447
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105590
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:27:09 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [044434d151d794146c68239de14b5de5]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:33:25 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 08a22856c5daf336438c430f78424c08
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_dayofmonth_unexpectedvalue.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_dayofmonth_unexpectedvalue.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,213 +52,304 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:09 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [e471d910286b92e52b6790682540e122]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:30 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 9cf8a535be7b112afecaa3cabbf60ccb
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:27:09", "enabled": true, "rrules": {"freq": "ONETIME", "interval": 1}, "starttime":
-      "2018-12-06 23:27:09"}, "name": "44a6194d-46cd-475d-a7cc-74c1e007617f", "description":
-      null}'
+    body: '{"name": "874a9a45-4223-4ec8-b082-d4817969cd8e", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:33:30", "endtime": "2021-03-17
+      11:33:30", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['239']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPsW4DIRBEf8XaGhS4w3Cmja5w4aRxaovAnoKEuQS4FLH871miVJHSrFaaeTOa
-        G1T/hmFLCPYGmEOLV3phEHLicuDC7ISwg7HiAIx095owgG1lQwalEFc7uBT8IOr5aT4fTzM5Y25Y
-        Pl0CK+8MeujXmnvw3PzDy/mRLLW50v7W6d0w/tYRl1xtl+sa4hK9a3HNl+Aa+eVeKTlO0ygY+IL/
-        SQGrL/G9q2DzlhKD7H76lHJaHlTgSns6Zh+4M95zo7xEIYyWZukraKpWarp/AyglIEgnAQAA
+        H4sIAAAAAAAAA3WPsVLEIBRFf8WhDiOPQIC0TgoLtVnrzAuQWcZsshJi4U7+3RcbLbRjuOeeCzcW
+        4upzupa0zKxlrGIzXiKdrFHoUGmupKy5it7yQVjJg7JgXON8sJHobUuB6MGBgMEYjo2kilXInacy
+        6rFBjRJ1A0T7HPFY6gMWGoEGtDNGgqjYhGvpL0tIY/L/MccUCK0dkGrJsd+uB7T2w7T4t0hpyVus
+        2OrPMWwTtW9sLZhLSd9/kkICFzUHcweireu2FvSoOIc/cviV4zD9yHMm83qoxxzfqfXy3J0enzoi
+        01xi/sCJLoHtFTu0n8t8qLvi719PD2zfvwD1lZn1cwEAAA==
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:10 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [8b9eb861c630614133dc952a1b76eb60]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:31 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - ef975fb993572a2f7c4b10a8d21f8f27
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6448
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105591
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPsW4DIRBEf8XaGhS4w3Cmja5w4aRxaovAnoKEuQS4FLH871miVJHSrFaaeTOa
-        G1T/hmFLCPYGmEOLV3phEHLicuDC7ISwg7HiAIx095owgG1lQwalEFc7uBT8IOr5aT4fTzM5Y25Y
-        Pl0CK+8MeujXmnvw3PzDy/mRLLW50v7W6d0w/tYRl1xtl+sa4hK9a3HNl+Aa+eVeKTlO0ygY+IL/
-        SQGrL/G9q2DzlhKD7H76lHJaHlTgSns6Zh+4M95zo7xEIYyWZukraKpWarp/AyglIEgnAQAA
+        H4sIAAAAAAAAA3WPsVLEIBRFf8WhDiOPQIC0TgoLtVnrzAuQWcZsshJi4U7+3RcbLbRjuOeeCzcW
+        4upzupa0zKxlrGIzXiKdrFHoUGmupKy5it7yQVjJg7JgXON8sJHobUuB6MGBgMEYjo2kilXInacy
+        6rFBjRJ1A0T7HPFY6gMWGoEGtDNGgqjYhGvpL0tIY/L/MccUCK0dkGrJsd+uB7T2w7T4t0hpyVus
+        2OrPMWwTtW9sLZhLSd9/kkICFzUHcweireu2FvSoOIc/cviV4zD9yHMm83qoxxzfqfXy3J0enzoi
+        01xi/sCJLoHtFTu0n8t8qLvi719PD2zfvwD1lZn1cwEAAA==
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:11 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [d5f1df3bc1b95abe47bc88003e8cba62]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:31 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - df886d0ebc0356aa03ca7dba5128cf80
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6448
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105591
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:27:12 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [49ed21a4c5b8f7d5e6be0e98a058a27d]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:33:32 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 36043f6f7f9e8262b9d48d0f1b4103d8
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_enable_exclusion.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_enable_exclusion.yaml
@@ -1,0 +1,424 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:25:53 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - f5119b43cd40021d1dbf177c19ee000b
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "413bca99-daa4-404c-86e1-fb40ceaabdbe", "description": "", "schedule":
+      {"enabled": false, "starttime": "2021-03-17 08:25:52", "endtime": "2021-03-17
+      09:25:52", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '238'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPsVLEIBCGX8WhDiMEyIW0TgoLtTnrzAKbkTGXnEAsvMm7u1hZaLez/7ffDzcW
+        MPsUryVuKxsYa9gKF6RJS+U8WMsDgOZaaM/7DiWfnRYeAVxwSPS+x0C08iGYvlfcBuW4RhO4Ra25
+        mkXbWn8yzgqifUKoTVOAQiWyk8Z21hjVsAVymS5biHP0/zG1SgpjekGqLeG0XyuUJ7ds/h0pLWnH
+        hmX/hmFf6PrGcoFUSvz5UytayYXi8nQn+qE1g2npUbiGP3L7Kwe3VPkMSyZ7SqTO1T0n/KCzl+fx
+        /Pg0EhrXgukTFlpKdjSser+2tbrH4u9fzw/sOL4BH7Hf/3QBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:25:53 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 7a4251723fb34103cc27ce8913b8aafa
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105580
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPsVLEIBCGX8WhDiMEyIW0TgoLtTnrzAKbkTGXnEAsvMm7u1hZaLez/7ffDzcW
+        MPsUryVuKxsYa9gKF6RJS+U8WMsDgOZaaM/7DiWfnRYeAVxwSPS+x0C08iGYvlfcBuW4RhO4Ra25
+        mkXbWn8yzgqifUKoTVOAQiWyk8Z21hjVsAVymS5biHP0/zG1SgpjekGqLeG0XyuUJ7ds/h0pLWnH
+        hmX/hmFf6PrGcoFUSvz5UytayYXi8nQn+qE1g2npUbiGP3L7Kwe3VPkMSyZ7SqTO1T0n/KCzl+fx
+        /Pg0EhrXgukTFlpKdjSser+2tbrH4u9fzw/sOL4BH7Hf/3QBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:25:54 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 0880f1df6e736a127878d3a4f3920c11
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "413bca99-daa4-404c-86e1-fb40ceaabdbe", "uuid":
+      "3cdd5883-9d3b-4e5d-9e44-3f0229c75b90", "creation_date": 1615969553, "last_modification_date":
+      1615969553, "id": 105580, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:25:53", "endtime": "2021-03-17 09:25:53", "enabled": true, "rrules":
+      {"freq": "ONETIME", "interval": "1"}, "timezone": "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '398'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105580
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22PsW7DIBCGX6ViNioYSIzXykOHtks6WwecFVTHTgF3aOR379GlHbKd7v/u++HG
+        Amaf4rXEdWE9Yw1b4II0aamcB2t5ANBcC+15d0DJJ6eFRwAXHBK9bTEQrXwIpusUt0E5rtEEblFr
+        ribRttYfjbOCaJ8QatMYoFCJPEhjD9YY1bAZchkva4hT9HcZ07BaJYUxnSDVmnDcrhXKo5tX/4GU
+        lrRhw7I/Y9hmur6xXCCVEn//1IpWcqG4PD6Irm9NbxQ9CpdwJ7f/cnDznzwlMueqnhJ+0tXb63B6
+        fhmIjEvB9AUzLSXbG1a13+tS1UPxj++nJ7bvP1smMnxzAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:25:55 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - df817635637f5a0566f8477790a245ad
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105580
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 08:25:56 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 1dbe757ba49b9cf63b1dd23d0d96c3bc
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_daily.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_daily.yaml
@@ -1,0 +1,424 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:25:41 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 81b0ae28597af7861a7a58d0b7ed9bb0
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "e013c69c-ebce-442f-84fd-c16cfb574156", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 08:25:40", "endtime": "2021-03-17
+      09:25:40", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPu07EMBBFfwW5joUdP/JoUQoKoFnqyI+x1iKbLLZDwSr/zpgGCuhGc8+ca9+I
+        h+xSvJa4rWQkpCGruQBOwLhwenAUrAMqZRtoL4OnjmsXrOokVxrpfY8eaRGY1sYIqhlYKk3X0V5o
+        oN0QWqGFNd4EpF0CU5tmbwqWcM3VoAcleUMWk8t82XwM0f3H1CrOlOoGVG0J5v1aoTzbZXNvgGlJ
+        OzQkuzP4fcHrG8nFpFLi959a1nLKBOXdHevHVo2S4aNg9X/kw6/c2OVHnhKac1WHBO949fI8nR6f
+        JiTjWiB9mAWXnBwNqdrPba3qqbj719MDOY4vsbt9+HMBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:25:41 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 08bb51bf50989093c9220de9eca1ba3e
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105579
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPu07EMBBFfwW5joUdP/JoUQoKoFnqyI+x1iKbLLZDwSr/zpgGCuhGc8+ca9+I
+        h+xSvJa4rWQkpCGruQBOwLhwenAUrAMqZRtoL4OnjmsXrOokVxrpfY8eaRGY1sYIqhlYKk3X0V5o
+        oN0QWqGFNd4EpF0CU5tmbwqWcM3VoAcleUMWk8t82XwM0f3H1CrOlOoGVG0J5v1aoTzbZXNvgGlJ
+        OzQkuzP4fcHrG8nFpFLi959a1nLKBOXdHevHVo2S4aNg9X/kw6/c2OVHnhKac1WHBO949fI8nR6f
+        JiTjWiB9mAWXnBwNqdrPba3qqbj719MDOY4vsbt9+HMBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:25:42 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - ffba87017a6c262fc333b2dca02d49ae
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "9833ad85-2692-43c4-a4ab-5037f0364613", "uuid":
+      "3f066aa3-60eb-4a77-836e-79f2363badaf", "creation_date": 1615969541, "last_modification_date":
+      1615969541, "id": 105579, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:25:40", "endtime": "2021-03-17 09:25:40", "enabled": true, "rrules":
+      {"freq": "DAILY", "interval": 2}, "timezone": "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '394'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105579
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22Pu07EMBBFfwW5joXtsZ04HQIKJEooqKKJH8Iimyy2Q8Eq/45NA8V2I90z585c
+        iPPZpngucVvJSEhHVjz5OpkBAN2gqNBGUAlWUpQ4U8WgDwy01Bwqve/RVRoC0xoRqGZ+phL7ng6g
+        Pe1NEKBhRoeh0jZ5bE2Tw1JLuObKaKMk78iCuUynzcUQ7VUGOtKqOFOqN1W1JT/t5wblaV42++Fr
+        WtLuO5Ltu3f7UrcvJBdMpcTfnwQTnDKgvL9hwyjUKFk9yq/uSm7+5Tgvf/KUqjk3dUj+s2493D09
+        v1UursWnL1yaiBwdadLvbW3ix2JvX1/uyXH8ABG0RSxxAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:25:43 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - d554ae82b4c5df8930843927139bf13b
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105579
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 08:25:44 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - fcb77e8a4079be96ba164f0232154438
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_monthly_valassigned.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_monthly_valassigned.yaml
@@ -1,0 +1,424 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:43 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 7d57a5688db12f9b52cfdfd14cf9fdd7
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "f5a71fb1-25ab-412b-a45d-c16bb48bc0f1", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 08:26:43", "endtime": "2021-03-17
+      09:26:43", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPPVPEIBCG/4pDHUYgQD5aJ4WF2px1huVjjjGXnEAsvMl/d7HRQrudfZ99XrgR
+        57NN8VritpKRkIas5uJxCsp0PACnQhmgkgugRipHLdcAsgfLAkd636NDWnfBdhYkBdtpKjunKUgZ
+        qB4YtAMaeiOQtsmb2jQ7U7CEa64GPWjWNmQxucyXzcUQ7X9MreJMqV6hakt+3q8VyjMsm33zmJa0
+        +4Zke/ZuX/D6RnIxqZT4/SfBBKespby7Y/0o9ChbfJRf3R/58Cs3sPzIU0JzruqQ/DtevTxPp8en
+        Ccm4Fp8+zIJLTo6GVO3ntlb1VOz96+mBHMcXCMqh2HMBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:43 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 6a38246d29a6a701eed5d789643e34c2
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105585
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPPVPEIBCG/4pDHUYgQD5aJ4WF2px1huVjjjGXnEAsvMl/d7HRQrudfZ99XrgR
+        57NN8VritpKRkIas5uJxCsp0PACnQhmgkgugRipHLdcAsgfLAkd636NDWnfBdhYkBdtpKjunKUgZ
+        qB4YtAMaeiOQtsmb2jQ7U7CEa64GPWjWNmQxucyXzcUQ7X9MreJMqV6hakt+3q8VyjMsm33zmJa0
+        +4Zke/ZuX/D6RnIxqZT4/SfBBKespby7Y/0o9ChbfJRf3R/58Cs3sPzIU0JzruqQ/DtevTxPp8en
+        Ccm4Fp8+zIJLTo6GVO3ntlb1VOz96+mBHMcXCMqh2HMBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:44 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 9b55255ec4945efe1f9c5879d0778be5
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "5675ab88-c3bf-46d5-85c0-caadaf9e6665", "uuid":
+      "67fc7cb4-bc76-47d6-b44f-690b395ab8a2", "creation_date": 1615969603, "last_modification_date":
+      1615969603, "id": 105585, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:26:43", "endtime": "2021-03-17 09:26:43", "enabled": true, "rrules":
+      {"freq": "MONTHLY", "interval": 2, "bymonthday": 8}, "timezone": "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '413'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105585
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22Pu27EIBBFfyWiNgp+MH60q0gp8mg2RSprGLAWxY8NxpE2K/97hjRJsd3APXMu
+        XIV1KwV/jn6ZRSdEJmacHE8aao2maSSVZpAVWC0bTUoSosWhdQCgmd42b5mGeqCaTCUN1SCr2oI0
+        VTVIaJUp2yTCgmkKDlNTbzFySQ65bqEFVWZixDX202L94OkmozORqnKldcMzLcH12zlBa2/GhT4c
+        pzFsLhMrnZzdRt6+ijViiNH//qlQRS5VKfP6TjVdAV1V8qPcbG/k7b8czfgnD4HNa1IPwX3y1vPr
+        y/Hx6Z1JP0cXvnBMKj6ay7TM8WTxwheN2DORer6XOXU9RLp/Ox7Evv8ACx1LqYQBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:45 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - d35ce02f507d77b2688955e7333af05f
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105585
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 08:26:46 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 94f37ac24194724bbe7f59dae129fdc5
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_monthly_valavailable.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_monthly_valavailable.yaml
@@ -1,0 +1,424 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:28:52 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 9b8df97c02c4e50f21e426f0193b07c5
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "b73f3f9f-7a6e-4855-af02-e08405fb2a04", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 08:28:52", "endtime": "2021-03-17
+      09:28:52", "timezone": "Etc/UTC", "rrules": {"freq": "MONTHLY", "interval":
+      1, "bymonthday": 8}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '254'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPPW/DIBCG/0rFbFTAxoDXqFKHfizp0Mk6zKGgOnaKcaU0yn/vuUs7tBvc+9z7
+        wIUFXIacTiXNE+sYq9gER6STN3Wso4vcQIu8sVpziEJxFLYROnoFoiF6XVMgWkmtRBQNN1ZH3mgv
+        uEMHvDWNt96AcNASPWSEzdQHKCSRrdSudaZWFRthKf1xDimm4T9mU0mhtW2pas7Yr6cNWno/zsMb
+        UlryihVbhgOGdaTtC1sK5FLS95+UUJKLmktzI2ynbKcVPQqn8EfufuXgx5/ynKl52apjxnfaenx+
+        2t8/vBKZpoL5A0YaSrr683GeyiHAmQaWXSu2eT7naXPdleH2Zb9j1+sXygA8o4QBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:28:52 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 8aad9f20d91b28c30a45ae9a522e11fb
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105586
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPPW/DIBCG/0rFbFTAxoDXqFKHfizp0Mk6zKGgOnaKcaU0yn/vuUs7tBvc+9z7
+        wIUFXIacTiXNE+sYq9gER6STN3Wso4vcQIu8sVpziEJxFLYROnoFoiF6XVMgWkmtRBQNN1ZH3mgv
+        uEMHvDWNt96AcNASPWSEzdQHKCSRrdSudaZWFRthKf1xDimm4T9mU0mhtW2pas7Yr6cNWno/zsMb
+        UlryihVbhgOGdaTtC1sK5FLS95+UUJKLmktzI2ynbKcVPQqn8EfufuXgx5/ynKl52apjxnfaenx+
+        2t8/vBKZpoL5A0YaSrr683GeyiHAmQaWXSu2eT7naXPdleH2Zb9j1+sXygA8o4QBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:28:53 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - e09e5a72912a599380c293fbd60ccdd4
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "b73f3f9f-7a6e-4855-af02-e08405fb2a04", "uuid":
+      "21520f04-785f-45b0-9e9a-674b8b7a09a6", "creation_date": 1615969732, "last_modification_date":
+      1615969732, "id": 105586, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:28:52", "endtime": "2021-03-17 09:28:52", "enabled": true, "rrules":
+      {"freq": "MONTHLY", "interval": 2, "bymonthday": "8"}, "timezone": "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '415'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105586
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22PPW/DIBCG/0rFbFSMwUDWqlKHfizp0Mk6zKGgOnaKcaU0yn/v0aUdugHvc897
+        XFjAdczpVNIysx1jDZvhiHTypotddJEb6JErqzWHKCRHYZXQ0UsQiuhtS4Fo2WopolDcWB250l5w
+        hw54b5S33oBw0BM9ZoTaNAQoVNL2rXa9M51s2ARrGY5LSDGN/zKqYbWqFVrbnlRLxmE7VWgd/LSM
+        70hpyRs2bB0PGLaJpi9sLZBLST9/kkK2XHS8NTfC7qTdaUlL4Rz+yd2fHPz0K8+ZzGtVx4wfNPX0
+        8rx/eHwjMs0F8ydMVUVXfz4uczkEONODZdeG1Z6vZa5d92W8fd3fsev1G/m0D2KEAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:28:55 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 97c0c75b3f1c93f58d1b5057128ba363
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105586
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 08:28:56 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-60nni-ap-southeast-1-prod
+      X-Request-Uuid:
+      - dbf59037b7504f23c2e9e9804857ec46
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_monthly_valddefault.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_monthly_valddefault.yaml
@@ -1,0 +1,424 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:32 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 28d73025ed836ce273515dd19ac61f9d
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "01ed8af9-a93c-4946-8a39-00a7bb62e9b5", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 08:26:32", "endtime": "2021-03-17
+      09:26:32", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPsVLEIBCGX8WhDiMkgYS0TgoLtTnrzALLHGMuOYFYeJN3d2OjhXY7+3/7/XBj
+        HrNL8VriurCBsYotcEGahETfQzAcTON4a1rNe2gMFwI6a3WNxiqity16ogNIH7zoeKsN0Rod72uj
+        OCJqIWywrQaiXUI4miYPhUqklspoo0xTsRlymS6rjyG6/5ijSgql+pZUa8Jpux5Qnuy8ujektKQN
+        K5bdGf020/WN5QKplPj9p1rUkouGy+5O9EOth6amR+Hi/8jNrxzs/CNPicz5UIeE73T18jyeHp9G
+        IuNSMH3ATEvJ9ood2s91OdRjcfevpwe2719saID3cwEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:33 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - c168f708742867d0644e10f47c7bbc18
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105584
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPsVLEIBCGX8WhDiMkgYS0TgoLtTnrzALLHGMuOYFYeJN3d2OjhXY7+3/7/XBj
+        HrNL8VriurCBsYotcEGahETfQzAcTON4a1rNe2gMFwI6a3WNxiqity16ogNIH7zoeKsN0Rod72uj
+        OCJqIWywrQaiXUI4miYPhUqklspoo0xTsRlymS6rjyG6/5ijSgql+pZUa8Jpux5Qnuy8ujektKQN
+        K5bdGf020/WN5QKplPj9p1rUkouGy+5O9EOth6amR+Hi/8jNrxzs/CNPicz5UIeE73T18jyeHp9G
+        IuNSMH3ATEvJ9ood2s91OdRjcfevpwe2719saID3cwEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:34 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 6cdc439b386232ba0193ec6fdcedf71a
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "bc721cb9-833e-4d2d-ae2c-c191febaf338", "uuid":
+      "fa1dfd07-469c-46ec-8295-eee600bfb46a", "creation_date": 1615969593, "last_modification_date":
+      1615969593, "id": 105584, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:26:32", "endtime": "2021-03-17 09:26:32", "enabled": true, "rrules":
+      {"freq": "MONTHLY", "interval": 2, "bymonthday": 17}, "timezone": "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '414'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105584
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22PuW7EIBRFfyWiNgqLjY3bUaQUWZpJkcpieWhQvEwwjjQZ+d/zSJMU0yDgnncu
+        XImH1aV4znGZSU9IRWYzAe6sawV3VtNOSqC1F54aEI46rnkAa4KUHdLbFj3SwXAfPGtprbTDBRzt
+        hG4oACjGbLC1Mki7BKY0Dd5kLOGKN1rpRsuKjGbNw7T4GKK7yTQVKVWcNU1Xo2pJMGznAq2DHRf3
+        AZjmtEFFVncCv404fSVrNinn+PsnwQSnTFLe3rGuF6qXAh8Fs7+R63+5seOfPCU0r0UdEnzi1PPr
+        y/Hx6R3JOGdIX2YsKjzay7TM+eTNBS94S/aKlKLvZS5lD9ndvx0PZN9/AApCpceFAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:35 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 0db8e92dca66c896cd097d7c4aff4a30
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105584
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 08:26:36 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 5a3b43b088dba94d6e63396a528f7448
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_yearly.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_freq_onetime_to_yearly.yaml
@@ -1,0 +1,424 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:29:11 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 28ee6176e4b7e5006b3d3af747c11ead
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "f43ba78d-8a81-4014-9316-0600cdae35a3", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 08:29:10", "endtime": "2021-03-17
+      09:29:10", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPvW7DIBRGX6ViNioY85e18pCh7ZLO1jVgBdWxE8AdGvnde+nSDu2C0P3OPR/c
+        iQ/ZpXgtcV3IgZCGLHAJeJs6MYI2nhownHaMd9QKrihTjDkPQUgQSG9b9EgzrUEJ0VJttaYdyJEa
+        hQeTouWj0ExahbRLAWrT4KFgCVcc51ZL3pAZchkuq49TdP8xtYozKY1G1ZrCsF0rlIdxXt17wLSk
+        LTQku3Pw24zbd5ILpFLi959a1nLKBOX6gZlDa1GGjwqL/yO3v3IY5x95SmjOVT2lcMOt15f+dHzu
+        kYxLCekDZhxysjekaj/Xpar74h7fTk9k378A3FtX9nMBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:29:11 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 26f9fc1ed2c07edf36f0608d6ab045d2
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105587
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPvW7DIBRGX6ViNioY85e18pCh7ZLO1jVgBdWxE8AdGvnde+nSDu2C0P3OPR/c
+        iQ/ZpXgtcV3IgZCGLHAJeJs6MYI2nhownHaMd9QKrihTjDkPQUgQSG9b9EgzrUEJ0VJttaYdyJEa
+        hQeTouWj0ExahbRLAWrT4KFgCVcc51ZL3pAZchkuq49TdP8xtYozKY1G1ZrCsF0rlIdxXt17wLSk
+        LTQku3Pw24zbd5ILpFLi959a1nLKBOX6gZlDa1GGjwqL/yO3v3IY5x95SmjOVT2lcMOt15f+dHzu
+        kYxLCekDZhxysjekaj/Xpar74h7fTk9k378A3FtX9nMBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:29:12 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - cc6e127125ec6d19d762265eb9e1871f
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "e2daa349-2546-41b2-92fc-2140d2f3d4d1", "uuid":
+      "077a6332-7977-4a5b-865b-05321b370596", "creation_date": 1615969751, "last_modification_date":
+      1615969751, "id": 105587, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:29:10", "endtime": "2021-03-17 09:29:10", "enabled": true, "rrules":
+      {"freq": "YEARLY", "interval": 2}, "timezone": "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '395'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105587
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22PvW7DIBRGX6W6s1H5x2SrqmydqnbIZGHACqpjp4A7NPK799KlHbIgxHfu+S43
+        CLH4nK41rQscADpY3CXiLfLgnJCWcCU1kWzkxPLJE84kDXwSQQaG9LalgDQ1xmkhODHWGCKdGkmv
+        8aBKcDYKQ5XVSPscXWsagqtYwjTDd2sU62B2pQ6XNaQp+buM6KBVMapUb1C15jhs1waVYZxX/xEx
+        rXmLHRR/jmGbcfoGpbpca/r9E6ecESoIMw+0P3CLMlwqLuFObv/lbpz/5DmjuTT1lOMnTp2OT68v
+        JwTTUmP+cnMzwd5Bs36vSzMfq398f3uGff8BfZH6NHIBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:29:13 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 205035c911957ccbae492652e69370cf
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105587
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 08:29:14 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - e42ff1fbacaeedcd22128eccd7d602d1
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_onetime_to_weekly_valassigned.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_onetime_to_weekly_valassigned.yaml
@@ -1,0 +1,424 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:13 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 3461b0a68ae9905f8a96d3e2ac6d037a
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "6b42426a-00b8-449d-98de-298ef1e030b8", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 08:26:11", "endtime": "2021-03-17
+      09:26:11", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPPVPEIBCG/4pDHUYgQEJaJ4WF2px1ho/NHGMuOYFYeJP/7mKjhXbMvs/77HIj
+        AbJP8VritpKBkIas9gL40k4KKbSljLmeSmkCNX0AKkwPMwfW4hjpfY8BaWGFYrPkVAsGVDrrqOVK
+        U4dFr71qnemQ9gls3TQFW3AJ11wZbVTXNmSxuUyXLcQ5+v+YuoozpXqBqi3BtF8rlCe3bP4NMC1p
+        h4Zkf4awL9i+kVxsKiV+/0kwwSlrKe/uWD8IPXCOR8Ea/sjNr9y65UeeEppzVc8J3rH18jyeHp9G
+        JONaIH3YBYecHA2p2s9treqx+PvX0wM5ji+hF2ytcwEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:13 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 9852434870d11bb5a7d19d3c5b505e41
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105582
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPPVPEIBCG/4pDHUYgQEJaJ4WF2px1ho/NHGMuOYFYeJP/7mKjhXbMvs/77HIj
+        AbJP8VritpKBkIas9gL40k4KKbSljLmeSmkCNX0AKkwPMwfW4hjpfY8BaWGFYrPkVAsGVDrrqOVK
+        U4dFr71qnemQ9gls3TQFW3AJ11wZbVTXNmSxuUyXLcQ5+v+YuoozpXqBqi3BtF8rlCe3bP4NMC1p
+        h4Zkf4awL9i+kVxsKiV+/0kwwSlrKe/uWD8IPXCOR8Ea/sjNr9y65UeeEppzVc8J3rH18jyeHp9G
+        JONaIH3YBYecHA2p2s9treqx+PvX0wM5ji+hF2ytcwEAAA==
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:14 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 86a921ea450f907a3332188da8163652
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "6b42426a-00b8-449d-98de-298ef1e030b8", "uuid":
+      "2a250f41-620e-4bab-a156-b449c6c53b97", "creation_date": 1615969573, "last_modification_date":
+      1615969573, "id": 105582, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:26:11", "endtime": "2021-03-17 09:26:11", "enabled": true, "rrules":
+      {"freq": "WEEKLY", "interval": "1", "byweekday": "MO,TU"}, "timezone": "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '419'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105582
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22PzU7DMBCEXwX5HAvbsd04V5QTIC6tEKfIPxthNU2K44BKlXdnzQUOve3ufDNj
+        X0mAxad4znGeSEtIRSZ7Apy0k0IKbSljrqFSmkBNE4AK08DAgdV4RnpdY0BaWKHYIDnVggGVzjpq
+        udLUodFrr2pndkj7BLY09cFmLOGaK6ON2tUVGe2S+9Mc4hD9TUZVpFRxplQjMGpO0K/nAi29G2d/
+        BFRzWqEii3+HsI7ovpIl25Rz/P2TYIJTVlO+u2NNK3TLOT4KpnBDN/9068a/8JQweSnRQ4IPdL12
+        3ePTG4JxypA+7Yi34nOXL4BjsBfcn1+q/YFsFSlN3/NU2rrs7w/7B7JtP/J0qOSGAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:15 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 5a0f1efc8aee876a96d298b387a8ae45
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105582
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 08:26:16 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - f60d668e4c7c7ff8e1602d3e4b9bedb9
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_onetime_to_weekly_valavailable.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_onetime_to_weekly_valavailable.yaml
@@ -1,0 +1,372 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:23 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - ebf852e41ad3880b4f4c2af7dceff5af
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "e68b5c71-c3ba-4c3a-ac0e-ab53bbe2f1fe", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 08:26:22", "endtime": "2021-03-17
+      09:26:22", "timezone": "Etc/UTC", "rrules": {"freq": "WEEKLY", "interval": 1,
+      "byweekday": "TU,WE"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '258'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPT0/DMAzFvwrKuRFJ2vTfFfUEx00Tpyp2XBGta0eagsa07467CxzgZvv9/J59
+        FZ4WjOGcwjyJVohMTO5EXFFZg8VKS8zByQJzJx0qkg5sDkBm0AMxva7BMw1gwdjSSONVJYsKUTbe
+        1jIfYGgarQpbAdMYyW1JvXeJQ3SpbVM2ts4zMbol9afZhyHgf8wWpZW91zhH6tfzBi09jDMeidUU
+        V8rEgm/k15G3r2JJLqYU7j8ZZbRUudTVg6pbU7bG8FE0+T/05pfuYPwxj5Gdl816iPTOW4eue355
+        ZTBMieKHG3mmuYXLJ9HRuwv3u3126MQtE1vS1zxtaV3Cx/3uSdxu348NoMmGAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:23 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 521a6f83ded77625633c3a59aff8a9b1
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105583
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPT0/DMAzFvwrKuRFJ2vTfFfUEx00Tpyp2XBGta0eagsa07467CxzgZvv9/J59
+        FZ4WjOGcwjyJVohMTO5EXFFZg8VKS8zByQJzJx0qkg5sDkBm0AMxva7BMw1gwdjSSONVJYsKUTbe
+        1jIfYGgarQpbAdMYyW1JvXeJQ3SpbVM2ts4zMbol9afZhyHgf8wWpZW91zhH6tfzBi09jDMeidUU
+        V8rEgm/k15G3r2JJLqYU7j8ZZbRUudTVg6pbU7bG8FE0+T/05pfuYPwxj5Gdl816iPTOW4eue355
+        ZTBMieKHG3mmuYXLJ9HRuwv3u3126MQtE1vS1zxtaV3Cx/3uSdxu348NoMmGAQAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:24 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 56142771acf2b7507c46ca5745893dd6
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "f83a538d-d4e4-4ec8-a114-e4a3d48774f0", "uuid":
+      "bb5b2562-2d07-47cc-9d58-3fbf9910457b", "creation_date": 1615969583, "last_modification_date":
+      1615969583, "id": 105583, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:26:22", "endtime": "2021-03-17 09:26:22", "enabled": true, "rrules":
+      {"freq": "WEEKLY", "interval": "1", "byweekday": "TU,WE"}, "timezone": "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '419'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105583
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22PvW7DIBRGX6ViNipgsLHXylM7Joo6WfxcqyiOnQJulUZ5916ytEM2Lt+534Er
+        8ZBcDOcc1oX0hFRkMSfA06Rro2rtqZcgqQSnqeFcUpCm9lK3rZwY0tsWPNLWKitUI6jwrKWydY52
+        XmlaT3bqOs6kai3SLoIpptGbjBLecNU1ndJ1RWaT8nhafZiCe8ioihQVZ+rOuzXCuJ0LlEY7r+4I
+        mOa4QUWS+wC/zbh9JSmbmHO4/0kwwSmrKW+fmO5F0wuBj4LFP8i7f7mx8195jNicSvUU4RO3DsPw
+        +vaOYFgyxC8z4x3H0V6+AY7eXHDe7avDQG4VKaafdSm2Ibvn/e6F3G6/eB8hZoYBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:25 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 19cb4c7e8d0f19affb3647e9c835121e
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_onetime_to_weekly_valdefault.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_onetime_to_weekly_valdefault.yaml
@@ -1,0 +1,426 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scans/timezones
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA4WdW28bObaF/0teTxs5mZnunum3WHbbji3HbckJ0gcHAiWVJVpS0Smp7JYH899n
+        sUhWcddeUoAAgfbaH1kXFi+bF//73c5uijdXFtt3v/3fv9+VZlO8++3dx8fKzsz7j1M7fzLlu5/e
+        vZh1TYT//KSQ2awyBGjMxH0+t9vJx6mZMigTCbpe2KLakryiQJDtxtCrC3YKFAcAb9fAqdmYldPX
+        FO0MKBe1ZUBjp8BTvaaAtxPAbremJkCwE2Btyt2+KgiSFAJV5u3NvNj1mnGZSND6qd5Ma/acT1tJ
+        YwNjK/Kkg5m5b80U1z8jBW1gWo2ARb1jTGMm7q40q2qvH94gCho5MytTaSCYmXs1KbaTkVkbs2FY
+        LhP8yU5dvSNl7iwpBHI1siOZBbsGzteTj8bWpO5oFQ39XhXFzr0SqFU0dGGmrkIFpi+uVTR0ie+d
+        lfBo18AntzQlakmU04XOSagErln19slbtfO12TzTZ50EgixNtXM1KQzXSSGQXZg1KQXXwc6AcrvE
+        l6Jv/9pGRUM3ZuFIHR3MxN1Oq+JALXLTaQR0aLhUO3XjrcS5NuWc3MdNsDNgiirKbJfked3UrcbA
+        Lb5icmF1Y9fAEK9+Sqq1aGfAc72jQGNnwLaoSHswNI2dAL51Zt/XMAoEcQuDhn3JsmklhpWVe7Hk
+        eQ1dVDR06yv8KXkxSSAIejWboiT53CaFQBYMqddvg50AqBtXs6Xb7fT7v+00DX6uDR6fqxeOPL9c
+        1OidQ0VwcuteSInINA2OjJuM6TfUKhoaW7Tbqx25ylYhUGWfHat4xlEgSF1aUomMG7N2/2rL+dIV
+        K/3YWyWHNkXo7M6NIHIzcy/xaiuzELVOYlqNgujYrWVj2nJRotjOLmpRZFsqKAzCBdbGypKesFaj
+        4KIodwDfn9ZF6dBFtxWGCFkF26ZCHY8mOTA7dJMr2RNT6XVexxNzGze/ty9mjt4nfTxVusKBdP1B
+        stXcyVZbX6ELPkcT+oQurKg1VDLB42giN2Zyb93T8dtrnY4mNSzKuXs7nlLyOZoQLmhyYdDf7zXw
+        6v6E49Ek0aWVXW2VVvD4QSLl5BMa8qOFdWSi0w+Tuqll1UMuqZw0TkeTGtezevODi0o+RxN6QKtq
+        flDQkw9NqNcXbe+n3xtNwrYuZ9bRx5kkls/OrtyK33CSKCZ7S+kidr3OUrSfmiV9FMFO0m+EySm6
+        eRi/s/qs50CTqKZonTkcJYYV60J00NMtNHYO2DfWupwWay8wxI9vT0YY59L3dZrLDHdm8sVu6Sd4
+        2moUXLgDVCNQxG7pzTlvZ8Dxdkg0UwQfmM20svNFgZfPqmOp8wSeUeFVvuiQqgV8J1O8nMnRcHz/
+        A7wyCBSpzIwW0gFGr16h0OG29WiLOjD7AgNcemtBobnteaWG1LzAkCU6WwvRPU1PIiocQq2Hf+zy
+        ljZqDEQXbT3BqB4hDxFiSXkKnSdwoB8wONz6Dxw+IrTYtIeTiSw/dLN29OsdRIVBte0FUNPtBYEi
+        vgjR14BInFcIdGZK9NtWiAK8sPZAyBR/3dJbOzONcBCZ4N5ldz7eXwCjzPCifCnYez8LAkV2lbNi
+        yJYyK4LCILexJX/dZ0ki2Pl840r+tluJYbaqy+KZfavnSWLY2scM0VF27IkgLNeqDC63GDDLoEl8
+        LudJItjvGI9Obos1f++5egj+ava0VmrYIB5Azbqg/VxPBo2AF2szO9RGdBoD3Xy3NFNSQV1EhUJu
+        ezA3lzQG+nZoMq4rNmRtGqkgUvTQi7yogsKg2syLtatpobvoRI7uik0vohmLDsiocXBvvmOszJ5p
+        baJGwb2hQ96LuhEIcomQ56P5i+SUFAq98HwuTSMwpKg2bovhP6t5LzuRoFfl3CLV9/F/H0NhfVDq
+        diS569Kx207JNPIRfIgwekmb85RC8jiSyF2xw0xeP7Qey0hKJ3M6ktS4WK8nA7tjfbyUUudzJKEv
+        xQvtKKZEgn4sAVvOfL/p2Ev60vocSQhBK4RLZqRspmtJHocT+UFpCTLF6xfL6pirshEY8h1zxbQB
+        vYoKgT7hDnn7mRQGHQitHAyofEKzKadCYxmLAsnjGmGwerbav79xGOOrmYnIM69jiSGcvbMzFFVW
+        DbSJZV4sMXyZk6tbUiz8N+sVBqE7jACQfWLv9LoTCYrw0p15I9lFgSF2w3rsN97M3H2csVxgQMy+
+        mZtMpfCR95O9PIq+FtXkrvIfI88510kCQ/QZLHuVUaBI6UOz5HEOUckfCOd6qWZXGAWaT2UxBqf5
+        BIVDiP3a71jyoSO+qM+TSFGMPzEfy68yaRR8MzsEKGiOUWLYwXDmkSAmJN8rL+jttRrNDTEE+tIw
+        h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
+        CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
+        wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:02 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 2c95ac0ca0a685372be3f796dfe7dfd6
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "015a0358-3b6f-4917-b2c9-29561f5faa6e", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 08:26:02", "endtime": "2021-03-17
+      09:26:02", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPu07EMBBFfwW5joUfsTdJi1JQAM1SR2N7orXIJovtULDaf2dMAwV0o7lnzrWv
+        LGD2KV5K3FY2MNawFc5Ik5AGhDYd187OvO3lgTvle656Y+VsZgCLRO97DERrbXrQLXLUneAtCuAO
+        LHCjRdCdbq3zkmifEGrTFKBQibTS9JaEumEL5DKdtxDn6P9japUUxnSSVFvCab9UKE9u2fwbUlrS
+        jg3L/oRhX+j6ynKBVEr8/pMSSnKhuTzciW5QdhCKHoVr+CPvf+Xglh95SmTOVT0nfKerl+fx+Pg0
+        EhnXgukDFlpKdmtY1X5ua1WPxd+/Hh/Y7fYF1w3Qd3MBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:03 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 670934f502d5a24ae39ac1d3e1363e00
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105581
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3WPu07EMBBFfwW5joUfsTdJi1JQAM1SR2N7orXIJovtULDaf2dMAwV0o7lnzrWv
+        LGD2KV5K3FY2MNawFc5Ik5AGhDYd187OvO3lgTvle656Y+VsZgCLRO97DERrbXrQLXLUneAtCuAO
+        LHCjRdCdbq3zkmifEGrTFKBQibTS9JaEumEL5DKdtxDn6P9japUUxnSSVFvCab9UKE9u2fwbUlrS
+        jg3L/oRhX+j6ynKBVEr8/pMSSnKhuTzciW5QdhCKHoVr+CPvf+Xglh95SmTOVT0nfKerl+fx+Pg0
+        EhnXgukDFlpKdmtY1X5ua1WPxd+/Hh/Y7fYF1w3Qd3MBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:04 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 018b6e0bfc7539e43e859831bba5f6c2
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"description": "", "name": "015a0358-3b6f-4917-b2c9-29561f5faa6e", "uuid":
+      "3359a34e-e380-4e0a-ba6a-530d38346bc1", "creation_date": 1615969563, "last_modification_date":
+      1615969563, "id": 105581, "core_updates_blocked": true, "schedule": {"starttime":
+      "2021-03-17 08:26:02", "endtime": "2021-03-17 09:26:02", "enabled": true, "rrules":
+      {"freq": "WEEKLY", "interval": "1", "byweekday": "SU,MO,TU,WE,TH,FR,SA"}, "timezone":
+      "Etc/UTC"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '434'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: PUT
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105581
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA22PQU7DMBBFr4K8toUdx27SXYWCkAAh0VYVq2hsT0TUNCmOAypV786EDSy6s/3f
+        /Oc5s4Cjj+0xtUPPloxx1sMB6SSVAalNIbSzjchLtRAu86XISmNVYxoAi0RPUxuI1tqUoHMUqAsp
+        cpQgHFgQRsugC51b5xXRPiLMpjpAIomyypSWCjVnHYypPgyhbVp/lTGczSoljSkUVQ0R6+k4Q2Pt
+        usHvkdIUJ+Rs9O8Ypo6mz2xMEFNqf3fKZKaE1EItbmSxzOxSZvQp7MOVvPyXg+v+ymOk5nGubiJ+
+        0NSuqh6f3ghs+4TxEzp6m5d1py/EfYAT3ddb/vzCN1u+q/jmgd+/8vWKXTibxd9DP8ur5G+3mzt2
+        ufwAvhTz7JUBAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 08:26:05 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 3e3a78286ae3834522e65b6750755da1
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105581
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 08:26:06 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-jagop-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 33593ef9021c1ac2d486ff4299e9af5a
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_weekdays_typerror.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_weekdays_typerror.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,213 +52,304 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:00 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [e0d8b945620add49704550582f0d5af0]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:06 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - b0ab7c0f29e6e87da84126fda2c704e7
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:27:00", "enabled": true, "rrules": {"freq": "ONETIME", "interval": 1}, "starttime":
-      "2018-12-06 23:27:00"}, "name": "414294cd-6c1a-4078-9ca7-40fc0b648541", "description":
-      null}'
+    body: '{"name": "3f2d3cc8-7296-4476-afec-4b5a6c55c57a", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:33:05", "endtime": "2021-03-17
+      11:33:05", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['239']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPMW/DIBSE/0r0ZlCBPNuEtfLQoe2SzhEBrCAR3ALu0Cj/vY+qU6VuJ919d7ob
-        VHcJfksBzA1C9i1eSYISUnOpuJh2Qhg1GSGAkW/PKXgwrWyBQSnE1Q4uJXwQ9foyH5+eZ0rG3EL5
-        tAmMvDPopV9r7sVzcw9vx0eK1GZL+zs37tT+d464ZGs7XVcfl+hsi2s+edsoLwdEuddaSQauhP8s
-        H6or8b27YPKWEoNsf/ZQojqg83x00nIUk+YHZydSixPnEfWAsr+gqyPicP8G4xGOVycBAAA=
+        H4sIAAAAAAAAA3WPu07EMBBFfwW5joWd+JFNi1JQAM1SR/Z4orXIJovtULDaf2dMAwV0o7lnzrWv
+        LGCGFC8lbisbGGvY6s5IUze3oQPouW0PhitlDXczAldeOwNag7aO6H2PgWiQQUinJTcCW656D9y3
+        ynBhUDirPMzeEg0JXW2agitUIo3UB2tlbxq2uFym8xbiHOE/plZJoXXfk2pLOO2XCuXJLxu8IaUl
+        7diwDCcM+0LXV5aLS6XE7z+1opVcdFzaOymGrhuEpkfhGv7I5a/c+eVHnhKZc1XPCd/p6uV5PD4+
+        jUTGtWD6cAstJbs1rGo/t7WqxwL3r8cHdrt9AZzjml9zAQAA
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:01 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [6db4ca55d3f7f2b23ce8acee5b126444]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:06 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 10466f0f8fa2b36cb9d06c1887d5195f
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6445
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105588
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPMW/DIBSE/0r0ZlCBPNuEtfLQoe2SzhEBrCAR3ALu0Cj/vY+qU6VuJ919d7ob
-        VHcJfksBzA1C9i1eSYISUnOpuJh2Qhg1GSGAkW/PKXgwrWyBQSnE1Q4uJXwQ9foyH5+eZ0rG3EL5
-        tAmMvDPopV9r7sVzcw9vx0eK1GZL+zs37tT+d464ZGs7XVcfl+hsi2s+edsoLwdEuddaSQauhP8s
-        H6or8b27YPKWEoNsf/ZQojqg83x00nIUk+YHZydSixPnEfWAsr+gqyPicP8G4xGOVycBAAA=
+        H4sIAAAAAAAAA3WPu07EMBBFfwW5joWd+JFNi1JQAM1SR/Z4orXIJovtULDaf2dMAwV0o7lnzrWv
+        LGCGFC8lbisbGGvY6s5IUze3oQPouW0PhitlDXczAldeOwNag7aO6H2PgWiQQUinJTcCW656D9y3
+        ynBhUDirPMzeEg0JXW2agitUIo3UB2tlbxq2uFym8xbiHOE/plZJoXXfk2pLOO2XCuXJLxu8IaUl
+        7diwDCcM+0LXV5aLS6XE7z+1opVcdFzaOymGrhuEpkfhGv7I5a/c+eVHnhKZc1XPCd/p6uV5PD4+
+        jUTGtWD6cAstJbs1rGo/t7WqxwL3r8cHdrt9AZzjml9zAQAA
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:02 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [8557524d5a9e39a49e0494e35a5aedb7]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:07 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 30330fdd45c2878a776b233165023f62
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6445
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105588
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:27:03 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [3c482217ef9fc2a286d8a2661dafc84c]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:33:08 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-av00j-ap-southeast-1-prod
+      X-Request-Uuid:
+      - cc4aa8f21871f800b9b2d283c933b4d5
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/cassettes/test_agentexclusions_edit_weekdays_unexpectedvalue.yaml
+++ b/tests/io/cassettes/test_agentexclusions_edit_weekdays_unexpectedvalue.yaml
@@ -2,11 +2,17 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
     uri: https://cloud.tenable.com/scans/timezones
   response:
@@ -46,213 +52,304 @@ interactions:
         h8B7TsMCd7Xyt8burBNpbn/ZmTvUmg2LTmWwf308DjRMEsNcOeMjEtRGjcIhNOCVnB2LVaOvxIJ2
         CHyx84J+PJ4M4gG0KgzrHPosG+kAhnnOytBPAmAUCXpr+gtp4i1GgSHF6+Sbo5302yQxzD7j02Sf
         wm1UGNSbvUsX158Cb+1YNLFkhfLWL6eAQvOodssJFqYgqvf+tKjXZklKNRJQXj9KbIB2lo7URWLR
-        60eJ+WeLwSyNt4r0OkeS5OcndLwW7AklhUB3qKJpoxcFjixKW+3qUqwsie8JXKtSuPJzaVjSQ17E
-        HeKEUWQo5khLyzr/d1FhEN7tialPQmvJ8pQOB5KYuMfJ6BkzkwdS6PQDCbjJx5lcwJOel58BD+JB
-        9EuxXtLn1bBBZXBdeB1xPQpnKoVLxAQ/+iE2axvv6kwm+D2e1R5Z83BWrlK4XNlyclWuC1bt3ZtM
-        Zngxs4/sXd8HgSILPut8XzQCRbZuXe94PlFiGKYhTxHwoO/ETz1GkaFuiy+Hvcv7qBAIM4d4j1dY
-        MFiwtkfIh/CK1kwN6qUDmOVhc4810gHMTZoQJB2je7bTaQIOvf6ajlP8wpCgMXDmEK+e7jFFOCff
-        +CiXGb60z5WbsVHKKEkMs36iUPdZR42dATvMB6G18pNwLGQwEjpPAIv/SvZJgw0Sx67tbncACxLH
-        buoZnfJEbkHi2HjpNrTiARc1DoYQBas2QCaRoa/2cTcZ1Oj6cVroJIFxscD9YC3iM3ujucrgZS0X
-        IsfWYdzYOeDnhA/MDgJrVQbbJyw4oJcZFQb5bpZcuZcuMioc2jk6lBj7tqu3FDem98XXjjVvOTqN
-        5PbFVqityfcUBYJ8XdpdgYVRdHI3Exlqy9I+F6wThABXkAj2zaywEpsV0KQwyMdeXlclb9e+ZWoO
-        +/p5hsCNeY8V43K005c4doY1SuKb77AgHcBqP0909lCp+FPGSx+eEOIR32u0eaKR7dLo5EN4fwIv
-        Z9UcXibOhjXWSuUlSYs8zzuzRjHmZNQ4eO9QrctNBV2eSeToCOvjl5M7J6uQjs70Awns3auoDjK2
-        kTg2rtxadCo6LEgc+4LpZieayo6LWg42RRjxzHKxLzAxjsn9/OkSNYe31q+UlEhrU47rjZGR+MY1
-        WJXzpreUoPFtjMoV01R7USYa32BVzt93Mubb+DZG4uqm4tuIvt6qnLfLBSbXRcXTuCc7AVaYITSi
-        PxSJKCgE+3DIxQdr3/nULJZznXoya/dl1RuA+YvBAqjGrN1XYp1v8IVNO5YLLP3Ky1TwDWbtXiGo
-        KUp9cA9m5V5ghls989NgVc5Ygr6SCweatKNZuftpdbGQvPEO1r7zwKxn9U6uevLurV0BaBlFndB4
-        N0bt6uzUrLcyGhr8W4VA5eI7Ovr9Jw8mChpBzAEjQ4IkQSFu7TYy2NBcVzT33c/MTC6C8c7BqF3R
-        QZ3J8HbwjnYFLHtbKxrvxqhcrVxw3nh6m3LEKkhVAs4ao3bFOphSVxdndbT3gd9xI4u6t7zOX0kn
-        9JELI1cweO/G1nf0K5xkT827RqtyLqboevaLyWWwKmcEoJd2MrSlCPU1yWeSxsrF5BoFT2UDWxA0
-        8qKqxksHW9/xqkKPb6tqmGRW7njk5VRXMVfJ3gc++Y13+ltNZu2+N8+97Yv+8XzCEoXGrgDss9n2
-        w5MN0Qp95NqQGwhG7bqZLU1vHOxTx/6xKGgES77k3qYABLN2902can+vsT/Km7X7bolWfK6aj2uT
-        BIIcIoJdAfgU53sZrG1uIdkV4NaYlFH18XU0K3esFi7d3lS62GHWtJUU5ndHYly+QTnofwjXuaZB
-        PHj98VzXwazdX42ccm9uvm6sfWf08uXCP+8bjMxVvTbvqt/A0O9Z0g1WMuuUV346RT2VIb69xq6B
-        0sqBb7jsxqqc6+1M98yGwdp3vrUzLMlRRSGZlTs2V63qt7IgVZDfeNVqDNzaqSVlyHNJ6mOfN7rM
-        NTbliOn7fiH77G19x7slpj8nd4Wu0TNFQX7JAoIcqtq9awWF7P0YA/2+/lXdtUIf+QPfpCoTwahc
-        92/7Ndbgqhf3Ryv0EQS6F063fMms3O3ezFWrdx+sfeeR6U/Z+fIZrdoZHf61brBHJto14Bfeoo7r
-        P8qRn+BpBIUUTrd5o8aoXFFLLpa64zNKdgWgEjLPiPCqy2kFhVTFvCxWbr0n5XkkxD46Noj9qF5Z
-        tGpn3+eXIUf/JsZonRq7AqboCG518tGs3AuMj1TnaRys2hnb4F/sS/8xYQVasCtg6bdUKvdgZc7P
-        co9tc6fw9mbl7lZ7EYJpnBujdiUvCdtDSa3z8IShAuYBsHFaf+hS7OfygAMMyqlhn3wuEaxEnHYn
-        lzH7mwGVFAVV9ea7eskPwaqct7uT217sqEk/2fvAF+t3S/Y2SXuiExSyxg5p1Pq9yE0DZVIfa2Ka
-        ukFIZu2OGk+V1m++HtSl9VuBLhEWsqCzLA858BclRZVPgW37+rP4Fs25u1/k4wNQH9/8DFFe1HsK
-        g06xRLaWVX6iksQwbLIx8kyOREWFQ88FJoMrud+nA1uVwb+bonKiekxgVDh0kPECQz6hxA/91h32
-        IDuRoUMs6bYyQJquMUkMuy/2qycEq0VHIIGdyNAQN70oHKYVRLOdcOlAk9hNLjFZJydbWrwVOWow
-        AS5m+TowSDmGkTo6Tyj5Hwfj/OEKOwewVN5g3RKnkkjR08pu+4cttBm24gHUoX2bXGJxOc34tOp0
-        mgA+halfGUXpVuQopvnkpEJ70X4GEBLFzkz1KjtBLRYlip3XMzkSaKmgUOgSO7UrEThsqShR7Oby
-        ij4Pb+cADh/AdgfxPbY53SSRo+jNTi7dKy84N61K4WGx9nvc5F6ZNuNOpfDt6Cu9S2/ngF/ixZFG
-        odAdls9wKCgU+qMuinKLNkN0fdsby2SKNzUKvdCgcGiPrqqoKNr8RkGiGLqYePGyZmvBVqToF4u1
-        ldUBtBUp+hUbBukNNgJF0P7PHL48WYu2l5rJGY51NG92/b637Cq3auezIi0m7NZkRKKTNHZuxC1F
-        orFq5979R+f+zQ/O80rc/8pSGozGvwzOhEO05E7oQ8zRGsQ2I3vkvg+RKxry6xbl6DwySdCIv9ui
-        yquRiCRBI0PnF5GJCjUyraIhLIF8BDfvfWERFKqG7wwWgNl8a0rkkqCRkdmilzlbFq+ijoycUDX8
-        rV6J3mykgjl3X9p1gUkJf4QJHr2IiyCa3dMUGB7xVb/WCaQQc1QerDDonadwLgqg/5Wx56O88Plf
-        Uvz5XJROODSW3Gmxf86rgfPmd+6AA1yyMouNoqJRPt/N3l8MxVVES55GMP3P/+YJtTbi+IE4fhBX
-        FekPLEkYWZo0UZ7q31j+f2OpMk/q+HeS5N9Ziv8gjv9gjj8Tx5+Z4y/E8Rfm+Ctx/JU5/pM4/pM5
-        /os4/os4npD3CJt+jSfkLcLGHFmStGicfKCJ8lTJCz/5wN74yQfyyr2RXSt56Scf2Fs/YfnT7Fnu
-        NHOWN82aFLgTVuBOSIGDjdw3KXAnrMCdkAIHG0mRFLgTVuBI4dDFDacHlK92lvcDm/qutfcu4EGM
-        +Lyrt/SdxoPeR/EAS9+p9Cu2MdnXd23tPeDPep2H/3zejSl3qyv3XGBpjG+k5uII0PO+RDAc/yQH
-        eQmKAkH8SBiB6bwzkqBWIhjWX4mFsYkJdg3gYJtH2fOLRBIosqgQx8gfb3gGYILCoErG3ttsGjsB
-        sF3Iojfwko+NE9RpDKy3W5x+QC4PU8CNQiBM8mEduOgCp8xaiWFz83yAigqDtojYi+hRm1VUNIR+
-        EDSxLilCrUIgvBTsKqJ5DTpNg1h9Qd9WtGvgAueE+mPC8nmkeH2dRDDs38BJFvmwL1FJ0RBiUXgU
-        qzywHKFW0RA6loXf4ILJS10wcpGhai1DzI+tZogSlhXQ+4p2ncu1n5tCucD3oy8wFwlqi3y2I17B
-        tbcyZxz3SXLAgZ7M/QaxMdH9j6lHu07/5gllBweYk8+2kwjmUBWSV4Mlk95OgPqvAouiZNQ8XVyn
-        aRBxVuwb1U8g2hkgT8iLmeB0WLmMrLUj9rY0G3Iz2MYbJZILzvPNw7sptcZM3HGytdh+k/yDnQFb
-        xB/IbbvGrgE9RR+zIJP0Ufm8FZtWcqtOHxvlxLrs6B3MxN3NF4jWiJVtCWklgvkTN0lTdRfsGrjH
-        9gf9lBorcZb7P+P13Pe2f0ZzM21M0o52nbo/MNEXmTKfQWwTazUGVuapEOfRtlhUOLRjVcMIV+0F
-        gtjNI6ZccJKFfmKjTiPgyj0/kbcyCnYCuEcRqEu305iJ+w77mJZunR/+l5BW0tgYR2siQqdvJgkE
-        wWyOiP/GbMbBzoEtfWIeaRQNPayxpMO9sAqikwj2tsQ340hl95AUDX0x8zo/ciLeUDAzd785gzyz
-        L+i/eYEgmLll7YOfuJX7FFPedl1asUq1J5A83HrheGP6pZU09hWrzQypJaNdA3+aRVXkJ1DFK4t2
-        BmANh3tb7knx/9Ov7wgaAWvUfmI4FTrdfwZ7BlycZiUYP4R00kShutDwxWmw5E4iJuUjVFIUsagQ
-        m5IOIiIBBxmNgCEfQTY/c56MHOmo8VIE8PyvLJVLLINCgDJfBtWaMrcrHAgjpzmSJXdqToHCXgf0
-        A/2kNpYQZA8wHAgkVQ0P0A0XB3RELNoZgHZwJ/cPtkySCOawsE5f3aAxM3d/cAjzb+wauC4qtJuY
-        DNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLYHofF02sLgkbuC5yBLvqqMZ8k5Ihc
-        t3TVW7B0ta2M2NIcDVkK+pQmcjrTJ/MsquDwO0vl+tU8YfWzmKfobJkj/uDDPu+jhN+Zw1DE1P2v
-        XBSf5FB+kvj561DE1JMlT6E5YQVbUZ6MPzUifzHh8JVM4thILPvNIC9o5KIoseoo78BEJAkZcvtn
-        VurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj8T/vxBO8i5bcKcwPvf/4LHpMcXYo
-        mJk7TtzqVYUtkiSCneJPJmD6q79JMqFCJjiqP5zgmHfTEpkUCtV1PlTqEG8nQJg+yt5dIqLAkEcs
-        y2JEY2eA36yMRVx5LKPNptUI+DtWX7vHvFQkLCkMsk95/KMlvJm516V5lH9/qEWSRDAcNY+KRLZb
-        ies0Cm6m+ENh5Pld4ExorzAIR1pigxda2PxrbPPLVA6zUoTDLsXZDik19AVw8IUI+yqJ5NKcLSCP
-        akpYKxHs2vqmCTsw2TvLRIY630SQB3kdBIaQuj5dJa3zkzg0T+hSkryiQPLC8BRHXm3FKQddcklj
-        oJ2/irMeWyoIBLk1tfgbOokIdgZYMfJv/b2ZubvqEVtRyP2jJWoUCtWbIm8w21zwt6EgEOQOXxQW
-        74rDQRLVaRRciwBwB3k7A+xuhr/Uk/fVWiZJDEMpl4u/WyoqFCoRCicPD3sVvEARHCc8DGeWUDCT
-        CX5vKodvUYRr0oV2GgGxQUB2lxIVBYpsHHvLiN3AToAx/ugB/dyjQJHKiB3s6bLGCMDI/eut4m9/
-        hx1v5PGNW43lVdEWdOzNxP2rWbFX25ipO+Io+SgkXe9XH2AR45CkfDPP5B68NU8fh22INWk4LqC3
-        DcP/wSX0SEQLkkxZSvef826W/yXE6+xa7j9f5+KIbMPobFkq/ixoMbMRDZmLnPPszXc+jLBr3y/c
-        ya6ls+WpeEf8ZUSMQvuu0dpzriz++Gg/2WiUrnoNFa6ArJ+C1XelTuLhuPIyhCLT1wuuYkp+FZZ0
-        vcQnYPP2E57RJh3jNZyMMBslSi2AnibBIcIoCPP2HmJr7TnrdV9In635gjkWcvlYklGmG63YCpFH
-        obo0GkEioQ7qIjpwVtWSnybPPOSk+QOZMO9sWWZfT0YPWTLNz1wWQ8OvcWg4i8cR/bar6uKn9Ndu
-        e3PuYb79///zXxP2YS0cdwAA
+        60eJ+WeLwSyNt4r0OkeWZF2zVvLWm4n75yf00xbsgSaFQHeo0WkbGQWOLEpb7epSLESJrxVcq1K4
+        8lNvWAFE3tsdwopRZCimVEvLxgp3UWEQisKJqU9C48rylA4Hkpi4x8noGROZB1Lo9AMJuMnHmVzv
+        k56XnzAP4kH0S7Fe0ufVsEFlcF14HWFACmcqhUuEED/6ETlrSu/qTCb4PZ7VHlnz6FeuUrhc2XJy
+        Va4LVkvem0xmeDGzj+xd3weBIgs+SX1fNAJFtm5d73g+UWIYZi1PER+h78TPVEaRoW6LL4e9y/uo
+        EAgTjXiPV1hfWLCmSsiH8IpWZA3qpQOY5VF2jzXSAcxNmoglHdJ7ttNpAg6DhJoOa/w6kqAxcOYQ
+        3p7uMaM4J9/4KJcZvrTPlZux6nqUJIZZP6+ou7ijxs6AHaaP0Lj5OTsWYRgJnSeAtYIl+6TBBolj
+        13a3O4AFiWM39YzOkCK3IHFsvHQbWvGAixoHQ0SDVRsgk8jQV/u4mwxq9BQ5LXSSwLhY4H6wdPGZ
+        vdFcZfCyluuWY+swbuwc8FPIByYTgbUqg+0T1ifQy4wKg3yvTC70SxcZFQ7tHB15jH3b1Vu5G9P7
+        4mvHmrccnUZy+2Ir1Nbke4oCQb4u7a7AOio6F5yJDLVlaZ8L1glCPCxIBPtmVli4zQpoUhjkQzWv
+        q5K3a98yNYd9/TxDnMe8xwJzOTjqSxw7w5Im8c13WJAOYLWfVjp7qFS4KuOlD08I4YvvNdo80ch2
+        aXTyIbw/35ezasovE2fDGkur8pKkRZ7nnVmjGHMyahy8d6jW5R6ELs8kcnSE5fTLyZ2TVUhHZ/qB
+        BPbuVVQHGdtIHBtXbi06FR0WJI59wey0E01lx0UtB5sijPBnudgXmEfHWoD86RI1h7fWL6yUSGtT
+        juuNkYH7xjVYlfOmt/Kg8W2MyhWzWntRJhrfYFXO33cyRNz4Nkbi6qbi24i+3qqct8sF5uJFxdO4
+        JzsBVphQNKI/FIkoKATbdsjFB2vf+dQslnOdejJr92XVG4D5i8F6qcas3VdiWXDwhU07lgusFMvL
+        VPANZu1eIQYqSn1wD2blXmBCXD3z02BVzlixvpLrDJq0o1m5+1l4se688Q7WvvPArGf1Ti6S8u6t
+        XQFoGUWd0Hg3Ru3q7NSstzJ4GvxbhUDl4js6+v0nDyYKGkHMASNDgiRBIW7tNjLY0FxXNPfdz8xM
+        rpnxzsGoXdFBncloePCOdgUsezsxGu/GqFytXJ/eeHqbcsSiSVUCzhqjdsWymVJXF2d1tPeB33Ej
+        i7q3Gs9fSSf0kQsjFzx478bWd/QLomRPzbtGq3Iupuh69ovJZbAqZ8Srl3YytKWIDDbJZ5LGysXk
+        GgVPZQNbEDTyoqrGSwdb3/GqQo9vq2qYZFbueOTlVFcxV8neBz75fXr6W01m7b43z73djv7xfMKK
+        hsauAGzL2fajmQ3RCn3k2pAbCEbtupktTW8c7FPHdrMoaAQrxORWqAAEs3b3TZxqf6+xncqbtftu
+        iVZ8rpqPa5MEghwigl0B+BTnexmsbW4h2RXg1pjDUfXxdTQrdywuLt3eVLrYYZK1lRTmN1NiXL5B
+        Oeh/CNe5pkE8eP3xXNfBrN1fjZyhb26+bqx9Z/Ty5TpB7xuMzFW9Nu+q38DQb3HSDVYy65RXfvZF
+        PZUhvr3GroHSyoFvuOzGqpzr7Uz3zIbB2ne+tTOs4FFFIZmVO/Zireq3siBVkN+n1WoM3NqpJWXI
+        c0nqY583usw1NuWI2f5+IfvsbX3HuyVmSyd3ha7RM0VBfoUDghyq2r1rBYXs/RgD/b7+Vd21Qh/5
+        A9+kKhPBqFz9mtxSLunxReKPZFfA/m2/xhpf9ab/aIU+gsj4wummMpmVu92buWom74O17zwy/SlB
+        f/XRqp0xQljrFn5kol0DfmEvKsX+sx/5GaFGUEjhdCM5aozKFdXqYql7SqNkVwBqLfOMkLC6nFZQ
+        SFXMy2Ll1nvyAYyE2EfHBsEi1Y2LVu3sBwkyRunfxBjNWWNXwBQ9x61OPpqVe4EBleptjYNVO2Ob
+        /Yt96T8mrHALdgUs/ZZN5R6szPlZ7uFt7hTe3qzc3WovYjaNc2PUruQlYfspqaYenjC2wMQBNmbr
+        mkGK/VwecEBCOTWsjsglgpUI7O7kMml/M6CSoqCq3nxXL/khWJXzdndy2ws2Neknex/4Yv1uzN4m
+        bE90gkLW2IGNZqIX6mmgTOpjTRBUtyDJrN1R46nS+s3Xg7q0fivQh8JCGfSu5SEK/qKkqPIpcCyA
+        /iy+RXPu7hcR+YjVxzc/pZQX9Z7CoFMswa1llZ+oJDEMm3iMPPMjUVHh0HOB2eNK7ifqwFZl8O+m
+        qJyoHhMYFQ4dZLzAkE8o8UO/NYg9yE5k6BBLxq2MqKZrTBLD7ov96gnRbdFzSGAnMjQEWi8Kh3kI
+        0WwnXDrQJHaTS8zuydmZFm9FjhrMmItpwQ4MUo5haI/eFkr+x8E4f7jCzgEsxTdYF8WpJFL0tLLb
+        /mEObYateAB1aN8ml1i8TjM+rTqdJoBPYepXXlG6FTmKeUE5C9FetJ8yhESxM1O9yk5Qi0WJYuf1
+        TA4dWiooFLrETvBKRBpbKkoUu7m8os/D2zmAww2wnUJ8j21ON0nkKHqzk0v3ygvOTatSeFis/R46
+        uRenzbhTKXw7+krv0ts54JeQcaRRKHSH9TYcCgqF/qiLotyizRBd3/bGMpniTY1CLzQoHNqjqyoq
+        ija/UZAohi4mXrys2VqwFSn6xWLtZnUAbUWKfsWGRHqDjUARtP8zhy9P1qLtpWZyhmPhzZtdv++t
+        08qt2vmsSIsVu0UckegkjZ0bcUuRaKzauXf/0bl/84PzvBL3v7KUBqPxL4Mz4RAtuRP6EHO0BrHN
+        yB6570Pkiob8ukg5nI9MEjTi77ao8mokIknQyND5VWeiQo1Mq2gISywfwc17X1gEharhO4MVYzbf
+        +hK5JGhkZLboZc6WxauoIyMnVA1/q1eiNxupYM7dl3ZdYBbDH5GCRy8CKQh/9zQFhkd81a91AinE
+        HJUHNwx65zWciwLof2Xs+SgvfP6XFH8+F6UTDo0ld1rsn/Nq4Lz5nTvggJiszGIjqmiUz3ez9xdD
+        cRXRkqcRTP/zv3lCrY04fiCOH8RVRfoDSxJGliZNlKf6N5b/31iqzJM6/p0k+XeW4j+I4z+Y48/E
+        8Wfm+Atx/IU5/kocf2WO/ySO/2SO/yKO/yKOJ+Q9wqZf4wl5i7AxR5YkLRonH2iiPFXywk8+sDd+
+        8oG8cm9k10pe+skH9tZPWP40e5Y7zZzlTbMmBe6EFbgTUuBgI/dNCtwJK3AnpMDBRlIkBe6EFThS
+        OHRxw+kE5aud5f3Apr5r7b0LeBAjPu/qLX2n8aD3UTzA0ncq/RJvzA72XVt7D/izXufhP593Y8rd
+        6so9F1hL4xupuThi9LwvEQzHS8lBXoKiQBA/EkZgOu+MJKiVCIYFW2IlbWKCXQM4OOdR9vwikQSK
+        LCrEMfLHG54BmKAwqJKx9zabxk4AbEey6A285GPjBHUaA+vtFqcrkMvDnHGjEAizglg4LrrAKbNW
+        YtjcPB+gosKgLSL2InrUZhUVDaEfBE0sZIpQqxAILwW7lmheg07TIJZr0LcV7Rq4wDmk/hiyfOIp
+        Xl8nEQwbPnBSRj7sS1RSNIRYFB7FKg8sR6hVNISOZeF3xGC2UxeMXGSoWvwQ82PLH6KEdQj0vqJd
+        53Lt56ZQLvD96AvMRYLaIp/tiFdw7a3MGceJkhxwYChzv0FsTHT/Y+rRrtO/eULZwQHp5LPtJII5
+        VIXk1WCNpbcToP6rwCoqGTVPF9dpGkScFftS9ROIdgbIE/hiJjh9Vq47a+2IvS3NhtwMtglHieSC
+        84Lz8G5KrTETd5ycLfbrJP9gZ8AW8Qdy266xa0DP6ccsyKx+VD5vxS6X3KrTx846sZA7egczcXfz
+        BaI1YilcQlqJYP5ET9JU3QW7Bu6xX0I/pcZKnOX+0ng9973tpdHcTBuTtKNdp+4PZPRFpsxnENvE
+        Wo2BlXkqxHm3LRYVDu1Y1TDCVXuBIHbziCkXnJShn9io0wi4cs9P5K2Mgp0A7lEE6tLtNGbivsPG
+        p6Vb54cLJqSVNDbG0Z2I0OmbSQJBMJsj4r8xm3Gwc2BLn5hHGkVDD2usAXEvrILoJIK9LfHNOFLZ
+        PSRFQ1/MvM6PtIg3FMzM3e/mIM/sC/pvXiAIZm5Z++AnbuXGxpS3XZdWLGvtCSQPt1443ph+aSWN
+        fcXyNENqyWjXwJ9mURX5CVfxyqKdAVjD4d6We1L8//TrO4JGwBq1nxhOhU73n8GeARenWQnGDyGd
+        NFGoLjR8cRosuZOISfkIlRRFLCrEpqSDiEjAQUYjYMhHkM3PnCcjRzpqvBQBPP8rS+US66YQoMzX
+        TbWmzO0KB87IaY5kyZ2aU6awOcIvlsKkNpYQZA8wHDgkVQ0P0A0XB4BELNoZgHZwJzcctkySCOaw
+        Ek9f3aAxM3d/MAnzb+wauC4qtJuYDNZMJ2lsaJZ5oYs30liZ8xrLNMQ6hRaICoPwHexkLdFSSWLY
+        HofR02sLgkbuC5yxLvqqMZ8k5Ihct3TVW7B0ta2M2AMdDVkK+hQocvrTJ/MsquDwO0vl+tU8Ybm0
+        mKfobJkj/qDEPu+jhN+Zw1DE1P2vXBSf5FB+kvj561DE1JMlT6E5wQV7V56MP5UifzHhcJdM4thI
+        rBPOIC9o5KIoseoo78BEJAkZcvtnVurxQ0gng8uPeSz/9s9gyZ0QzXjKv7bbYMhc7u7zCJf/lYuj
+        8T/vxBO8i5bcKcwPvf/4LHpMcXYomJk7TvTqVYUtkiSCneJPMmD6q7+rMqFCJjiqP5wQmXfTEpkU
+        CslTSDqkdwxJEsL0UfbuegLJ4/wRy7IY0dgZ4Hc3YxFXHstos2k1Av6O5druMS8VCUsKg+xTHv9o
+        CW9m7nVpHuXfN2qRJBEMR9mjIpHtVuI6jYKbKf4QGXl+Fzhz2isMwpGZ2BGGFjb/Gtv8MpXDrBTh
+        ME1xGERKDX0BnJQhwr5KIrk0hxHIo6AS1koEu7a+acKWTfbOMpGhzjcR5EFeB4EhpK5PV0nr/CQO
+        zRO6lCSvKJC8MDzFkVpbcSxCl1zSGGjnr2LheUsFgSC3phZ/oycRwc4AK0b+rb83M3dXPWLvCrl/
+        tESNQqF6U+QNZpsL/vYUBILc4YvC4l1xmkiiOo2CaxEA7iBvZ4DdzfCXgPK+WsskiWEo5XLxd0tF
+        hUIlQuHk4WFzgxcoguOKh+GQEwpmMsHvTeXwLYpwTbrQTiMgNgjI7lKiokCRjWNvGbEb2Akwxh9V
+        oJ97FChSGbHlPV3WGAEYueG9Vfzt77BFjjy+cauxvCpxjlebnjcT969mxV5tY6buiKPko5CU/lcf
+        YBHjkKR8M8/kHrw1Tx+nc4g1aThfoLcNw/9BJ/RIRAuSTFlK95/zbpb/JcTr7FruP1/n4ohsw+hs
+        WSr+rGkxsxENmYuc8+zNdz6MsM3fL9zJrqWz5al4R/zlRYxC+67R2nOuLP64aT/ZaJSueg0VroCs
+        n4LV97FO4uG78jKEItPXC65iSn4VlnS9xCdg8/YTntEmHeM1nIwwGyVKLYCeJsEhwigI8/YeYmvt
+        Oet1X0ifrfmCORZy+ViSUaYbKpQuPANa1TF+zjvzkDPgD2T2u7NlmX09GT1kyTQ/c1mM877Gcd4s
+        Hkb0266qi5/Sn8btTaCHyfP//89/AZTWEzdJdwAA
     headers:
-      accept-ranges: [bytes]
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-length: ['6231']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:03 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [3cc19685162c7ebb31d62883b45e6123]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '6243'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:14 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Expires:
+      - '0'
+      Pragma:
+      - no-cache
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - c40e9faac371ab31731f66c63d7c4b9c
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
-    body: !!python/unicode '{"schedule": {"timezone": "Etc/UTC", "endtime": "2018-12-07
-      00:27:03", "enabled": true, "rrules": {"freq": "ONETIME", "interval": 1}, "starttime":
-      "2018-12-06 23:27:03"}, "name": "7a726b7f-a5d8-4a9b-9ac5-91ea9b5a3284", "description":
-      null}'
+    body: '{"name": "87b56210-1c5d-46fd-ae10-35c262232320", "description": "", "schedule":
+      {"enabled": true, "starttime": "2021-03-17 10:33:14", "endtime": "2021-03-17
+      11:33:14", "timezone": "Etc/UTC", "rrules": {"freq": "ONETIME", "interval":
+      1}}}'
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['239']
-      Content-Type: [application/json]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '237'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: POST
     uri: https://cloud.tenable.com/scanners/1/agents/exclusions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPMW/DIBSE/0r0ZlABY2OzVh4ytF3SOXoGrCAR3ADu0Cj/vVB1qtTtpLvvTneH
-        bC7O7sGBvoOLtvhrlSAYHykXlKkDY1oozTog1cclOAu6pN0RSKlyuYFrcrdKvb3Op+PLXJM+Fpc+
-        MYDmDwKt9GuLrXgu5un99FwjuWAqf+eGg+h+5yoXMJfzdbN+9QaL3+LZYql53kvJu3EUkoBJ7j/L
-        umyS/2gu6LiHQCDiz55CJYZFrRR7O1KJ00InND2duKu6x06Msr2oVwcph8c3O2EniCcBAAA=
+        H4sIAAAAAAAAA3WPvVLEIBRGX8WhDiOXv4S0TgoLtVnrDAEyy5hNViAW7uTdvdhooUMDfOeeD27E
+        h+xSvJa4raQnpCGrvQTcde2kNAdGwSlPpZ49tQGPQjmuORe4GNL7Hj3SrdYgpeyokoZTqYyhk5w7
+        ar2VzAmjtJ6RdinY2jR6W7AENCjTtmBkQxaby3jZfJyj+4+pVcCU6gyqthTG/VqhPE7L5t4CpiXt
+        oSHZnYPfF5y+kVxsKiV+/4kzDpQJCu0dsF6IHiQ+Kqz+jxx+5XZafuQpoTlX9ZzCO069PA+nx6cB
+        ybiWkD7sgpdAjoZU7ee2VvVQ3P3r6YEcxxc1j2X9cwEAAA==
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:04 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [b7a444cef8908ab0b6e838342e019d95]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:14 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 7fb827d0f2b7fdc47e8a2a661688b759
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: GET
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6446
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105589
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3WPMW/DIBSE/0r0ZlABY2OzVh4ytF3SOXoGrCAR3ADu0Cj/vVB1qtTtpLvvTneH
-        bC7O7sGBvoOLtvhrlSAYHykXlKkDY1oozTog1cclOAu6pN0RSKlyuYFrcrdKvb3Op+PLXJM+Fpc+
-        MYDmDwKt9GuLrXgu5un99FwjuWAqf+eGg+h+5yoXMJfzdbN+9QaL3+LZYql53kvJu3EUkoBJ7j/L
-        umyS/2gu6LiHQCDiz55CJYZFrRR7O1KJ00InND2duKu6x06Msr2oVwcph8c3O2EniCcBAAA=
+        H4sIAAAAAAAAA3WPvVLEIBRGX8WhDiOXv4S0TgoLtVnrDAEyy5hNViAW7uTdvdhooUMDfOeeD27E
+        h+xSvJa4raQnpCGrvQTcde2kNAdGwSlPpZ49tQGPQjmuORe4GNL7Hj3SrdYgpeyokoZTqYyhk5w7
+        ar2VzAmjtJ6RdinY2jR6W7AENCjTtmBkQxaby3jZfJyj+4+pVcCU6gyqthTG/VqhPE7L5t4CpiXt
+        oSHZnYPfF5y+kVxsKiV+/4kzDpQJCu0dsF6IHiQ+Kqz+jxx+5XZafuQpoTlX9ZzCO069PA+nx6cB
+        ybiWkD7sgpdAjoZU7ee2VvVQ3P3r6YEcxxc1j2X9cwEAAA==
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-encoding: [gzip]
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 06 Dec 2018 23:27:05 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      transfer-encoding: [chunked]
-      vary: [accept-encoding]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [525e76b5ff9ec7f76e7c592b6ba9d399]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 17 Mar 2021 10:33:15 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 058a304c7570f5fc8e32b4213ae0c6e5
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Length: ['0']
-      Cookie: [nginx-cloud-site-id=us-2b]
-      User-Agent: [pyTenable/0.3.4 (pyTenable/0.3.4; Python/2.7.14)]
-      X-APIKeys: [accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
     method: DELETE
-    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/6446
+    uri: https://cloud.tenable.com/scanners/1/agents/exclusions/105589
   response:
-    body: {string: !!python/unicode ''}
+    body:
+      string: ''
     headers:
-      cache-control: [no-cache]
-      connection: [keep-alive]
-      content-length: ['0']
-      date: ['Thu, 06 Dec 2018 23:27:06 GMT']
-      expires: ['0']
-      pragma: ['']
-      server: [tenable.io]
-      set-cookie: [nginx-cloud-site-id=us-2b; path=/; HttpOnly, nginx-cloud-site-id=us-2b;
-          path=/; HttpOnly]
-      strict-transport-security: [max-age=63072000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-frame-options: [DENY]
-      x-gateway-site-id: [nginx-router-b-prod-us-east-2]
-      x-request-uuid: [63a31f789922daeb2286bf8017934e34]
-      x-xss-protection: [mode=block]
-    status: {code: 200, message: OK}
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Date:
+      - Wed, 17 Mar 2021 10:33:16 GMT
+      Server:
+      - tenable.io
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-kuwml-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 0ac85ff1555b16b46fa85815c6b791de
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/tests/io/test_agent_exclusions.py
+++ b/tests/io/test_agent_exclusions.py
@@ -363,6 +363,196 @@ def test_agentexclusions_edit_success(api, agentexclusion):
     api.agent_exclusions.edit(agentexclusion['id'], name=str(uuid.uuid4()))
 
 @pytest.mark.vcr()
+def test_agentexclusions_edit_freq_onetime_to_daily(api, agentexclusion):
+    resp = api.agent_exclusions.edit(agentexclusion['id'], name=str(uuid.uuid4()),
+                               frequency='daily',
+                               interval=2)
+
+    assert isinstance(resp, dict)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'id', int)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'name', str)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'rrules', dict)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    assert resp['schedule']['rrules']['freq'] == 'DAILY'
+    assert resp['schedule']['rrules']['interval'] == '2'
+
+@pytest.mark.vcr()
+def test_agentexclusions_edit_enable_exclusion(api):
+    agentexclusion = api.agent_exclusions.create(str(uuid.uuid4()), enabled=False)
+    resp = api.agent_exclusions.edit(agentexclusion['id'], enabled=True,
+                                     start_time=dtime.utcnow(),
+                                     end_time=dtime.utcnow() + timedelta(hours=1))
+    check(resp, 'id', int)
+    check(resp, 'name', str)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    assert resp['schedule']['enabled'] == True
+    api.agent_exclusions.delete(resp['id'])
+
+@pytest.mark.vcr()
+def test_agentexclusions_edit_onetime_to_weekly_valdefault(api, agentexclusion):
+    resp = api.agent_exclusions.edit(agentexclusion['id'],
+                                     frequency='Weekly')
+    check(resp, 'id', int)
+    check(resp, 'name', str)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    assert resp['schedule']['rrules']['byweekday'] == 'SU,MO,TU,WE,TH,FR,SA'
+
+@pytest.mark.vcr()
+def test_agentexclusions_edit_onetime_to_weekly_valassigned(api, agentexclusion):
+    resp = api.agent_exclusions.edit(agentexclusion['id'],
+                                     frequency='Weekly',
+                                     weekdays=['MO', 'TU'])
+    check(resp, 'id', int)
+    check(resp, 'name', str)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    assert resp['schedule']['rrules']['byweekday'] == 'MO,TU'
+
+@pytest.mark.vcr()
+def test_agentexclusions_edit_onetime_to_weekly_valavailable(api):
+    agentexclusion = api.agent_exclusions.create(str(uuid.uuid4()),
+                                                 frequency='Weekly',
+                                                 weekdays=['TU', 'WE'],
+                                                 start_time=dtime.utcnow(),
+                                                 end_time=dtime.utcnow() + timedelta(hours=1))
+    resp = api.agent_exclusions.edit(agentexclusion['id'], name=str(uuid.uuid4()))
+    check(resp, 'id', int)
+    check(resp, 'name', str)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    assert resp['schedule']['rrules']['byweekday'] == 'TU,WE'
+
+@pytest.mark.vcr()
+def test_agentexclusions_edit_freq_onetime_to_monthly_valddefault(api, agentexclusion):
+    resp = api.agent_exclusions.edit(agentexclusion['id'], name=str(uuid.uuid4()),
+                               frequency='monthly',
+                               interval=2)
+    assert isinstance(resp, dict)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'id', int)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'name', str)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'rrules', dict)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    assert resp['schedule']['rrules']['freq'] == 'MONTHLY'
+    assert resp['schedule']['rrules']['interval'] == '2'
+
+@pytest.mark.vcr()
+def test_agentexclusions_edit_freq_onetime_to_monthly_valassigned(api, agentexclusion):
+    resp = api.agent_exclusions.edit(agentexclusion['id'], name=str(uuid.uuid4()),
+                               frequency='monthly',
+                               interval=2,
+                               day_of_month=8)
+    assert isinstance(resp, dict)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'id', int)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'name', str)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'rrules', dict)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    assert resp['schedule']['rrules']['freq'] == 'MONTHLY'
+    assert resp['schedule']['rrules']['interval'] == '2'
+    assert resp['schedule']['rrules']['bymonthday'] == '8'
+
+@pytest.mark.vcr()
+def test_agentexclusions_edit_freq_onetime_to_monthly_valavailable(api):
+    agentexclusion = api.agent_exclusions.create(str(uuid.uuid4()),
+                                      start_time = dtime.utcnow(),
+                                      end_time = dtime.utcnow() + timedelta(hours=1),
+                                      frequency='monthly', day_of_month=8)
+    resp = api.agent_exclusions.edit(agentexclusion['id'],
+                               frequency='monthly',
+                               interval=2)
+    assert isinstance(resp, dict)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'id', int)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'name', str)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'rrules', dict)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    assert resp['schedule']['rrules']['freq'] == 'MONTHLY'
+    assert resp['schedule']['rrules']['interval'] == '2'
+    assert resp['schedule']['rrules']['bymonthday'] == '8'
+    api.agent_exclusions.delete(resp['id'])
+
+@pytest.mark.vcr()
+def test_agentexclusions_edit_freq_onetime_to_yearly(api, agentexclusion):
+    resp = api.agent_exclusions.edit(agentexclusion['id'], name=str(uuid.uuid4()),
+                               frequency='yearly',
+                               interval=2)
+    assert isinstance(resp, dict)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'id', int)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'name', str)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'rrules', dict)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    assert resp['schedule']['rrules']['freq'] == 'YEARLY'
+    assert resp['schedule']['rrules']['interval'] == '2'
+
+@pytest.mark.vcr()
 def test_agentexclusions_list_blackouts(api, agentexclusion):
     items = api.agent_exclusions.list()
     assert isinstance(items, list)

--- a/tests/io/test_agent_exclusions.py
+++ b/tests/io/test_agent_exclusions.py
@@ -239,6 +239,25 @@ def test_agentexclusions_create_yearly_exclusion(api):
     api.agent_exclusions.delete(resp['id'])
 
 @pytest.mark.vcr()
+def test_agentexclusions_create_enabled_false_exclusion(api):
+    resp = api.agent_exclusions.create(str(uuid.uuid4()),
+        enabled=False)
+    assert isinstance(resp, dict)
+    check(resp, 'id', int)
+    check(resp, 'name', str)
+    check(resp, 'description', str, allow_none=True)
+    check(resp, 'last_modification_date', int)
+    check(resp, 'schedule', dict)
+    check(resp['schedule'], 'enabled', bool)
+    check(resp['schedule'], 'starttime', 'datetime')
+    check(resp['schedule'], 'endtime', 'datetime')
+    check(resp['schedule'], 'timezone', str)
+    check(resp['schedule']['rrules'], 'freq', str)
+    check(resp['schedule']['rrules'], 'interval', str)
+    assert resp['schedule']['enabled'] == False
+    api.agent_exclusions.delete(resp['id'])
+
+@pytest.mark.vcr()
 def test_agentexclusions_create_standard_users_cant_create(stdapi):
     with pytest.raises(PermissionError):
         stdapi.agent_exclusions.create(str(uuid.uuid4()),

--- a/tests/io/test_agent_exclusions.py
+++ b/tests/io/test_agent_exclusions.py
@@ -151,7 +151,7 @@ def test_agentexclusions_create_onetime_exclusion(api):
     check(resp['schedule'], 'endtime', 'datetime')
     check(resp['schedule'], 'timezone', str)
     check(resp['schedule']['rrules'], 'freq', str)
-    check(resp['schedule']['rrules'], 'interval', int)
+    check(resp['schedule']['rrules'], 'interval', str)
     api.agent_exclusions.delete(resp['id'])
 
 @pytest.mark.vcr()
@@ -171,7 +171,7 @@ def test_agentexclusions_create_daily_exclusion(api):
     check(resp['schedule'], 'endtime', 'datetime')
     check(resp['schedule'], 'timezone', str)
     check(resp['schedule']['rrules'], 'freq', str)
-    check(resp['schedule']['rrules'], 'interval', int)
+    check(resp['schedule']['rrules'], 'interval', str)
     api.agent_exclusions.delete(resp['id'])
 
 @pytest.mark.vcr()
@@ -192,7 +192,7 @@ def test_agentexclusions_create_weekly_exclusion(api):
     check(resp['schedule'], 'endtime', 'datetime')
     check(resp['schedule'], 'timezone', str)
     check(resp['schedule']['rrules'], 'freq', str)
-    check(resp['schedule']['rrules'], 'interval', int)
+    check(resp['schedule']['rrules'], 'interval', str)
     check(resp['schedule']['rrules'], 'byweekday', str)
     api.agent_exclusions.delete(resp['id'])
 
@@ -214,8 +214,8 @@ def test_agentexclusions_create_monthly_exclusion(api):
     check(resp['schedule'], 'endtime', 'datetime')
     check(resp['schedule'], 'timezone', str)
     check(resp['schedule']['rrules'], 'freq', str)
-    check(resp['schedule']['rrules'], 'interval', int)
-    check(resp['schedule']['rrules'], 'bymonthday', int)
+    check(resp['schedule']['rrules'], 'interval', str)
+    check(resp['schedule']['rrules'], 'bymonthday', str)
     api.agent_exclusions.delete(resp['id'])
 
 @pytest.mark.vcr()
@@ -235,7 +235,7 @@ def test_agentexclusions_create_yearly_exclusion(api):
     check(resp['schedule'], 'endtime', 'datetime')
     check(resp['schedule'], 'timezone', str)
     check(resp['schedule']['rrules'], 'freq', str)
-    check(resp['schedule']['rrules'], 'interval', int)
+    check(resp['schedule']['rrules'], 'interval', str)
     api.agent_exclusions.delete(resp['id'])
 
 @pytest.mark.vcr()
@@ -336,22 +336,22 @@ def test_agentexclusions_edit_interval_typerror(api, agentexclusion):
 @pytest.mark.vcr()
 def test_agentexclusions_edit_weekdays_typerror(api, agentexclusion):
     with pytest.raises(TypeError):
-        api.agent_exclusions.edit(agentexclusion['id'], weekdays='nope')
+        api.agent_exclusions.edit(agentexclusion['id'], frequency='weekly', weekdays='nope')
 
 @pytest.mark.vcr()
 def test_agentexclusions_edit_weekdays_unexpectedvalue(api, agentexclusion):
     with pytest.raises(UnexpectedValueError):
-        api.agent_exclusions.edit(agentexclusion['id'], weekdays=['MO', 'WE', 'nope'])
+        api.agent_exclusions.edit(agentexclusion['id'], frequency='weekly', weekdays=['MO', 'WE', 'nope'])
 
 @pytest.mark.vcr()
 def test_agentexclusions_edit_dayofmonth_typerror(api, agentexclusion):
     with pytest.raises(TypeError):
-        api.agent_exclusions.edit(agentexclusion['id'], day_of_month='nope')
+        api.agent_exclusions.edit(agentexclusion['id'], frequency='monthly', day_of_month='nope')
 
 @pytest.mark.vcr()
 def test_agentexclusions_edit_dayofmonth_unexpectedvalue(api, agentexclusion):
     with pytest.raises(UnexpectedValueError):
-        api.agent_exclusions.edit(agentexclusion['id'], day_of_month=0)
+        api.agent_exclusions.edit(agentexclusion['id'], frequency='monthly', day_of_month=0)
 
 @pytest.mark.vcr()
 def test_agentexclusions_edit_standard_user_permission_error(stdapi, agentexclusion):


### PR DESCRIPTION
# Description

- Issue with create agent exclusion with enable false required optional fields starttime, endtime
```
Traceback (most recent call last):
  File "REDACTED", line 30, in <module>
    exclusion = tio.agent_exclusions.create(name='test-agent-exclusion', enabled=False)
  File "REDACTED", line 159, in create
    'starttime': self._check('start_time', start_time, datetime).strftime('%Y-%m-%d %H:%M:%S'),
AttributeError: 'NoneType' object has no attribute 'strftime'
```
Refactored create payload to provide default time when enabled False

- Issue with edit agent exclusion is missing weekday and dayofmonth authentication when frequency changed to weekly/monthly
```
'rrules': {'freq': 'MONTHLY', 'interval': '1'},
```
Refactored code to assign default value when not provided by user


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] **Create:** Tested by creating enabled True and False agent-exclusion
- added test `test_agentexclusions_create_enabled_false_exclusion`
- [x] **EDIT:** Added tests to check multiple scenerios
- `test_agentexclusions_edit_freq_onetime_to_daily` edit agent exclusion frequency from ONETIME to DAILY
- `test_agentexclusions_edit_enable_exclusion` edit agent exclusion enable False to True
- `test_agentexclusions_edit_onetime_to_weekly_valdefault` if weekdays are not provided in edit, assign default value
- `test_agentexclusions_edit_onetime_to_weekly_valassigned` if weekdays are provided in edit, assign provided value
- `test_agentexclusions_edit_onetime_to_weekly_valavailable` if weekdays are not provided in edit but already assigned when created, assign existing value
- `test_agentexclusions_edit_freq_onetime_to_monthly_valddefault` if day_of_month is not provided in edit, assign default value
- `test_agentexclusions_edit_freq_onetime_to_monthly_valassigned` if day_of_month is provided in edit, assign provided value
- `test_agentexclusions_edit_freq_onetime_to_monthly_valavailable` if day_of_month is not provided in edit but already assigned when created, assign existing value
- `test_agentexclusions_edit_freq_onetime_to_yearly` edit exclusion frequency from ONETIME to YEARLY
-  [x] Updated broken tests and re-recorded cassettes

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
