### PR TITLE
removed can_use permission from tags create API

### DIFF
--- a/tenable/io/tags.py
+++ b/tenable/io/tags.py
@@ -224,7 +224,7 @@ class TagsAPI(TIOEndpoint):
 
             >>> tio.tags.create('00000000-0000-0000-0000-000000000000', 'Madison')
         '''
-        all_permissions = ['ALL', 'CAN_EDIT', 'CAN_SET_PERMISSIONS', 'CAN_USE']
+        all_permissions = ['ALL', 'CAN_EDIT', 'CAN_SET_PERMISSIONS']
         payload = dict()
 
         # First lets see if the category is a UUID or a general string.  If its


### PR DESCRIPTION
# Description

Updated `current_user_permissions` value in tags create API.
reference https://developer.tenable.com/reference#tags-create-tag-value

```
current_user_permissions

List of all permissions for the current user on the current tag. 
Possible values are ALL, CAN_EDIT, and CAN_SET_PERMISSIONS.
```
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
