### PR TITLE
Added sort feature in scan history and Updated sort feature in tags list_constructor

### DIFF
--- a/tenable/io/scans.py
+++ b/tenable/io/scans.py
@@ -394,7 +394,7 @@ class ScansAPI(TIOEndpoint):
         '''
         self._api.delete('scans/{}'.format(scan_id))
 
-    def history(self, id, limit=None, offset=None, pages=None):
+    def history(self, id, limit=None, offset=None, pages=None, sort=None):
         '''
         Get the scan history of a given scan from Tenable.io.
 
@@ -407,6 +407,9 @@ class ScansAPI(TIOEndpoint):
                 The number of records to retrieve.  Default is 50
             offset (int, optional):
                 The starting record to retrieve.  Default is 0.
+            sort (tuple, optional):
+                A tuple of tuples identifying the the field and sort order of
+                the field.
 
         Returns:
             :obj:`ScanHistoryIterator`:
@@ -417,11 +420,18 @@ class ScansAPI(TIOEndpoint):
             >>> for history in tio.scans.history(1):
             ...     pprint(history)
         '''
+        query = dict()
+        if sort and self._check('sort', sort, tuple):
+            query['sort'] = ','.join(['{}:{}'.format(
+                self._check('sort_field', i[0], str),
+                self._check('sort_direction', i[1], str, choices=['asc', 'desc'])
+            ) for i in sort])
+
         return ScanHistoryIterator(self._api,
             _limit=limit if limit else 50,
             _offset=offset if offset else 0,
             _pages_total=pages,
-            _query=dict(),
+            _query=query,
             _path='scans/{}/history'.format(id),
             _resource='history'
         )

--- a/tenable/io/tags.py
+++ b/tenable/io/tags.py
@@ -326,8 +326,9 @@ class TagsAPI(TIOEndpoint):
             offset (int, optional):
                 How many records to skip before returning results.  If nothing
                 is set, it will default to 0.
-            sort (str, optional):
-                What field to sort the results on.
+            sort (tuple, optional):
+                A tuple of tuples identifying the the field and sort order of
+                the field.
 
         Returns:
             :obj:`TagIterator`:
@@ -381,8 +382,9 @@ class TagsAPI(TIOEndpoint):
             offset (int, optional):
                 How many records to skip before returning results.  If nothing
                 is set, it will default to 0.
-            sort (str, optional):
-                What field to sort the results on.
+            sort (tuple, optional):
+                A tuple of tuples identifying the the field and sort order of
+                the field.
 
         Returns:
             :obj:`TagIterator`:

--- a/tenable/io/tags.py
+++ b/tenable/io/tags.py
@@ -294,9 +294,11 @@ class TagsAPI(TIOEndpoint):
         if filter_type:
             query['ft'] = self._check('filter_type', filter_type, str,
                 choices=['AND', 'OR'], case='upper')
-        if sort:
-            query['sort'] = self._check('sort', sort, str,
-                choices=[k for k in filterdefs.keys()])
+        if sort and self._check('sort', sort, tuple):
+            query['sort'] = ','.join(['{}:{}'.format(
+                self._check('sort_field', i[0], str, choices=[k for k in filterdefs.keys()]),
+                self._check('sort_direction', i[1], str, choices=['asc', 'desc'])
+            ) for i in sort])
         return query
 
     def list(self, *filters, **kw):

--- a/tests/io/test_tags.py
+++ b/tests/io/test_tags.py
@@ -251,12 +251,12 @@ def test_tags_list_constructor_sort_typeerror(api):
 def test_tags_list_constructor_sort_unexpectedvalueerror(api):
     with pytest.raises(UnexpectedValueError):
         api.tags._tag_list_constructor([],
-            api.tags._filterset_tags, None, 'something_else')
+            api.tags._filterset_tags, None, (('something_else'),))
 
 def test_tags_list_constructor_sort_success(api):
     resp = api.tags._tag_list_constructor([],
-        api.tags._filterset_tags, None, 'value')
-    assert resp['sort'] == 'value'
+        api.tags._filterset_tags, None, (('value','asc'),))
+    assert resp['sort'] == 'value:asc'
 
 def test_tags_list_constructor_filter_success(api):
     resp = api.tags._tag_list_constructor([


### PR DESCRIPTION
# Description

- Added sort feature in `Scan - history` function
- Updated sort feature in `Tags - list and list_category` functions with sort_direction and multifield sort

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] **Tags - lIst:**
```
for tag in tio.tags.list(sort=(('updated_at', 'asc'),)):
    pprint(tag)
```
- [x] **Tags - lIst_category:**
```
for tag in tio.tags.list_categories(sort=(('updated_at', 'desc'),)):
    pprint(tag))
```
- [x] **Scan- history:**
```
for history in tio.scans.history(1, sort=(('status', 'desc'),)):
    pprint(history)
```
- Updated tests for tags that are affected by change in sort design

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
