### PR TITLE
Updated plugins populate_maptable to handle keyerror

### DIFF
--- a/tenable/io/plugins.py
+++ b/tenable/io/plugins.py
@@ -15,8 +15,8 @@ Methods available on ``tio.plugins``:
     .. automethod:: list
     .. automethod:: plugin_details
 '''
-from .base import TIOEndpoint, TIOIterator
 from datetime import date
+from tenable.io.base import TIOEndpoint, TIOIterator
 
 
 class PluginIterator(TIOIterator):
@@ -93,6 +93,9 @@ class PluginIterator(TIOIterator):
 
 
 class PluginsAPI(TIOEndpoint):
+    '''
+    This will contain all methods related to plugins
+    '''
     def families(self):
         '''
         List the available plugin families.
@@ -109,14 +112,14 @@ class PluginsAPI(TIOEndpoint):
         '''
         return self._api.get('plugins/families').json()['families']
 
-    def family_details(self, id):
+    def family_details(self, family_id):
         '''
         Retrieve the details for a specific plugin family.
 
         :devportal:`plugins: family-details plugins-family-details>`
 
         Args:
-            id (int): The plugin family unique identifier.
+            family_id (int): The plugin family unique identifier.
 
         Returns:
             :obj:`dict`:
@@ -127,29 +130,29 @@ class PluginsAPI(TIOEndpoint):
             >>> family = tio.plugins.family_details(1)
         '''
         return self._api.get('plugins/families/{}'.format(
-                self._check('id', id, int)
+            self._check('family_id', family_id, int)
         )).json()
 
-    def plugin_details(self, id):
-            '''
-            Retrieve the details for a specific plugin.
+    def plugin_details(self, plugin_id):
+        '''
+        Retrieve the details for a specific plugin.
 
-            :devportal:`plugins: plugin-details <plugins-plugin-details>`
+        :devportal:`plugins: plugin-details <plugins-plugin-details>`
 
-            Args:
-                id (int): The plugin id for the requested plugin.
+        Args:
+            plugin_id (int): The plugin id for the requested plugin.
 
-            Returns:
-                :obj:`dict`:
-                    A dictionary stating the id, name, family, and any other
-                    relevant attributes associated to the plugin.
+        Returns:
+            :obj:`dict`:
+                A dictionary stating the id, name, family, and any other
+                relevant attributes associated to the plugin.
 
-            Examples:
-                >>> plugin = tio.plugins.plugin_details(19506)
-                >>> pprint(plugin)
-            '''
-            return self._api.get('plugins/plugin/{}'.format(
-                self._check('id', id, int))).json()
+        Examples:
+            >>> plugin = tio.plugins.plugin_details(19506)
+            >>> pprint(plugin)
+        '''
+        return self._api.get('plugins/plugin/{}'.format(
+            self._check('plugin_id', plugin_id, int))).json()
 
     def list(self, page=None, size=None, last_updated=None, num_pages=None):
         '''

--- a/tenable/io/plugins.py
+++ b/tenable/io/plugins.py
@@ -84,7 +84,8 @@ class PluginIterator(TIOIterator):
                 fid = self._maptable['plugins'][item['id']]
                 item['family_id'] = fid
                 item['family_name'] = self._maptable['families'][fid]
-            except:
+            except KeyError:
+                self._log.warning("plugin id {} not found in plugin family".format(item['id']))
                 item['family_id'] = None
                 item['family_name'] = None
 

--- a/tenable/io/plugins.py
+++ b/tenable/io/plugins.py
@@ -80,9 +80,13 @@ class PluginIterator(TIOIterator):
         # If the maptable exists, then graft on the plugin family information
         # on to to the item.
         if self._maptable:
-            fid = self._maptable['plugins'][item['id']]
-            item['family_id'] = fid
-            item['family_name'] = self._maptable['families'][fid]
+            try:
+                fid = self._maptable['plugins'][item['id']]
+                item['family_id'] = fid
+                item['family_name'] = self._maptable['families'][fid]
+            except:
+                item['family_id'] = None
+                item['family_name'] = None
 
         return item
 


### PR DESCRIPTION
# Description

-  **Issue :**

```
plugins = tio.plugins.list()
plugins.populate_maptable = True
for plugin in plugins:
    pprint(plugin)
```
getting below error when plugin not found in family
```
Traceback (most recent call last):
  File "REDACTED", line 9, in <module>
    for plugin in plugins:
  File "REDACTED", line 86, in __next__
    return self.next()
  File "REDACTED", line 83, in next
    fid = self._maptable['plugins'][item['id']]
KeyError: 32
```

-  **changes done :**
Assigned default value to family_id and family_name when not found

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested by running below program
```
plugins = tio.plugins.list()
plugins.populate_maptable = True
for plugin in plugins:
    pprint(plugin)
```

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
