### PR TITLE
Doc change for 'enabled' variable in 'create' function in exclusion bugfix/issue-273

### DIFF
--- a/tenable/io/exclusions.py
+++ b/tenable/io/exclusions.py
@@ -64,7 +64,9 @@ class ExclusionsAPI(TIOEndpoint):
                 The day of the month to repeat a **MONTHLY** frequency rule on.
                 The default is today.
             enabled (bool, optional):
-                enable/disable exclusion. The default is ``True``
+				If enabled is true, the exclusion schedule is active.
+				If enabled is false, the exclusion is "Always Active"  
+                The default value is ``True``
             network_id (uuid, optional):
                 The ID of the network object associated with scanners
                 where Tenable.io applies the exclusion.

--- a/tenable/io/exclusions.py
+++ b/tenable/io/exclusions.py
@@ -64,8 +64,8 @@ class ExclusionsAPI(TIOEndpoint):
                 The day of the month to repeat a **MONTHLY** frequency rule on.
                 The default is today.
             enabled (bool, optional):
-				If enabled is true, the exclusion schedule is active.
-				If enabled is false, the exclusion is "Always Active"  
+		If enabled is true, the exclusion schedule is active.
+		If enabled is false, the exclusion is "Always Active"  
                 The default value is ``True``
             network_id (uuid, optional):
                 The ID of the network object associated with scanners


### PR DESCRIPTION
# Description

As per the API doc, the value of the 'enabled' boolean flag enables the schedule of exclusion active. That doc correction done in pytenable exclusion.py 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
