### PR TITLE
fix: missing import in ContainerSecurity class

### DIFF
--- a/tenable/cs/__init__.py
+++ b/tenable/cs/__init__.py
@@ -33,6 +33,7 @@ Example:
     .. automethod:: put
     .. automethod:: delete
 '''
+import os
 from tenable.base import APISession
 from tenable.errors import UnexpectedValueError
 from .images import ImageAPI


### PR DESCRIPTION
# Description

Creating an instance of `ContainerSecurity` without passing in credentials raises an exception:
```
Traceback (most recent call last):
  File "/Users/tim.birkett/Projects/docker-tenable-cleanup/tenable_cleanup.py", line 39, in <module>
    cs = ContainerSecurity(access_key=TENABLE_ACCESS_KEY, secret_key=TENABLE_SECRET_KEY)
  File "/Users/tim.birkett/Projects/docker-tenable-cleanup/venv/lib/python3.9/site-packages/tenable/cs/__init__.py", line 99, in __init__
    self._access_key = os.getenv('TIO_ACCESS_KEY')
NameError: name 'os' is not defined
```

This fixes that issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)