### PR TITLE
Added network asset count api 

### DIFF
--- a/tenable/io/networks.py
+++ b/tenable/io/networks.py
@@ -20,7 +20,9 @@ Methods available on ``tio.networks``:
     .. automethod:: unassigned_scanners
     .. automethod:: network_asset_count
 '''
-from .base import TIOEndpoint, TIOIterator
+from tenable.io.base import TIOEndpoint, TIOIterator
+from tenable.errors import UnexpectedValueError
+
 
 class NetworksIterator(TIOIterator):
     '''
@@ -44,6 +46,9 @@ class NetworksIterator(TIOIterator):
     pass
 
 class NetworksAPI(TIOEndpoint):
+    '''
+    This will contain all methods related to networks
+    '''
     def create(self, name, description=None):
         '''
         Creates a new network within Tenable.io
@@ -69,43 +74,43 @@ class NetworksAPI(TIOEndpoint):
             'description': self._check('description', description, str)
         }).json()
 
-    def delete(self, id):
+    def delete(self, network_id):
         '''
         Deletes the specified network.
 
         :devportal:`networks: delete <networks-delete>`
 
         Args:
-            id (str): The UUID of the network to remove.
+            network_id (str): The UUID of the network to remove.
 
         Examples:
             >>> tio.networks.delete('00000000-0000-0000-0000-000000000000')
         '''
-        self._api.delete('networks/{}'.format(self._check('id', id, 'uuid')))
+        self._api.delete('networks/{}'.format(self._check('network_id', network_id, 'uuid')))
 
-    def details(self, id):
+    def details(self, network_id):
         '''
         Retreives the details of the specified network.
 
         :devportal:`networks: details <networks-details>`
 
         Args:
-            id (str): The UUID of the network.
+            network_id (str): The UUID of the network.
 
         Examples:
             >>> nw = tio.networks.details('00000000-0000-0000-0000-000000000000')
         '''
         return self._api.get('networks/{}'.format(
-            self._check('id', id, 'uuid'))).json()
+            self._check('network_id', network_id, 'uuid'))).json()
 
-    def edit(self, id, name, description=None):
+    def edit(self, network_id, name, description=None):
         '''
         Updates the specified network resource.
 
         :devportal:`networks: update <networks-update>`
 
         Args:
-            id (str): The UUID of the network resource to update.
+            network_id (str): The UUID of the network resource to update.
             name (str): The new name of the network resource.
             description (str, optional):
                 The new description of the network resource.
@@ -121,13 +126,13 @@ class NetworksAPI(TIOEndpoint):
         if not description:
             description = ''
 
-        return self._api.put('networks/{}'.format(self._check('id', id, 'uuid')),
+        return self._api.put('networks/{}'.format(self._check('network_id', network_id, 'uuid')),
             json={
                 'name': self._check('name', name, str),
                 'description': self._check('description', description, str)
             }).json()
 
-    def assign_scanners(self, id, *scanner_uuids):
+    def assign_scanners(self, network_id, *scanner_uuids):
         '''
         Assigns one or many scanners to a network.
 
@@ -135,7 +140,7 @@ class NetworksAPI(TIOEndpoint):
         :devportal:`networks: bulk-assign-scanner <networks-assign-scanner-bulk>`
 
         Args:
-            id (str): The UUID of the network.
+            network_id (str): The UUID of the network.
             *scanner_uuids (str): Scanner UUID(s) to assign to the network.
 
         Examples:
@@ -154,25 +159,25 @@ class NetworksAPI(TIOEndpoint):
         '''
         if len(scanner_uuids) == 1:
             self._api.post('networks/{}/scanners/{}'.format(
-                self._check('id', id, 'uuid'),
+                self._check('network_id', network_id, 'uuid'),
                 self._check('scanner_uuid', scanner_uuids[0], 'scanner-uuid')
             ))
         elif len(scanner_uuids) > 1:
             self._api.post('networks/{}/scanners'.format(
-                self._check('id', id, 'uuid')),
+                self._check('network_id', network_id, 'uuid')),
                     json={'scanner_uuids': [self._check('scanner_uuid', i, 'scanner-uuid')
                         for i in scanner_uuids]})
         else:
             raise UnexpectedValueError('No scanner_uuids were supplied.')
 
-    def list_scanners(self, id):
+    def list_scanners(self, network_id):
         '''
         Retreives the list of scanners associated to a given network.
 
         :devportal:`networks: list-scanners <networks-list-scanners>`
 
         Args:
-            id (str): The UUID of the network.
+            network_id (str): The UUID of the network.
 
         Returns:
             :obj:`list`:
@@ -184,9 +189,9 @@ class NetworksAPI(TIOEndpoint):
             ...     pprint(scanner)
         '''
         return self._api.get('networks/{}/scanners'.format(
-            self._check('id', id, 'uuid'))).json()['scanners']
+            self._check('network_id', network_id, 'uuid'))).json()['scanners']
 
-    def unassigned_scanners(self, id):
+    def unassigned_scanners(self, network_id):
         '''
         Retrives the list of scanners that are currently unassigned to the given
         network.  This will include scanners and scanner groups that are
@@ -207,7 +212,7 @@ class NetworksAPI(TIOEndpoint):
             ...     pprint(scanner)
         '''
         return self._api.get('networks/{}/assignable-scanners'.format(
-            self._check('id', id, 'uuid'))).json()['scanners']
+            self._check('network_id', network_id, 'uuid'))).json()['scanners']
 
     def list(self, *filters, **kw):
         '''
@@ -332,7 +337,7 @@ class NetworksAPI(TIOEndpoint):
             _resource='networks'
         )
 
-    def network_asset_count(self, id, num_days):
+    def network_asset_count(self, network_id, num_days):
         '''
         get the total number of assets in the network along with the number of assets
         that have not been seen for the specified number of days.
@@ -340,7 +345,7 @@ class NetworksAPI(TIOEndpoint):
         :devportal:`networks: network_asset_count <networks-asset-count-details>`
 
         Args:
-            id (str): The UUID of the network.
+            network_id (str): The UUID of the network.
             num_days (int): count of assets that have not been seen for the specified number of days
 
         Returns:
@@ -353,4 +358,5 @@ class NetworksAPI(TIOEndpoint):
             >>> count = tio.networks.network_asset_count(network, 180)
         '''
         return self._api.get('networks/{}/counts/assets-not-seen-in/{}'.format(
-            self._check('id', id, 'uuid'), self._check('num_days', num_days, int))).json()
+            self._check('network_id', network_id, 'uuid'),
+            self._check('num_days', num_days, int))).json()

--- a/tenable/io/networks.py
+++ b/tenable/io/networks.py
@@ -18,6 +18,7 @@ Methods available on ``tio.networks``:
     .. automethod:: list
     .. automethod:: list_scanners
     .. automethod:: unassigned_scanners
+    .. automethod:: network_asset_count
 '''
 from .base import TIOEndpoint, TIOIterator
 
@@ -331,3 +332,25 @@ class NetworksAPI(TIOEndpoint):
             _resource='networks'
         )
 
+    def network_asset_count(self, id, num_days):
+        '''
+        get the total number of assets in the network along with the number of assets
+        that have not been seen for the specified number of days.
+
+        :devportal:`networks: network_asset_count <networks-asset-count-details>`
+
+        Args:
+            id (str): The UUID of the network.
+            num_days (int): count of assets that have not been seen for the specified number of days
+
+        Returns:
+            :obj:`dict`:
+                Returns the total number of assets in the network along with the number of assets
+                that have not been seen for the specified number of days.
+
+        Examples:
+            >>> network = '00000000-0000-0000-0000-000000000000'
+            >>> count = tio.networks.network_asset_count(network, 180)
+        '''
+        return self._api.get('networks/{}/counts/assets-not-seen-in/{}'.format(
+            self._check('id', id, 'uuid'), self._check('num_days', num_days, int))).json()

--- a/tests/io/cassettes/test_network_asset_count_network_num_days_invalidinputerror.yaml
+++ b/tests/io/cassettes/test_network_asset_count_network_num_days_invalidinputerror.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/networks/00000000-0000-0000-0000-000000000000/counts/assets-not-seen-in/-180
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAz2NMQ7CMBAEv3LaOkWQqFzCD2iTFEd8EAsnhjsbKYrydwwF7cxqdoNlzsXOyQvc
+        sW0biGpSOJzY00VeRSyjwSxmfK8bjFOInnp4Xq0H3ThEo6uMXEyo+/O5WK6YIutdlPLECyWlGuRI
+        OdFhqNU3x+A5h7TAbbBUdPxePFl5tuofshpc92ti2PcPjbIc8q8AAAA=
+    headers:
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 05 May 2021 08:25:54 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-j15ji-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 057b2d7922858c2f467acb80d325ec2d
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/tests/io/cassettes/test_network_asset_count_network_num_days_invalidinputerror.yaml
+++ b/tests/io/cassettes/test_network_asset_count_network_num_days_invalidinputerror.yaml
@@ -1,61 +1,63 @@
+---
 interactions:
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/networks/00000000-0000-0000-0000-000000000000/counts/assets-not-seen-in/-180
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAz2NMQ7CMBAEv3LaOkWQqFzCD2iTFEd8EAsnhjsbKYrydwwF7cxqdoNlzsXOyQvc
-        sW0biGpSOJzY00VeRSyjwSxmfK8bjFOInnp4Xq0H3ThEo6uMXEyo+/O5WK6YIutdlPLECyWlGuRI
-        OdFhqNU3x+A5h7TAbbBUdPxePFl5tuofshpc92ti2PcPjbIc8q8AAAA=
-    headers:
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 05 May 2021 08:25:54 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-j15ji-ap-southeast-1-prod
-      X-Request-Uuid:
-      - 057b2d7922858c2f467acb80d325ec2d
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 400
-      message: Bad Request
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: GET
+      uri: https://cloud.tenable.com/networks/00000000-0000-0000-0000-000000000000/counts/assets-not-seen-in/-180
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAAz2NMQ7CMBAEv3LaOkWQqFzCD2iTFEd8EAsnhjsbKYrydwwF7cxqdoNlzsXOyQvc
+          sW0biGpSOJzY00VeRSyjwSxmfK8bjFOInnp4Xq0H3ThEo6uMXEyo+/O5WK6YIutdlPLECyWlGuRI
+          OdFhqNU3x+A5h7TAbbBUdPxePFl5tuofshpc92ti2PcPjbIc8q8AAAA=
+      headers:
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 05 May 2021 08:25:54 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        Vary:
+          - accept-encoding
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+        X-Gateway-Site-ID:
+          - nginx-router-j15ji-ap-southeast-1-prod
+        X-Request-Uuid:
+          - 057b2d7922858c2f467acb80d325ec2d
+        X-Xss-Protection:
+          - 1; mode=block
+      status:
+        code: 400
+        message: Bad Request
 version: 1

--- a/tests/io/cassettes/test_network_asset_count_network_success.yaml
+++ b/tests/io/cassettes/test_network_asset_count_network_success.yaml
@@ -1,61 +1,63 @@
+---
 interactions:
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
-        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
-      X-APIKeys:
-      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
-    method: GET
-    uri: https://cloud.tenable.com/networks/00000000-0000-0000-0000-000000000000/counts/assets-not-seen-in/180
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWyivNdSwuTi0pDskvScxRsjLSQQj55ZcEp6bmKVkZ1AIAII7ioykAAAA=
-    headers:
-      Accept-Ranges:
-      - bytes
-      Cache-Control:
-      - no-store
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Wed, 05 May 2021 08:25:59 GMT
-      Expect-CT:
-      - enforce, max-age=86400
-      Pragma:
-      - no-cache
-      Set-Cookie:
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - accept-encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - DENY
-      X-Gateway-Site-ID:
-      - nginx-router-c3gdt-ap-southeast-1-prod
-      X-Request-Uuid:
-      - 034868f17de2a24ec99637fc2e262ce7
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - '*/*'
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - Integration/1.0
+            (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+            (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+        X-APIKeys:
+          - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+      method: GET
+      uri: https://cloud.tenable.com/networks/00000000-0000-0000-0000-000000000000/counts/assets-not-seen-in/180
+    response:
+      body:
+        string: !!binary |
+          H4sIAAAAAAAAA6tWyivNdSwuTi0pDskvScxRsjLSQQj55ZcEp6bmKVkZ1AIAII7ioykAAAA=
+      headers:
+        Accept-Ranges:
+          - bytes
+        Cache-Control:
+          - no-store
+        Connection:
+          - keep-alive
+        Content-Encoding:
+          - gzip
+        Content-Type:
+          - application/json; charset=utf-8
+        Date:
+          - Wed, 05 May 2021 08:25:59 GMT
+        Expect-CT:
+          - enforce, max-age=86400
+        Pragma:
+          - no-cache
+        Set-Cookie:
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+          - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+        Strict-Transport-Security:
+          - max-age=63072000; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        Vary:
+          - accept-encoding
+        X-Content-Type-Options:
+          - nosniff
+        X-Frame-Options:
+          - DENY
+        X-Gateway-Site-ID:
+          - nginx-router-c3gdt-ap-southeast-1-prod
+        X-Request-Uuid:
+          - 034868f17de2a24ec99637fc2e262ce7
+        X-Xss-Protection:
+          - 1; mode=block
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/io/cassettes/test_network_asset_count_network_success.yaml
+++ b/tests/io/cassettes/test_network_asset_count_network_success.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (pytest; pytenable-automated-testing; Build/unknown) pyTenable/1.2.8
+        (pyTenable/1.2.8; Python/3.8.6; Windows/AMD64)
+      X-APIKeys:
+      - accessKey=TIO_ACCESS_KEY;secretKey=TIO_SECRET_KEY
+    method: GET
+    uri: https://cloud.tenable.com/networks/00000000-0000-0000-0000-000000000000/counts/assets-not-seen-in/180
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWyivNdSwuTi0pDskvScxRsjLSQQj55ZcEp6bmKVkZ1AIAII7ioykAAAA=
+    headers:
+      Accept-Ranges:
+      - bytes
+      Cache-Control:
+      - no-store
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 05 May 2021 08:25:59 GMT
+      Expect-CT:
+      - enforce, max-age=86400
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      - nginx-cloud-site-id=us-2b; path=/; HttpOnly; SameSite=Strict; Secure
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Gateway-Site-ID:
+      - nginx-router-c3gdt-ap-southeast-1-prod
+      X-Request-Uuid:
+      - 034868f17de2a24ec99637fc2e262ce7
+      X-Xss-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/io/test_exclusions.py
+++ b/tests/io/test_exclusions.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from tenable.errors import *
 from ..checker import check, single
-from tests.io.test_networks import network
+from tests.io.test_networks import fixture_network
 import uuid, pytest
 
 @pytest.fixture

--- a/tests/io/test_networks.py
+++ b/tests/io/test_networks.py
@@ -6,8 +6,8 @@ import pytest
 from tenable.errors import UnexpectedValueError, APIError, InvalidInputError
 from tests.checker import check
 
-@pytest.fixture
-def network(request, api, vcr):
+@pytest.fixture(name='network')
+def fixture_network(request, api, vcr):
     '''
     Fixture to create network
     '''

--- a/tests/io/test_networks.py
+++ b/tests/io/test_networks.py
@@ -255,3 +255,31 @@ def test_networks_list(api):
         check(i, 'created_in_seconds', int)
         check(i, 'modified_in_seconds', int)
     assert count == networks.total
+
+@pytest.mark.vcr()
+def test_network_asset_count_network_id_typeerror(api):
+    with pytest.raises(TypeError):
+        api.networks.network_asset_count(1, 180)
+
+@pytest.mark.vcr()
+def test_network_asset_count_network_id_unexpectedvalueerror(api):
+    with pytest.raises(UnexpectedValueError):
+        api.networks.network_asset_count('nope', 180)
+
+@pytest.mark.vcr()
+def test_network_asset_count_network_num_days_typeerror(api):
+    with pytest.raises(TypeError):
+        api.networks.network_asset_count('00000000-0000-0000-0000-000000000000', 'nope')
+
+@pytest.mark.vcr()
+def test_network_asset_count_network_num_days_invalidinputerror(api):
+    with pytest.raises(InvalidInputError):
+        api.networks.network_asset_count('00000000-0000-0000-0000-000000000000', -180)
+
+@pytest.mark.vcr()
+def test_network_asset_count_network_success(api):
+    network = '00000000-0000-0000-0000-000000000000'
+    resp = api.networks.network_asset_count(network, 180)
+    assert isinstance(resp, dict)
+    check(resp, 'numAssetsTotal', int)
+    check(resp, 'numAssetsNotSeen', int)

--- a/tests/io/test_networks.py
+++ b/tests/io/test_networks.py
@@ -1,12 +1,22 @@
-from tenable.errors import *
-from ..checker import check, single
-import pytest, uuid
+'''
+test networks
+'''
+import uuid
+import pytest
+from tenable.errors import UnexpectedValueError, APIError, InvalidInputError
+from tests.checker import check
 
 @pytest.fixture
 def network(request, api, vcr):
+    '''
+    Fixture to create network
+    '''
     with vcr.use_cassette('test_networks_create_success'):
         network = api.networks.create('Example')
     def teardown():
+        '''
+        cleanup function to delete network
+        '''
         try:
             with vcr.use_cassette('test_networks_delete_success'):
                 api.networks.delete(network['uuid'])
@@ -16,15 +26,24 @@ def network(request, api, vcr):
     return network
 
 def test_networks_create_name_typeerror(api):
+    '''
+    test to raise exception when type of name param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.create(1, 'something')
 
 def test_networks_create_description_typeerror(api):
+    '''
+    test to raise exception when type of description param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.create('something', 1)
 
 @pytest.mark.vcr()
-def test_networks_create_success(api, network):
+def test_networks_create_success(network):
+    '''
+    test to create network.
+    '''
     assert isinstance(network, dict)
     check(network, 'owner_uuid', 'uuid')
     check(network, 'created', int)
@@ -40,137 +59,203 @@ def test_networks_create_success(api, network):
     check(network, 'modified_in_seconds', int)
 
 def test_networks_delete_id_typeerror(api):
+    '''
+    test to raise exception when type of network_id param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.delete(1)
 
 def test_networks_delete_id_unexpectedvalueerror(api):
+    '''
+    test to raise exception when value of network_id param does not match the expected pattern.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.delete('something')
 
 @pytest.mark.vcr()
 def test_networks_delete_success(api, network):
+    '''
+    test to delete network.
+    '''
     api.networks.delete(network['uuid'])
 
 def test_networks_details_id_typeerror(api):
+    '''
+    test to raise exception when type of network param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.details(1)
 
 def test_networks_details_id_unexpectedvalueerror(api):
+    '''
+    test to raise exception when value of network_id param does not match the expected pattern.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.details('something')
 
 @pytest.mark.vcr()
 def test_networks_details_success(api, network):
-    n = api.networks.details(network['uuid'])
-    assert isinstance(n, dict)
-    check(n, 'owner_uuid', 'uuid')
-    check(n, 'created', int)
-    check(n, 'modified', int)
-    check(n, 'scanner_count', int)
-    check(n, 'uuid', 'uuid')
-    check(n, 'name', str)
-    check(n, 'description', str)
-    check(n, 'is_default', bool)
-    check(n, 'created_by', 'uuid')
-    check(n, 'modified_by', 'uuid')
-    check(n, 'created_in_seconds', int)
-    check(n, 'modified_in_seconds', int)
+    '''
+    test to get details of specified network.
+    '''
+    resp = api.networks.details(network['uuid'])
+    assert isinstance(resp, dict)
+    check(resp, 'owner_uuid', 'uuid')
+    check(resp, 'created', int)
+    check(resp, 'modified', int)
+    check(resp, 'scanner_count', int)
+    check(resp, 'uuid', 'uuid')
+    check(resp, 'name', str)
+    check(resp, 'description', str)
+    check(resp, 'is_default', bool)
+    check(resp, 'created_by', 'uuid')
+    check(resp, 'modified_by', 'uuid')
+    check(resp, 'created_in_seconds', int)
+    check(resp, 'modified_in_seconds', int)
 
 def test_networks_edit_id_typeerror(api):
+    '''
+    test to raise exception when type of network_id param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.edit(1, 'something')
 
 def test_networks_edit_id_unexpectedvalueerror(api):
+    '''
+    test to raise exception when value of network_id param does not match the expected pattern.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.edit('something', 'something')
 
 def test_networks_edit_name_typeerror(api):
+    '''
+    test to raise exception when type of name param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.edit(str(uuid.uuid4()), 1)
 
 def test_networks_edit_description_typeerror(api):
+    '''
+    test to raise exception when type of description param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.edit(str(uuid.uuid4()), 'something', 1)
 
 @pytest.mark.vcr()
 def test_networks_edit_success(api, network):
-    n = api.networks.edit(network['uuid'], 'New Name')
-    assert isinstance(n, dict)
-    check(n, 'owner_uuid', 'uuid')
-    check(n, 'created', int)
-    check(n, 'modified', int)
-    check(n, 'scanner_count', int)
-    check(n, 'uuid', 'uuid')
-    check(n, 'name', str)
-    check(n, 'description', str)
-    check(n, 'is_default', bool)
-    check(n, 'created_by', 'uuid')
-    check(n, 'modified_by', 'uuid')
-    check(n, 'created_in_seconds', int)
-    check(n, 'modified_in_seconds', int)
+    '''
+    test to update the specified network resource.
+    '''
+    resp = api.networks.edit(network['uuid'], 'New Name')
+    assert isinstance(resp, dict)
+    check(resp, 'owner_uuid', 'uuid')
+    check(resp, 'created', int)
+    check(resp, 'modified', int)
+    check(resp, 'scanner_count', int)
+    check(resp, 'uuid', 'uuid')
+    check(resp, 'name', str)
+    check(resp, 'description', str)
+    check(resp, 'is_default', bool)
+    check(resp, 'created_by', 'uuid')
+    check(resp, 'modified_by', 'uuid')
+    check(resp, 'created_in_seconds', int)
+    check(resp, 'modified_in_seconds', int)
 
 def test_networks_list_scanners_id_typeerror(api):
+    '''
+    test to raise exception when type of network_id param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list_scanners(1)
 
 def test_networks_list_scanners_id_unexpectedvalueerror(api):
+    '''
+    test to raise exception when value of network_id param does not match the expected pattern.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.list_scanners('something')
 
 @pytest.mark.vcr()
 def test_networks_list_scanners_success(api):
+    '''
+    test to get list of scanners associated to given network.
+    '''
     scanners = api.networks.list_scanners('00000000-0000-0000-0000-000000000000')
     assert isinstance(scanners, list)
-    for s in scanners:
-        assert isinstance(s, dict)
-        check(s, 'owner_uuid', 'uuid')
-        check(s, 'uuid', 'scanner-uuid')
-        check(s, 'id', int)
-        check(s, 'name', str)
-        check(s, 'key', str)
-        check(s, 'status', str)
-        check(s, 'group', bool)
+    for scanner in scanners:
+        assert isinstance(scanner, dict)
+        check(scanner, 'owner_uuid', 'uuid')
+        check(scanner, 'uuid', 'scanner-uuid')
+        check(scanner, 'id', int)
+        check(scanner, 'name', str)
+        check(scanner, 'key', str)
+        check(scanner, 'status', str)
+        check(scanner, 'group', bool)
 
 def test_networks_unassigned_scanners_id_typeerror(api):
+    '''
+    test to raise exception when type of network_id param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.unassigned_scanners(1)
 
 def test_networks_unassigned_scanners_id_unexpectedvalueerror(api):
+    '''
+    test to raise exception when value of network_id param does not match the expected pattern.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.unassigned_scanners('something')
 
 @pytest.mark.vcr()
 def test_networks_unassigned_scanners_success(api, network):
+    '''
+    test to get the list of scanners that are currently unassigned to the given network
+    '''
     scanners = api.networks.unassigned_scanners(network['uuid'])
     assert isinstance(scanners, list)
-    for s in scanners:
-        assert isinstance(s, dict)
-        check(s, 'owner_uuid', 'uuid')
-        check(s, 'uuid', 'scanner-uuid')
-        check(s, 'id', int)
-        check(s, 'name', str)
-        check(s, 'key', str)
-        check(s, 'status', str)
-        check(s, 'group', bool)
+    for scanner in scanners:
+        assert isinstance(scanner, dict)
+        check(scanner, 'owner_uuid', 'uuid')
+        check(scanner, 'uuid', 'scanner-uuid')
+        check(scanner, 'id', int)
+        check(scanner, 'name', str)
+        check(scanner, 'key', str)
+        check(scanner, 'status', str)
+        check(scanner, 'group', bool)
 
 def test_networks_assign_scanners_id_typeerror(api):
+    '''
+    test to raise exception when type of network_id param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.assign_scanners(1, str(uuid.uuid4()))
 
 def test_networks_assign_scanners_id_unexpectedvalueerror(api):
+    '''
+    test to raise exception when value of network_id param does not match the expected pattern.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.assign_scanners('something', str(uuid.uuid4()))
 
 def test_networks_assign_scanners_scanner_id_typeerror(api):
+    '''
+    test to raise exception when type of scanner_uuis param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.assign_scanners(str(uuid.uuid4()), 1)
 
 def test_networks_assign_scanners_scanner_id_unexpectedvalueerror(api):
+    '''
+    test to raise exception when value of scanner_uuid param does not match the expected pattern.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.assign_scanners(str(uuid.uuid4()), 'something')
 
 @pytest.mark.vcr()
 def test_networks_assign_scanners_success(api, network, vcr):
+    '''
+    test to assign scanners to network.
+    '''
     with vcr.use_cassette('test_networks_list_scanners_success'):
         scanner = api.networks.list_scanners(
             '00000000-0000-0000-0000-000000000000')[0]
@@ -178,106 +263,160 @@ def test_networks_assign_scanners_success(api, network, vcr):
 
 @pytest.mark.vcr()
 def test_networks_list_offset_typeerror(api):
+    '''
+    test to raise exception when type of offset param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(offset='nope')
 
 @pytest.mark.vcr()
 def test_networks_list_limit_typeerror(api):
+    '''
+    test to raise exception when type of limit param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(limit='nope')
 
 @pytest.mark.vcr()
 def test_networks_list_sort_field_typeerror(api):
+    '''
+    test to raise exception when type of sort field param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(sort=((1, 'asc'),))
 
 @pytest.mark.vcr()
 def test_networks_list_sort_direction_typeerror(api):
+    '''
+    test to raise exception when type of sort direction param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(sort=(('uuid', 1),))
 
 @pytest.mark.vcr()
 def test_networks_list_sort_direction_unexpectedvalue(api):
+    '''
+    test to raise exception when value of sort direction param does not match the choices.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.list(sort=(('uuid', 'nope'),))
 
 @pytest.mark.vcr()
 def test_networks_list_filter_name_typeerror(api):
+    '''
+    test to raise exception when type of filter_name param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list((1, 'match', 'win'))
 
 @pytest.mark.vcr()
 def test_networks_list_filter_operator_typeerror(api):
+    '''
+    test to raise exception when type of filter_operator param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(('name', 1, 'win'))
 
 @pytest.mark.vcr()
 def test_networks_list_filter_value_typeerror(api):
+    '''
+    test to raise exception when type of filter_value param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(('name', 'match', 1))
 
 @pytest.mark.vcr()
 def test_networks_list_filter_type_typeerror(api):
+    '''
+    test to raise exception when type of filter_type param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(filter_type=1)
 
 @pytest.mark.vcr()
 def test_networks_list_wildcard_typeerror(api):
+    '''
+    test to raise exception when type of wildcard param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(wildcard=1)
 
 @pytest.mark.vcr()
 def test_networks_list_wildcard_fields_typeerror(api):
+    '''
+    test to raise exception when type of wildcard_fields param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(wildcard_fields='nope')
 
 @pytest.mark.vcr()
 def test_networks_list_include_deleted_typeerror(api):
+    '''
+    test to raise exception when type of include_deleted param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.list(include_deleted='nope')
 
 @pytest.mark.vcr()
 def test_networks_list(api):
+    '''
+    test to get list of configured networks.
+    '''
     count = 0
     networks = api.networks.list()
-    for i in networks:
+    for network in networks:
         count += 1
-        assert isinstance(i, dict)
-        check(i, 'owner_uuid', 'uuid')
-        check(i, 'created', int)
-        check(i, 'modified', int)
-        check(i, 'scanner_count', int)
-        check(i, 'uuid', 'uuid')
-        check(i, 'name', str)
-        check(i, 'is_default', bool)
-        check(i, 'created_by', 'uuid')
-        check(i, 'modified_by', 'uuid')
-        check(i, 'created_in_seconds', int)
-        check(i, 'modified_in_seconds', int)
+        assert isinstance(network, dict)
+        check(network, 'owner_uuid', 'uuid')
+        check(network, 'created', int)
+        check(network, 'modified', int)
+        check(network, 'scanner_count', int)
+        check(network, 'uuid', 'uuid')
+        check(network, 'name', str)
+        check(network, 'is_default', bool)
+        check(network, 'created_by', 'uuid')
+        check(network, 'modified_by', 'uuid')
+        check(network, 'created_in_seconds', int)
+        check(network, 'modified_in_seconds', int)
     assert count == networks.total
 
 @pytest.mark.vcr()
 def test_network_asset_count_network_id_typeerror(api):
+    '''
+    test to raise exception when type of network_id param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.network_asset_count(1, 180)
 
 @pytest.mark.vcr()
 def test_network_asset_count_network_id_unexpectedvalueerror(api):
+    '''
+    test to raise exception when value of network_id param does not match the expected pattern.
+    '''
     with pytest.raises(UnexpectedValueError):
         api.networks.network_asset_count('nope', 180)
 
 @pytest.mark.vcr()
 def test_network_asset_count_network_num_days_typeerror(api):
+    '''
+    test to raise exception when type of num_days param does not match the expected type.
+    '''
     with pytest.raises(TypeError):
         api.networks.network_asset_count('00000000-0000-0000-0000-000000000000', 'nope')
 
 @pytest.mark.vcr()
 def test_network_asset_count_network_num_days_invalidinputerror(api):
+    '''
+    test to raise exception when value of num_days param is not valid.
+    '''
     with pytest.raises(InvalidInputError):
         api.networks.network_asset_count('00000000-0000-0000-0000-000000000000', -180)
 
 @pytest.mark.vcr()
 def test_network_asset_count_network_success(api):
+    '''
+    test to raise exception when type of network_id param does not match the expected type.
+    '''
     network = '00000000-0000-0000-0000-000000000000'
     resp = api.networks.network_asset_count(network, 180)
     assert isinstance(resp, dict)


### PR DESCRIPTION
# Description

Added **`network asset count`** api in TIO networks
```
>>> count = tio.networks.network_asset_count(network_uuid, num_of_days)
```
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Added below tests for **network asset count** api
- [x] `test_network_asset_count_network_id_typeerror`
- [x] `test_network_asset_count_network_id_unexpectedvalueerror`
- [x] `test_network_asset_count_network_num_days_typeerror`
- [x] `test_network_asset_count_network_num_days_invalidinputerror`
- [x] `test_network_asset_count_network_success `

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
