### PR TITLE
Typos / Inaccuracies in Documentation

### DIFF
--- a/tenable/sc/scans.py
+++ b/tenable/sc/scans.py
@@ -323,11 +323,11 @@ class ScanAPI(SCEndpoint):
 
         Returns:
             :obj:`dict`:
-                The alert resource record.
+                The scan resource record.
 
         Examples:
-            >>> alert = sc.alerts.detail(1)
-            >>> pprint(alert)
+            >>> scan = sc.scans.detail(1)
+            >>> pprint(scan)
         '''
         params = dict()
         if fields:
@@ -399,7 +399,7 @@ class ScanAPI(SCEndpoint):
                 The scan resource for the created scan.
 
         Examples:
-            Creating a scan for a single host:
+            Editing an existing scan's name:
 
             >>> sc.scans.edit(1, name='Example scan')
         '''


### PR DESCRIPTION
# Description

This fixes two of the bugs in the documentation related to examples. There are a number more spelling errors throughout this package, sadly I can't seem to branch this repo. From my count though, I've located close to 60 or so typos.

```
❯ git checkout -b typos
warning: refname 'HEAD' is ambiguous.
fatal: Ambiguous object name: 'HEAD'.
```

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
