### PR TITLE
Updated tags.delete with bulk delete feature

### DIFF
--- a/tenable/io/tags.py
+++ b/tenable/io/tags.py
@@ -145,24 +145,34 @@ class TagsAPI(TIOEndpoint):
             payload['description'] = self._check('description', description, str)
         return self._api.post('tags/categories', json=payload).json()
 
-    def delete(self, tag_value_uuid):
+    def delete(self, *tag_value_uuids):
         '''
-        Deletes a tag category/value pair.
+        Deletes tag value(s).
 
         :devportal:`tag: delete tag value <tags-delete-tag-value>`
 
         Args:
-            tag_value_uuid (str):
-                The unique identifier for the c/v pair to be deleted.
+            *tag_value_uuid (str):
+                The unique identifier for the tag value to be deleted.
 
         Returns:
             :obj:`None`
 
         Examples:
+            Deleting a single tag value:
+
             >>> tio.tags.delete('00000000-0000-0000-0000-000000000000')
+
+            Deleting multiple tag values:
+
+            >>> tio.tags.delete('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000001')
         '''
-        self._api.delete('tags/values/{}'.format(
-            self._check('tag_value_uuid', tag_value_uuid, 'uuid')))
+        if len(tag_value_uuids) <= 1:
+            self._api.delete('tags/values/{}'.format(
+                self._check('tag_value_uuid', tag_value_uuids[0], 'uuid')))
+        else:
+            self._api.post('tags/values/delete-requests',
+                json={'values': [self._check('tag_value_uuid', i, 'uuid') for i in tag_value_uuids]})
 
     def delete_category(self, tag_category_uuid):
         '''

--- a/tenable/io/tags.py
+++ b/tenable/io/tags.py
@@ -21,8 +21,8 @@ Methods available on ``tio.tags``:
     .. automethod:: list
     .. automethod:: list_categories
 '''
-from .base import TIOEndpoint, TIOIterator
 from tenable.errors import UnexpectedValueError
+from tenable.io.base import TIOEndpoint, TIOIterator
 
 class TagsIterator(TIOIterator):
     '''
@@ -46,19 +46,42 @@ class TagsIterator(TIOIterator):
     pass
 
 class TagsAPI(TIOEndpoint):
+    '''
+    This will contain all methods related to tags
+    '''
     _filterset_tags = {
-        'value': {'operators': ['eq', 'match'], 'pattern': None, 'choices': None},
-        'category_name': {'operators': ['eq', 'match'], 'pattern': None, 'choices': None},
-        'description': {'operators': ['eq', 'match'], 'pattern': None, 'choices': None},
-        'updated_at': {'operators': ['date-eq', 'date-gt', 'date-lt'], 'pattern': '\\d+', 'choices': None},
-        'updated_by': {'operators': ['eq'], 'pattern': None} # Add UUID regex here
+        'value': {
+            'operators': ['eq', 'match'], 'pattern': None, 'choices': None
+        },
+        'category_name': {
+            'operators': ['eq', 'match'], 'pattern': None, 'choices': None
+        },
+        'description': {
+            'operators': ['eq', 'match'], 'pattern': None, 'choices': None
+        },
+        'updated_at': {
+            'operators': ['date-eq', 'date-gt', 'date-lt'], 'pattern': '\\d+', 'choices': None
+        },
+        'updated_by': {
+            'operators': ['eq'], 'pattern': None
+        }  # Add UUID regex here
     }
     _filterset_categories = {
-        'name': {'operators': ['eq', 'match'], 'pattern': None, 'choices': None},
-        'description': {'operators': ['eq', 'match'], 'pattern': None, 'choices': None},
-        'created_at': {'operators': ['date-eq', 'date-gt', 'date-lt'], 'pattern': '\\d+', 'choices': None},
-        'updated_at': {'operators': ['date-eq', 'date-gt', 'date-lt'], 'pattern': '\\d+', 'choices': None},
-        'updated_by': {'operators': ['eq'], 'pattern': None, 'choices': None} # Add UUID regex here
+        'name': {
+            'operators': ['eq', 'match'], 'pattern': None, 'choices': None
+        },
+        'description': {
+            'operators': ['eq', 'match'], 'pattern': None, 'choices': None
+        },
+        'created_at': {
+            'operators': ['date-eq', 'date-gt', 'date-lt'], 'pattern': '\\d+', 'choices': None
+        },
+        'updated_at': {
+            'operators': ['date-eq', 'date-gt', 'date-lt'], 'pattern': '\\d+', 'choices': None
+        },
+        'updated_by': {
+            'operators': ['eq'], 'pattern': None, 'choices': None
+        } # Add UUID regex here
     }
 
     def create(self, category, value, description=None, filters=None,
@@ -165,14 +188,17 @@ class TagsAPI(TIOEndpoint):
 
             Deleting multiple tag values:
 
-            >>> tio.tags.delete('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000001')
+            >>> tio.tags.delete('00000000-0000-0000-0000-000000000000',
+            ...     '10000000-0000-0000-0000-000000000001')
         '''
         if len(tag_value_uuids) <= 1:
             self._api.delete('tags/values/{}'.format(
                 self._check('tag_value_uuid', tag_value_uuids[0], 'uuid')))
         else:
             self._api.post('tags/values/delete-requests',
-                json={'values': [self._check('tag_value_uuid', i, 'uuid') for i in tag_value_uuids]})
+                json={'values': [
+                    self._check('tag_value_uuid', i, 'uuid') for i in tag_value_uuids
+                ]})
 
     def delete_category(self, tag_category_uuid):
         '''

--- a/tests/io/cassettes/test_tags_delete_bulk_success.yaml
+++ b/tests/io/cassettes/test_tags_delete_bulk_success.yaml
@@ -1,0 +1,188 @@
+interactions:
+- request:
+    body: '{"category_name": "Example", "value": "Test1"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/values
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WQzWrDMBCE30XXRkG2/H9qaH0IpGmp3UtLMGtpHQy2bCS5rQl59yolhRx6COSm
+        nf1m2NGBTFMrSUYazqIgjGLqxVzSgPsRBUw8mqCULEww9uKaLIjQCBZlBdZ5fOZ7lAWUJaXHM84y
+        L1omPHq/4OrZcbaG7gtUuxRW342zvbeooO5wKYbesdMor8r8467JFI7cD3quzvWCUCaQ1g1NPY40
+        iOOU1gIY9cOU+yKBpg4DZ/uEbkKHl2is52Y7j6fRWLCtuIxV0J8W+Tf0Y4duA8a0e9WjspUYJuWq
+        MCcKgcY4QVk9dCQ7EDFpfWImg7oaUfet8w3KkOyDrDYbF/Sw2lb547o8P4u8rF7y16d1Uayft8VZ
+        fStyslsQiU2r3I/IoYdW3Z4HXfd7mbk96q/ov6ftjscfKgZQr3kCAAA=
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 08 Apr 2021 13:30:17 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-ud6hv-ap-southeast-1-prod
+      X-Request-Uuid:
+      - e8053e62adc8597fa91fe78750bd286c
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"category_name": "Example", "value": "Test2"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/values
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WQS2uDQBSF/8tsmwk6jom6amhdBNK0VLtpCXLnYRB0lJmxrYT8996UFLLoIpDd
+        fXzncM89kHFsFMlIlLBFLYSiQrGU8jiUNOULrIROw0hxloQhmRFpNXitKvCoYQELacBpkJRhlEVB
+        FibzgCfvF5yYkPMC2i8wzVx6ezdM/t5rA6LVc9l3yI6Dusrzj7vGUyK57+1UnePxWCWQippiGE35
+        cplSISGgLE4jJhOoRcxR9gntqBEvtfMMez8Np9Z58I28tDXQnRb5N3RDq3EDzjV702njK9mPBqME
+        OJRSO4cD423fkuxA5GjtiRmdttWgbdegrjeOZB9ktdmg0cNqW+WP6/JcFnlZveSvT+uiWD9vi/P0
+        rcjJbkaUrhuDH1F9B4253Q/a9vcyd7vVX9B/T9sdjz+7B3sReQIAAA==
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 08 Apr 2021 13:30:18 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-ud6hv-ap-southeast-1-prod
+      X-Request-Uuid:
+      - a39c363f3943659a909aab64f6d9abe5
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"values": ["f3064567-173d-4326-ae81-8edd058e717b", "3826fbbd-bd29-451c-9469-4be913d42811"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '92'
+      Content-Type:
+      - application/json
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/values/delete-requests
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 08 Apr 2021 13:30:19 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-ud6hv-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 3de821a0a3c8583f7fe2dfe7bead2862
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_tags_delete_bulk_success.yaml
+++ b/tests/io/cassettes/test_tags_delete_bulk_success.yaml
@@ -1,188 +1,193 @@
+---
 interactions:
-- request:
-    body: '{"category_name": "Example", "value": "Test1"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '46'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: POST
-    uri: https://cloud.tenable.com/tags/values
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6WQzWrDMBCE30XXRkG2/H9qaH0IpGmp3UtLMGtpHQy2bCS5rQl59yolhRx6COSm
-        nf1m2NGBTFMrSUYazqIgjGLqxVzSgPsRBUw8mqCULEww9uKaLIjQCBZlBdZ5fOZ7lAWUJaXHM84y
-        L1omPHq/4OrZcbaG7gtUuxRW342zvbeooO5wKYbesdMor8r8467JFI7cD3quzvWCUCaQ1g1NPY40
-        iOOU1gIY9cOU+yKBpg4DZ/uEbkKHl2is52Y7j6fRWLCtuIxV0J8W+Tf0Y4duA8a0e9WjspUYJuWq
-        MCcKgcY4QVk9dCQ7EDFpfWImg7oaUfet8w3KkOyDrDYbF/Sw2lb547o8P4u8rF7y16d1Uayft8VZ
-        fStyslsQiU2r3I/IoYdW3Z4HXfd7mbk96q/ov6ftjscfKgZQr3kCAAA=
-    headers:
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 08 Apr 2021 13:30:17 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Gateway-Site-ID:
-      - nginx-router-ud6hv-ap-southeast-1-prod
-      X-Request-Uuid:
-      - e8053e62adc8597fa91fe78750bd286c
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"category_name": "Example", "value": "Test2"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '46'
-      Content-Type:
-      - application/json
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: POST
-    uri: https://cloud.tenable.com/tags/values
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6WQS2uDQBSF/8tsmwk6jom6amhdBNK0VLtpCXLnYRB0lJmxrYT8996UFLLoIpDd
-        fXzncM89kHFsFMlIlLBFLYSiQrGU8jiUNOULrIROw0hxloQhmRFpNXitKvCoYQELacBpkJRhlEVB
-        FibzgCfvF5yYkPMC2i8wzVx6ezdM/t5rA6LVc9l3yI6Dusrzj7vGUyK57+1UnePxWCWQippiGE35
-        cplSISGgLE4jJhOoRcxR9gntqBEvtfMMez8Np9Z58I28tDXQnRb5N3RDq3EDzjV702njK9mPBqME
-        OJRSO4cD423fkuxA5GjtiRmdttWgbdegrjeOZB9ktdmg0cNqW+WP6/JcFnlZveSvT+uiWD9vi/P0
-        rcjJbkaUrhuDH1F9B4253Q/a9vcyd7vVX9B/T9sdjz+7B3sReQIAAA==
-    headers:
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 08 Apr 2021 13:30:18 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Gateway-Site-ID:
-      - nginx-router-ud6hv-ap-southeast-1-prod
-      X-Request-Uuid:
-      - a39c363f3943659a909aab64f6d9abe5
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"values": ["f3064567-173d-4326-ae81-8edd058e717b", "3826fbbd-bd29-451c-9469-4be913d42811"]}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '92'
-      Content-Type:
-      - application/json
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: POST
-    uri: https://cloud.tenable.com/tags/values/delete-requests
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/octet-stream
-      Date:
-      - Thu, 08 Apr 2021 13:30:19 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Gateway-Site-ID:
-      - nginx-router-ud6hv-ap-southeast-1-prod
-      X-Request-Uuid:
-      - 3de821a0a3c8583f7fe2dfe7bead2862
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
+  - request:
+      body: '{"category_name": "Example", "value": "Test1"}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '46'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: POST
+      uri: https://cloud.tenable.com/tags/values
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA6WQzWrDMBCE30XXRkG2/H9qaH0IpGmp3UtLMGtpHQy2bCS5rQl59yolhRx6COSm
+          nf1m2NGBTFMrSUYazqIgjGLqxVzSgPsRBUw8mqCULEww9uKaLIjQCBZlBdZ5fOZ7lAWUJaXHM84y
+          L1omPHq/4OrZcbaG7gtUuxRW342zvbeooO5wKYbesdMor8r8467JFI7cD3quzvWCUCaQ1g1NPY40
+          iOOU1gIY9cOU+yKBpg4DZ/uEbkKHl2is52Y7j6fRWLCtuIxV0J8W+Tf0Y4duA8a0e9WjspUYJuWq
+          MCcKgcY4QVk9dCQ7EDFpfWImg7oaUfet8w3KkOyDrDYbF/Sw2lb547o8P4u8rF7y16d1Uayft8VZ
+          fStyslsQiU2r3I/IoYdW3Z4HXfd7mbk96q/ov6ftjscfKgZQr3kCAAA=
+      headers:
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 08 Apr 2021 13:30:17 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        Vary:
+          - accept-encoding
+        X-Content-Type-Options:
+          - nosniff
+        X-Gateway-Site-ID:
+          - nginx-router-ud6hv-ap-southeast-1-prod
+        X-Request-Uuid:
+          - e8053e62adc8597fa91fe78750bd286c
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"category_name": "Example", "value": "Test2"}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '46'
+        Content-Type:
+          - application/json
+        Cookie:
+          - nginx-cloud-site-id=us-2b
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: POST
+      uri: https://cloud.tenable.com/tags/values
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA6WQS2uDQBSF/8tsmwk6jom6amhdBNK0VLtpCXLnYRB0lJmxrYT8996UFLLoIpDd
+          fXzncM89kHFsFMlIlLBFLYSiQrGU8jiUNOULrIROw0hxloQhmRFpNXitKvCoYQELacBpkJRhlEVB
+          FibzgCfvF5yYkPMC2i8wzVx6ezdM/t5rA6LVc9l3yI6Dusrzj7vGUyK57+1UnePxWCWQippiGE35
+          cplSISGgLE4jJhOoRcxR9gntqBEvtfMMez8Np9Z58I28tDXQnRb5N3RDq3EDzjV702njK9mPBqME
+          OJRSO4cD423fkuxA5GjtiRmdttWgbdegrjeOZB9ktdmg0cNqW+WP6/JcFnlZveSvT+uiWD9vi/P0
+          rcjJbkaUrhuDH1F9B4253Q/a9vcyd7vVX9B/T9sdjz+7B3sReQIAAA==
+      headers:
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 08 Apr 2021 13:30:18 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        Vary:
+          - accept-encoding
+        X-Content-Type-Options:
+          - nosniff
+        X-Gateway-Site-ID:
+          - nginx-router-ud6hv-ap-southeast-1-prod
+        X-Request-Uuid:
+          - a39c363f3943659a909aab64f6d9abe5
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: '{"values": ["f3064567-173d-4326-ae81-8edd058e717b",\
+       "3826fbbd-bd29-451c-9469-4be913d42811"]}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '92'
+        Content-Type:
+          - application/json
+        Cookie:
+          - nginx-cloud-site-id=us-2b
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: POST
+      uri: https://cloud.tenable.com/tags/values/delete-requests
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        Content-Type:
+          - application/octet-stream
+        Date:
+          - Thu, 08 Apr 2021 13:30:19 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        X-Content-Type-Options:
+          - nosniff
+        X-Gateway-Site-ID:
+          - nginx-router-ud6hv-ap-southeast-1-prod
+        X-Request-Uuid:
+          - 3de821a0a3c8583f7fe2dfe7bead2862
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/io/cassettes/test_tags_delete_bulk_typeerror.yaml
+++ b/tests/io/cassettes/test_tags_delete_bulk_typeerror.yaml
@@ -1,0 +1,120 @@
+interactions:
+- request:
+    body: '{"category_name": "Example", "value": "Test"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '45'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/values
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WQS2vDMBCE/4uujYL8imyfGlofAmlaavfSEszqkSCQZSPJbU3If69SUsihh0Bu
+        2tlvhh0d0DgqgUq0YFFeiAXFqcgFTgsQmGU5xZRFhAGNIKMczRC3ErwULfjgiUkcYZJikjdRUiak
+        JPE8ThbvFxybAucZ6C8was69vRsmf++lAablnPddYMdBXJX5x12TyQO57+3UnuulmcihYDtcRInE
+        KaUFZhwIjrMiiXkOO5alwfYJepQBb6TzYfTTcJqcB6/4ZaqB7rSovqEbtAwbcE7tTSeNb3k/mtCE
+        BJFz6VwQjLe9RuUB8dHaEzM6adtB2k4FX28cKj/Qcr0OQQ/LTVs9rprzs66a9qV6fVrV9ep5U5/V
+        t7pC2xkScqdM+BDRd6DM7Xmg9e9l7vaov6L/nrY9Hn8A9+riXXgCAAA=
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 08 Apr 2021 13:30:02 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-ud6hv-ap-southeast-1-prod
+      X-Request-Uuid:
+      - c49355c550a7c06cbdb27842d76dfa30
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/tags/values/6b189d67-4d8d-49ad-b587-7b10ba71a57c
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 08 Apr 2021 13:30:03 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-ud6hv-ap-southeast-1-prod
+      X-Request-Uuid:
+      - a0ac31212a1e1cd003bc2973283ea04b
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/cassettes/test_tags_delete_bulk_typeerror.yaml
+++ b/tests/io/cassettes/test_tags_delete_bulk_typeerror.yaml
@@ -1,120 +1,123 @@
+---
 interactions:
-- request:
-    body: '{"category_name": "Example", "value": "Test"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '45'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: POST
-    uri: https://cloud.tenable.com/tags/values
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6WQS2vDMBCE/4uujYL8imyfGlofAmlaavfSEszqkSCQZSPJbU3If69SUsihh0Bu
-        2tlvhh0d0DgqgUq0YFFeiAXFqcgFTgsQmGU5xZRFhAGNIKMczRC3ErwULfjgiUkcYZJikjdRUiak
-        JPE8ThbvFxybAucZ6C8was69vRsmf++lAablnPddYMdBXJX5x12TyQO57+3UnuulmcihYDtcRInE
-        KaUFZhwIjrMiiXkOO5alwfYJepQBb6TzYfTTcJqcB6/4ZaqB7rSovqEbtAwbcE7tTSeNb3k/mtCE
-        BJFz6VwQjLe9RuUB8dHaEzM6adtB2k4FX28cKj/Qcr0OQQ/LTVs9rprzs66a9qV6fVrV9ep5U5/V
-        t7pC2xkScqdM+BDRd6DM7Xmg9e9l7vaov6L/nrY9Hn8A9+riXXgCAAA=
-    headers:
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 08 Apr 2021 13:30:02 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Gateway-Site-ID:
-      - nginx-router-ud6hv-ap-southeast-1-prod
-      X-Request-Uuid:
-      - c49355c550a7c06cbdb27842d76dfa30
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: DELETE
-    uri: https://cloud.tenable.com/tags/values/6b189d67-4d8d-49ad-b587-7b10ba71a57c
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/octet-stream
-      Date:
-      - Thu, 08 Apr 2021 13:30:03 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Gateway-Site-ID:
-      - nginx-router-ud6hv-ap-southeast-1-prod
-      X-Request-Uuid:
-      - a0ac31212a1e1cd003bc2973283ea04b
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
+  - request:
+      body: '{"category_name": "Example", "value": "Test"}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '45'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: POST
+      uri: https://cloud.tenable.com/tags/values
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA6WQS2vDMBCE/4uujYL8imyfGlofAmlaavfSEszqkSCQZSPJbU3If69SUsihh0Bu
+          2tlvhh0d0DgqgUq0YFFeiAXFqcgFTgsQmGU5xZRFhAGNIKMczRC3ErwULfjgiUkcYZJikjdRUiak
+          JPE8ThbvFxybAucZ6C8was69vRsmf++lAablnPddYMdBXJX5x12TyQO57+3UnuulmcihYDtcRInE
+          KaUFZhwIjrMiiXkOO5alwfYJepQBb6TzYfTTcJqcB6/4ZaqB7rSovqEbtAwbcE7tTSeNb3k/mtCE
+          BJFz6VwQjLe9RuUB8dHaEzM6adtB2k4FX28cKj/Qcr0OQQ/LTVs9rprzs66a9qV6fVrV9ep5U5/V
+          t7pC2xkScqdM+BDRd6DM7Xmg9e9l7vaov6L/nrY9Hn8A9+riXXgCAAA=
+      headers:
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 08 Apr 2021 13:30:02 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        Vary:
+          - accept-encoding
+        X-Content-Type-Options:
+          - nosniff
+        X-Gateway-Site-ID:
+          - nginx-router-ud6hv-ap-southeast-1-prod
+        X-Request-Uuid:
+          - c49355c550a7c06cbdb27842d76dfa30
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        Cookie:
+          - nginx-cloud-site-id=us-2b
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: DELETE
+      uri: https://cloud.tenable.com/tags/values/6b189d67-4d8d-49ad-b587-7b10ba71a57c
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        Content-Type:
+          - application/octet-stream
+        Date:
+          - Thu, 08 Apr 2021 13:30:03 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        X-Content-Type-Options:
+          - nosniff
+        X-Gateway-Site-ID:
+          - nginx-router-ud6hv-ap-southeast-1-prod
+        X-Request-Uuid:
+          - a0ac31212a1e1cd003bc2973283ea04b
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/io/cassettes/test_tags_delete_bulk_unexpectedvalueerror.yaml
+++ b/tests/io/cassettes/test_tags_delete_bulk_unexpectedvalueerror.yaml
@@ -1,120 +1,123 @@
+---
 interactions:
-- request:
-    body: '{"category_name": "Example", "value": "Test"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '45'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: POST
-    uri: https://cloud.tenable.com/tags/values
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6WQzWrDMBCE30XXRkH+w7JPDa0PgTQttXtpCWa9koPBlo0ktzUh7165JJBDDoHo
-        pJ39ZtjdAxnHRpCUiEiE6B4F9JCGYS0pj72IRn5d8SCO49qTZEFQS7BSlGCdx2e+R1lIGS+8IA1Y
-        ypJlwvnnBVdNjrMVtD+gmiVa/TBM9tFKBVUrl9h3jh0HcVPmmbslEx257/VUntYLI8EhqWqaeIGk
-        YRwntEJg1I+SwEcOdRWFzvYN7SgdXkhjXWmnYa6MBdvgZaqCbm5kv9AN7XwXMKbZq04qW2I/KrcJ
-        cyKiNMYJyuq+JemB4Kj1zIxG6nKQumucr1eGpF9ktdm4oKfVtsye18Xpm2dF+Za9v6zzfP26zU/q
-        R56R3YIIWTfKHUT0HTTq/jxo2//JzP1R50WvjrY7Hv8Asl3ZE3gCAAA=
-    headers:
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 08 Apr 2021 13:30:10 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Gateway-Site-ID:
-      - nginx-router-k6ayn-ap-southeast-1-prod
-      X-Request-Uuid:
-      - 87eb6f33b9560e9a4cdfa64a5942721e
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Cookie:
-      - nginx-cloud-site-id=us-2b
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: DELETE
-    uri: https://cloud.tenable.com/tags/values/d5d4cccc-ac1c-44fe-8715-52fb83777f1e
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/octet-stream
-      Date:
-      - Thu, 08 Apr 2021 13:30:11 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-Content-Type-Options:
-      - nosniff
-      X-Gateway-Site-ID:
-      - nginx-router-k6ayn-ap-southeast-1-prod
-      X-Request-Uuid:
-      - 3cc3eb80cb864348edb801e02f876335
-      X-XSS-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
+  - request:
+      body: '{"category_name": "Example", "value": "Test"}'
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '45'
+        Content-Type:
+          - application/json
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: POST
+      uri: https://cloud.tenable.com/tags/values
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA6WQzWrDMBCE30XXRkH+w7JPDa0PgTQttXtpCWa9koPBlo0ktzUh7165JJBDDoHo
+          pJ39ZtjdAxnHRpCUiEiE6B4F9JCGYS0pj72IRn5d8SCO49qTZEFQS7BSlGCdx2e+R1lIGS+8IA1Y
+          ypJlwvnnBVdNjrMVtD+gmiVa/TBM9tFKBVUrl9h3jh0HcVPmmbslEx257/VUntYLI8EhqWqaeIGk
+          YRwntEJg1I+SwEcOdRWFzvYN7SgdXkhjXWmnYa6MBdvgZaqCbm5kv9AN7XwXMKbZq04qW2I/KrcJ
+          cyKiNMYJyuq+JemB4Kj1zIxG6nKQumucr1eGpF9ktdm4oKfVtsye18Xpm2dF+Za9v6zzfP26zU/q
+          R56R3YIIWTfKHUT0HTTq/jxo2//JzP1R50WvjrY7Hv8Asl3ZE3gCAAA=
+      headers:
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Thu, 08 Apr 2021 13:30:10 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        Vary:
+          - accept-encoding
+        X-Content-Type-Options:
+          - nosniff
+        X-Gateway-Site-ID:
+          - nginx-router-k6ayn-ap-southeast-1-prod
+        X-Request-Uuid:
+          - 87eb6f33b9560e9a4cdfa64a5942721e
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        Cookie:
+          - nginx-cloud-site-id=us-2b
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: DELETE
+      uri: https://cloud.tenable.com/tags/values/d5d4cccc-ac1c-44fe-8715-52fb83777f1e
+    response:
+      body:
+        string: ''
+      headers:
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Length:
+          - '0'
+        Content-Type:
+          - application/octet-stream
+        Date:
+          - Thu, 08 Apr 2021 13:30:11 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        X-Content-Type-Options:
+          - nosniff
+        X-Gateway-Site-ID:
+          - nginx-router-k6ayn-ap-southeast-1-prod
+        X-Request-Uuid:
+          - 3cc3eb80cb864348edb801e02f876335
+        X-XSS-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/io/cassettes/test_tags_delete_bulk_unexpectedvalueerror.yaml
+++ b/tests/io/cassettes/test_tags_delete_bulk_unexpectedvalueerror.yaml
@@ -1,0 +1,120 @@
+interactions:
+- request:
+    body: '{"category_name": "Example", "value": "Test"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '45'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: POST
+    uri: https://cloud.tenable.com/tags/values
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6WQzWrDMBCE30XXRkH+w7JPDa0PgTQttXtpCWa9koPBlo0ktzUh7165JJBDDoHo
+        pJ39ZtjdAxnHRpCUiEiE6B4F9JCGYS0pj72IRn5d8SCO49qTZEFQS7BSlGCdx2e+R1lIGS+8IA1Y
+        ypJlwvnnBVdNjrMVtD+gmiVa/TBM9tFKBVUrl9h3jh0HcVPmmbslEx257/VUntYLI8EhqWqaeIGk
+        YRwntEJg1I+SwEcOdRWFzvYN7SgdXkhjXWmnYa6MBdvgZaqCbm5kv9AN7XwXMKbZq04qW2I/KrcJ
+        cyKiNMYJyuq+JemB4Kj1zIxG6nKQumucr1eGpF9ktdm4oKfVtsye18Xpm2dF+Za9v6zzfP26zU/q
+        R56R3YIIWTfKHUT0HTTq/jxo2//JzP1R50WvjrY7Hv8Asl3ZE3gCAAA=
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 08 Apr 2021 13:30:10 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-k6ayn-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 87eb6f33b9560e9a4cdfa64a5942721e
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Cookie:
+      - nginx-cloud-site-id=us-2b
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: DELETE
+    uri: https://cloud.tenable.com/tags/values/d5d4cccc-ac1c-44fe-8715-52fb83777f1e
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Thu, 08 Apr 2021 13:30:11 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Gateway-Site-ID:
+      - nginx-router-k6ayn-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 3cc3eb80cb864348edb801e02f876335
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/test_tags.py
+++ b/tests/io/test_tags.py
@@ -1,13 +1,23 @@
-from ..checker import check, single
+'''
+test tags
+'''
+import uuid
+import pytest
+from tests.checker import check, single
 from tenable.errors import UnexpectedValueError, NotFoundError
 from tenable.io.tags import TagsIterator
-import uuid, pytest
 
 @pytest.fixture
 @pytest.mark.vcr()
 def tagvalue(request, api):
+    '''
+    Fixture to create tag value
+    '''
     tag = api.tags.create('Example', 'Test')
     def teardown():
+        '''
+        cleanup function to delete tag value
+        '''
         try:
             api.tags.delete(tag['uuid'])
         except NotFoundError:
@@ -18,8 +28,14 @@ def tagvalue(request, api):
 @pytest.fixture
 @pytest.mark.vcr()
 def tagcat(request, api):
+    '''
+    Fixture to create tag category
+    '''
     tag = api.tags.create_category('Example3')
     def teardown():
+        '''
+        cleanup function to delete tag category
+        '''
         try:
             api.tags.delete_category(tag['uuid'])
         except NotFoundError:
@@ -29,26 +45,42 @@ def tagcat(request, api):
 
 @pytest.mark.vcr()
 def test_tags_create_category_typeerror(api):
+    '''
+    test to raise exception when type of category param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.create(1, '')
 
 @pytest.mark.vcr()
 def test_tags_create_value_typerror(api):
+    '''
+    test to raise exception when type of value param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.create('', 1)
 
 @pytest.mark.vcr()
 def test_tags_create_value_description_typerror(api):
+    '''
+    test to raise exception when type of description param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.create('', '', description=1)
 
 @pytest.mark.vcr()
 def test_tags_create_value_category_description_typeerror(api):
+    '''
+    test to raise exception when type of category_description
+    param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.create('', '', category_description=1)
 
 @pytest.mark.vcr()
 def test_tags_create_success(api, tagvalue):
+    '''
+    test to create tag value.
+    '''
     assert isinstance(tagvalue, dict)
     check(tagvalue, 'uuid', 'uuid')
     check(tagvalue, 'created_at', 'datetime')
@@ -61,16 +93,25 @@ def test_tags_create_success(api, tagvalue):
 
 @pytest.mark.vcr()
 def test_tags_create_category_name_typeerror(api):
+    '''
+    test to raise exception when type of name param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.create_category(1)
 
 @pytest.mark.vcr()
 def test_tags_create_category_description_typeerror(api):
+    '''
+    test to raise exception when type of description param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.create_category('', description=1)
 
 @pytest.mark.vcr()
 def test_tags_create_category_success(api, tagcat):
+    '''
+    test to create tag category.
+    '''
     assert isinstance(tagcat, dict)
     check(tagcat, 'uuid', 'uuid')
     check(tagcat, 'created_at', 'datetime')
@@ -82,199 +123,295 @@ def test_tags_create_category_success(api, tagcat):
 
 @pytest.mark.vcr()
 def test_tags_delete_uuid_typeerror(api):
+    '''
+    test to raise exception when type of tag_value_uuid param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.delete(1)
 
 @pytest.mark.vcr()
 def test_tags_delete_uuid_unexpectedvalueerror(api):
+    '''
+    test to raise exception when type of tag_value_uuid param does not match the expected type.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.delete('1')
 
 @pytest.mark.vcr()
 def test_tags_delete_success(api, tagvalue):
+    '''
+    test to delete tag value.
+    '''
     api.tags.delete(tagvalue['uuid'])
 
 @pytest.mark.vcr()
 def test_tags_delete_bulk_typeerror(api, tagvalue):
+    '''
+    test to raise exception when type of tag_value_uuid param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.delete(tagvalue['uuid'], 1)
 
 @pytest.mark.vcr()
 def test_tags_delete_bulk_unexpectedvalueerror(api, tagvalue):
+    '''
+    test to raise exception when type of tag_value_uuid param does not match the expected type.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.delete(tagvalue['uuid'], 'nope')
 
 @pytest.mark.vcr()
 def test_tags_delete_bulk_success(api):
+    '''
+    test to delete multiple tags .
+    '''
     tag1 = api.tags.create('Example', 'Test1')
     tag2 = api.tags.create('Example', 'Test2')
     api.tags.delete(tag1['uuid'], tag2['uuid'])
 
 @pytest.mark.vcr()
 def test_tags_delete_category_uuid_typeerror(api):
+    '''
+    test to raise exception when type of tag_category_uuid param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.delete_category(1)
 
 @pytest.mark.vcr()
 def test_tags_delete_category_uuid_unexpectedvalueerror(api):
+    '''
+    test to raise exception when type of tag_category_uuid param does not match the expected type.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.delete_category('1')
 
 @pytest.mark.vcr()
 def test_tags_delete_category_success(api, tagcat):
+    '''
+    test to delete tag category.
+    '''
     api.tags.delete_category(tagcat['uuid'])
 
 @pytest.mark.vcr()
 def test_tags_details_uuid_typeerror(api):
+    '''
+    test to raise exception when type of tag_value_uuid param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.details(1)
 
 @pytest.mark.vcr()
 def test_tags_details_unexpectedvalueerror(api):
+    '''
+    test to raise exception when type of tag_value_uuid param does not match the expected type.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.details('1')
 
 @pytest.mark.vcr()
 def test_tags_details_success(api, tagvalue):
-    t = api.tags.details(tagvalue['uuid'])
-    assert isinstance(t, dict)
-    check(t, 'uuid', 'uuid')
-    check(t, 'created_at', 'datetime')
-    check(t, 'created_by', str)
-    check(t, 'updated_at', 'datetime')
-    check(t, 'updated_by', str)
-    check(t, 'category_uuid', 'uuid')
-    check(t, 'value', str)
-    check(t, 'type', str)
+    '''
+    test to get details for a specific tag category/value pair.
+    '''
+    details = api.tags.details(tagvalue['uuid'])
+    assert isinstance(details, dict)
+    check(details, 'uuid', 'uuid')
+    check(details, 'created_at', 'datetime')
+    check(details, 'created_by', str)
+    check(details, 'updated_at', 'datetime')
+    check(details, 'updated_by', str)
+    check(details, 'category_uuid', 'uuid')
+    check(details, 'value', str)
+    check(details, 'type', str)
     #check(t, 'description', str, allow_none=True)
-    check(t, 'category_name', str)
+    check(details, 'category_name', str)
     #check(t, 'category_description', str, allow_none=True)
 
 @pytest.mark.vcr()
 def test_tags_details_category_uuid_typeerror(api):
+    '''
+    test to raise exception when type of tag_category_uuid param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.details_category(1)
 
 @pytest.mark.vcr()
 def test_tags_details_category_unexpectedvalueerror(api):
+    '''
+    test to raise exception when type of tag_category_uuid param does not match the expected type.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.details_category('1')
 
 @pytest.mark.vcr()
 def test_tags_details_category_success(api, tagcat):
-    t = api.tags.details_category(tagcat['uuid'])
-    assert isinstance(t, dict)
-    check(t, 'uuid', 'uuid')
-    check(t, 'created_at', 'datetime')
-    check(t, 'created_by', str)
-    check(t, 'updated_at', 'datetime')
-    check(t, 'updated_by', str)
-    check(t, 'name', str)
+    '''
+    test to get details for a specific tag category.
+    '''
+    details = api.tags.details_category(tagcat['uuid'])
+    assert isinstance(details, dict)
+    check(details, 'uuid', 'uuid')
+    check(details, 'created_at', 'datetime')
+    check(details, 'created_by', str)
+    check(details, 'updated_at', 'datetime')
+    check(details, 'updated_by', str)
+    check(details, 'name', str)
     #check(t, 'description', str, allow_none=True)
-    check(t, 'reserved', bool)
+    check(details, 'reserved', bool)
 
 @pytest.mark.vcr()
 def test_tags_edit_uuid_typeerror(api):
+    '''
+    test to raise exception when type of tag_value_uuid param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.edit(1)
 
 @pytest.mark.vcr()
 def test_tags_edit_uuid_unexpectedvalueerror(api):
+    '''
+    test to raise exception when type of tag_value_uuid param does not match the expected type.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.edit('1')
 
 @pytest.mark.vcr()
 def test_tags_edit_value_typeerror(api):
+    '''
+    test to raise exception when type of value param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.edit(uuid.uuid4(), value=1)
 
 @pytest.mark.vcr()
 def test_tags_edit_description_typeerror(api):
+    '''
+    test to raise exception when type of description param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.edit(uuid.uuid4(), description=1)
 
 @pytest.mark.vcr()
 def test_tags_edit_success(api, tagvalue):
-    t = api.tags.edit(tagvalue['uuid'], value='Edited')
-    assert isinstance(t, dict)
-    check(t, 'uuid', 'uuid')
-    check(t, 'created_at', 'datetime')
-    check(t, 'created_by', str)
-    check(t, 'updated_at', 'datetime')
-    check(t, 'updated_by', str)
-    check(t, 'category_uuid', 'uuid')
-    check(t, 'value', str)
-    check(t, 'type', str)
+    '''
+    test to edit tag category/value pair information.
+    '''
+    resp = api.tags.edit(tagvalue['uuid'], value='Edited')
+    assert isinstance(resp, dict)
+    check(resp, 'uuid', 'uuid')
+    check(resp, 'created_at', 'datetime')
+    check(resp, 'created_by', str)
+    check(resp, 'updated_at', 'datetime')
+    check(resp, 'updated_by', str)
+    check(resp, 'category_uuid', 'uuid')
+    check(resp, 'value', str)
+    check(resp, 'type', str)
     #check(t, 'description', str, allow_none=True)
-    check(t, 'category_name', str)
+    check(resp, 'category_name', str)
     #check(t, 'category_description', str, allow_none=True)
-    assert t['value'] == 'Edited'
+    assert resp['value'] == 'Edited'
 
 @pytest.mark.vcr()
 def test_tags_edit_category_uuid_typeerror(api):
+    '''
+    test to raise exception when type of tag_category_uuid param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.edit_category(1)
 
 @pytest.mark.vcr()
 def test_tags_edit_category_uuid_unexpectedvalueerror(api):
+    '''
+    test to raise exception when type of tag_category_uuid param does not match the expected type.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.edit_category('1')
 
 @pytest.mark.vcr()
 def test_tags_edit_category_value_typeerror(api):
+    '''
+    test to raise exception when type of value param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.edit_category(uuid.uuid4(), value=1)
 
 @pytest.mark.vcr()
 def test_tags_edit_category_description_typeerror(api):
+    '''
+    test to raise exception when type of description param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.edit_category(uuid.uuid4(), description=1)
 
 @pytest.mark.vcr()
 def test_tags_edit_category_success(api, tagcat):
-    t = api.tags.edit_category(tagcat['uuid'], name='Edited')
-    assert isinstance(t, dict)
-    check(t, 'uuid', 'uuid')
-    check(t, 'created_at', 'datetime')
-    check(t, 'created_by', str)
-    check(t, 'updated_at', 'datetime')
-    check(t, 'updated_by', str)
-    check(t, 'name', str)
+    '''
+    test to edit tag category information.
+    '''
+    resp = api.tags.edit_category(tagcat['uuid'], name='Edited')
+    assert isinstance(resp, dict)
+    check(resp, 'uuid', 'uuid')
+    check(resp, 'created_at', 'datetime')
+    check(resp, 'created_by', str)
+    check(resp, 'updated_at', 'datetime')
+    check(resp, 'updated_by', str)
+    check(resp, 'name', str)
     #check(t, 'description', str, allow_none=True)
-    check(t, 'reserved', bool)
-    assert t['name'] == 'Edited'
+    check(resp, 'reserved', bool)
+    assert resp['name'] == 'Edited'
 
 def test_tags_list_constructor_filter_type_typeerror(api):
+    '''
+    test to raise exception when type of filter_type param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags._tag_list_constructor([],
             api.tags._filterset_tags, True, None)
 
 def test_tags_list_constructor_filter_type_unexpectedvalueerror(api):
+    '''
+    test to raise exception when filter_type param value does not match the choices.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags._tag_list_constructor([],
             api.tags._filterset_tags, 'nadda', None)
 
 def test_tags_list_constructor_filter_type_success(api):
+    '''
+    test to check filter_type param in tags_list_constructor method.
+    '''
     resp = api.tags._tag_list_constructor([],
         api.tags._filterset_tags, 'and', None)
     assert resp['ft'] == 'AND'
 
 def test_tags_list_constructor_sort_typeerror(api):
+    '''
+    test to raise exception when type of sort param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags._tag_list_constructor([],
             api.tags._filterset_tags, None, 1)
 
 def test_tags_list_constructor_sort_unexpectedvalueerror(api):
+    '''
+    test to raise exception when sort param value does not match the choices.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags._tag_list_constructor([],
             api.tags._filterset_tags, None, (('something_else'),))
 
 def test_tags_list_constructor_sort_success(api):
+    '''
+    test to check sort param in tags_list_constructor method.
+    '''
     resp = api.tags._tag_list_constructor([],
         api.tags._filterset_tags, None, (('value','asc'),))
     assert resp['sort'] == 'value:asc'
 
 def test_tags_list_constructor_filter_success(api):
+    '''
+    test to check filter param in tags_list_constructor method.
+    '''
     resp = api.tags._tag_list_constructor([
         ('value', 'eq', 'Test')
     ], api.tags._filterset_tags, None, None)
@@ -282,108 +419,159 @@ def test_tags_list_constructor_filter_success(api):
 
 @pytest.mark.vcr()
 def test_tags_list_success(api, tagvalue):
+    '''
+    test to get list of tags.
+    '''
     tags = api.tags.list()
     assert isinstance(tags, TagsIterator)
-    t = tags.next()
-    check(t, 'uuid', 'uuid')
-    check(t, 'created_at', 'datetime')
-    check(t, 'created_by', str)
-    check(t, 'updated_at', 'datetime')
-    check(t, 'updated_by', str)
-    check(t, 'category_uuid', 'uuid')
-    check(t, 'value', str)
-    check(t, 'type', str)
+    resp = tags.next()
+    check(resp, 'uuid', 'uuid')
+    check(resp, 'created_at', 'datetime')
+    check(resp, 'created_by', str)
+    check(resp, 'updated_at', 'datetime')
+    check(resp, 'updated_by', str)
+    check(resp, 'category_uuid', 'uuid')
+    check(resp, 'value', str)
+    check(resp, 'type', str)
     #check(t, 'description', str, allow_none=True)
-    check(t, 'category_name', str)
+    check(resp, 'category_name', str)
     #check(t, 'category_description', str, allow_none=True)
 
 @pytest.mark.vcr()
 def test_tags_list_category_success(api, tagcat):
+    '''
+    test to list of tag categories.
+    '''
     tags = api.tags.list_categories()
     assert isinstance(tags, TagsIterator)
-    t = tags.next()
-    check(t, 'uuid', 'uuid')
-    check(t, 'created_at', 'datetime')
-    check(t, 'created_by', str)
-    check(t, 'updated_at', 'datetime')
-    check(t, 'updated_by', str)
-    check(t, 'name', str)
+    resp = tags.next()
+    check(resp, 'uuid', 'uuid')
+    check(resp, 'created_at', 'datetime')
+    check(resp, 'created_by', str)
+    check(resp, 'updated_at', 'datetime')
+    check(resp, 'updated_by', str)
+    check(resp, 'name', str)
     #check(t, 'description', str, allow_none=True)
     #check(t, 'reserved', bool)
 
 @pytest.mark.vcr()
 def test_tags_list_date_failure(api):
+    '''
+    test to raise exception when value of filter tuple does not match the expected.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.list(('updated_at', 'eq', 'something_else'))
 
 @pytest.mark.vcr()
 def test_tags_assign_assets_typeerror_list(api):
+    '''
+    test to raise exception when type of asset param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.assign(1, [])
 
 @pytest.mark.vcr()
 def test_tags_assign_assets_typeerror_entity(api):
+    '''
+    test to raise exception when type of asset param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.assign([1,], [])
 
 @pytest.mark.vcr()
 def test_tags_assign_assets_unexpectedvalueerror_entity(api):
+    '''
+    test to raise exception when asset param value does not match the expected.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.assign(['something'], [])
 
 @pytest.mark.vcr()
 def test_tags_assign_tags_typeerror_list(api):
+    '''
+    test to raise exception when type of tags param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.assign([], 1)
 
 @pytest.mark.vcr()
 def test_tags_assign_tags_typeerror_entity(api):
+    '''
+    test to raise exception when type of tags param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.assign([], [1, ])
 
 @pytest.mark.vcr()
 def test_tags_assign_tags_unexpectedvalueerror_entity(api):
+    '''
+    test to raise exception when tags param value does not match the expected.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.assign([], ['something', ])
 
 @pytest.mark.vcr()
 def test_tags_assign_success(api, tagvalue):
+    '''
+    test to assign tags to assets.
+    '''
     assets = api.assets.list()
     resp = api.tags.assign([a['id'] for a in assets], [tagvalue['uuid']])
     single(resp, str)
 
 @pytest.mark.vcr()
 def test_tags_unassign_assets_typeerror_list(api):
+    '''
+    test to raise exception when type of asstes param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.unassign(1, [])
 
 @pytest.mark.vcr()
 def test_tags_unassign_assets_typeerror_entity(api):
+    '''
+    test to raise exception when type of assets param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.unassign([1,], [])
 
 @pytest.mark.vcr()
 def test_tags_unassign_assets_unexpectedvalueerror_entity(api):
+    '''
+    test to raise exception when assets param value does not match the expected.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.unassign(['something'], [])
 
 @pytest.mark.vcr()
 def test_tags_unassign_tags_typeerror_list(api):
+    '''
+    test to unassign tags from assets.
+    '''
     with pytest.raises(TypeError):
         api.tags.unassign([], 1)
 
 @pytest.mark.vcr()
 def test_tags_unassign_tags_typeerror_entity(api):
+    '''
+    test to raise exception when type of tags param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.tags.unassign([], [1, ])
 
 @pytest.mark.vcr()
 def test_tags_unassign_tags_unexpectedvalueerror_entity(api):
+    '''
+    test to raise exception when type of tags param does not match the expected type.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.tags.unassign([], ['something', ])
 
 @pytest.mark.vcr()
 def test_tags_unassign_success(api, tagvalue):
+    '''
+    test to raise exception when tags param value does not match the expected.
+    '''
     assets = api.assets.list()
     resp = api.tags.unassign([a['id'] for a in assets], [tagvalue['uuid']])
     single(resp, str)

--- a/tests/io/test_tags.py
+++ b/tests/io/test_tags.py
@@ -7,9 +7,9 @@ from tests.checker import check, single
 from tenable.errors import UnexpectedValueError, NotFoundError
 from tenable.io.tags import TagsIterator
 
-@pytest.fixture
+@pytest.fixture(name='tagvalue')
 @pytest.mark.vcr()
-def tagvalue(request, api):
+def fixture_tagvalue(request, api):
     '''
     Fixture to create tag value
     '''
@@ -25,9 +25,9 @@ def tagvalue(request, api):
     request.addfinalizer(teardown)
     return tag
 
-@pytest.fixture
+@pytest.fixture(name='tagcat')
 @pytest.mark.vcr()
-def tagcat(request, api):
+def fixture_tagcat(request, api):
     '''
     Fixture to create tag category
     '''
@@ -77,7 +77,7 @@ def test_tags_create_value_category_description_typeerror(api):
         api.tags.create('', '', category_description=1)
 
 @pytest.mark.vcr()
-def test_tags_create_success(api, tagvalue):
+def test_tags_create_success(tagvalue):
     '''
     test to create tag value.
     '''
@@ -108,7 +108,7 @@ def test_tags_create_category_description_typeerror(api):
         api.tags.create_category('', description=1)
 
 @pytest.mark.vcr()
-def test_tags_create_category_success(api, tagcat):
+def test_tags_create_category_success(tagcat):
     '''
     test to create tag category.
     '''
@@ -365,23 +365,23 @@ def test_tags_list_constructor_filter_type_typeerror(api):
     test to raise exception when type of filter_type param does not match the expected type.
     '''
     with pytest.raises(TypeError):
-        api.tags._tag_list_constructor([],
-            api.tags._filterset_tags, True, None)
+        getattr(api.tags, '_tag_list_constructor')([],
+            getattr(api.tags, '_filterset_tags'), True, None)
 
 def test_tags_list_constructor_filter_type_unexpectedvalueerror(api):
     '''
     test to raise exception when filter_type param value does not match the choices.
     '''
     with pytest.raises(UnexpectedValueError):
-        api.tags._tag_list_constructor([],
-            api.tags._filterset_tags, 'nadda', None)
+        getattr(api.tags, '_tag_list_constructor')([],
+            getattr(api.tags, '_filterset_tags'), 'nadda', None)
 
 def test_tags_list_constructor_filter_type_success(api):
     '''
     test to check filter_type param in tags_list_constructor method.
     '''
-    resp = api.tags._tag_list_constructor([],
-        api.tags._filterset_tags, 'and', None)
+    resp = getattr(api.tags, '_tag_list_constructor')([],
+        getattr(api.tags, '_filterset_tags'), 'and', None)
     assert resp['ft'] == 'AND'
 
 def test_tags_list_constructor_sort_typeerror(api):
@@ -389,36 +389,36 @@ def test_tags_list_constructor_sort_typeerror(api):
     test to raise exception when type of sort param does not match the expected type.
     '''
     with pytest.raises(TypeError):
-        api.tags._tag_list_constructor([],
-            api.tags._filterset_tags, None, 1)
+        getattr(api.tags, '_tag_list_constructor')([],
+            getattr(api.tags, '_filterset_tags'), None, 1)
 
 def test_tags_list_constructor_sort_unexpectedvalueerror(api):
     '''
     test to raise exception when sort param value does not match the choices.
     '''
     with pytest.raises(UnexpectedValueError):
-        api.tags._tag_list_constructor([],
-            api.tags._filterset_tags, None, (('something_else'),))
+        getattr(api.tags, '_tag_list_constructor')([],
+            getattr(api.tags, '_filterset_tags'), None, (('something_else'),))
 
 def test_tags_list_constructor_sort_success(api):
     '''
     test to check sort param in tags_list_constructor method.
     '''
-    resp = api.tags._tag_list_constructor([],
-        api.tags._filterset_tags, None, (('value','asc'),))
+    resp = getattr(api.tags, '_tag_list_constructor')([],
+        getattr(api.tags, '_filterset_tags'), None, (('value','asc'),))
     assert resp['sort'] == 'value:asc'
 
 def test_tags_list_constructor_filter_success(api):
     '''
     test to check filter param in tags_list_constructor method.
     '''
-    resp = api.tags._tag_list_constructor([
+    resp = getattr(api.tags, '_tag_list_constructor')([
         ('value', 'eq', 'Test')
-    ], api.tags._filterset_tags, None, None)
+    ], getattr(api.tags, '_filterset_tags'), None, None)
     assert resp['f'] == ['value:eq:Test']
 
 @pytest.mark.vcr()
-def test_tags_list_success(api, tagvalue):
+def test_tags_list_success(api):
     '''
     test to get list of tags.
     '''
@@ -438,7 +438,7 @@ def test_tags_list_success(api, tagvalue):
     #check(t, 'category_description', str, allow_none=True)
 
 @pytest.mark.vcr()
-def test_tags_list_category_success(api, tagcat):
+def test_tags_list_category_success(api):
     '''
     test to list of tag categories.
     '''

--- a/tests/io/test_tags.py
+++ b/tests/io/test_tags.py
@@ -1,5 +1,5 @@
 from ..checker import check, single
-from tenable.errors import *
+from tenable.errors import UnexpectedValueError, NotFoundError
 from tenable.io.tags import TagsIterator
 import uuid, pytest
 
@@ -38,12 +38,12 @@ def test_tags_create_value_typerror(api):
         api.tags.create('', 1)
 
 @pytest.mark.vcr()
-def test_tags_create_description_typerror(api):
+def test_tags_create_value_description_typerror(api):
     with pytest.raises(TypeError):
         api.tags.create('', '', description=1)
 
 @pytest.mark.vcr()
-def test_tags_create_category_description_typeerror(api):
+def test_tags_create_value_category_description_typeerror(api):
     with pytest.raises(TypeError):
         api.tags.create('', '', category_description=1)
 

--- a/tests/io/test_tags.py
+++ b/tests/io/test_tags.py
@@ -95,6 +95,22 @@ def test_tags_delete_success(api, tagvalue):
     api.tags.delete(tagvalue['uuid'])
 
 @pytest.mark.vcr()
+def test_tags_delete_bulk_typeerror(api, tagvalue):
+    with pytest.raises(TypeError):
+        api.tags.delete(tagvalue['uuid'], 1)
+
+@pytest.mark.vcr()
+def test_tags_delete_bulk_unexpectedvalueerror(api, tagvalue):
+    with pytest.raises(UnexpectedValueError):
+        api.tags.delete(tagvalue['uuid'], 'nope')
+
+@pytest.mark.vcr()
+def test_tags_delete_bulk_success(api):
+    tag1 = api.tags.create('Example', 'Test1')
+    tag2 = api.tags.create('Example', 'Test2')
+    api.tags.delete(tag1['uuid'], tag2['uuid'])
+
+@pytest.mark.vcr()
 def test_tags_delete_category_uuid_typeerror(api):
     with pytest.raises(TypeError):
         api.tags.delete_category(1)


### PR DESCRIPTION
# Description

Updated tags.delete with bulk delete feature

- Deleting a single tag value:

```
>>> tio.tags.delete('00000000-0000-0000-0000-000000000000')
```

- Deleting multiple tag values:
```
>>> tio.tags.delete('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000001')
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added below test to check bulk delete tag values
 
- [x] Test `test_tags_delete_bulk_typeerror` to check any of value doesn't match to expected type
- [x] Test `test_tags_delete_bulk_unexpectedvalueerror` to check any of value doesn't match to expected value
- [x] Test `test_tags_delete_bulk_success` to check api is working

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
