### PR TITLE
IN-404: Add UUID regular expression check

### DIFF
--- a/tenable/io/tags.py
+++ b/tenable/io/tags.py
@@ -22,6 +22,8 @@ Methods available on ``tio.tags``:
     .. automethod:: list_categories
 '''
 import json
+import re
+
 from tenable.utils import dict_merge
 from tenable.errors import UnexpectedValueError
 from tenable.io.base import TIOEndpoint, TIOIterator
@@ -231,9 +233,12 @@ class TagsAPI(TIOEndpoint):
         # a UUID, then we will pass the value of category into the category_uuid
         # parameter, if not (but is still a string), then we will pass into
         # category_name
-        try:
+
+        uuid_pattern = re.compile(r'^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$')
+
+        if uuid_pattern.search(category):
             payload['category_uuid'] = self._check('category', category, 'uuid')
-        except UnexpectedValueError:
+        else:
             payload['category_name'] = self._check('category', category, str)
 
         payload['value'] = self._check('value', value, str)

--- a/tenable/io/tags.py
+++ b/tenable/io/tags.py
@@ -25,7 +25,6 @@ import json
 import re
 
 from tenable.utils import dict_merge
-from tenable.errors import UnexpectedValueError
 from tenable.io.base import TIOEndpoint, TIOIterator
 
 class TagsIterator(TIOIterator):

--- a/tests/io/test_tags.py
+++ b/tests/io/test_tags.py
@@ -316,7 +316,8 @@ def test_tags_create_value_category_description_typeerror(api):
     param does not match the expected type.
     '''
     with pytest.raises(TypeError):
-        api.tags.create('', '', category_description=1)
+        api.tags.create('a7b7ebf6-8aaf-4509-a5b3-872b7647fa86', '', category_description=1)
+
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
# Description

Add UUID regular expression check in order to refrain throwing exception if passed category is not uuid.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pytest.


**Test Configuration**:
* Python Version(s) Tested: 3.8
* Tenable.sc version (if necessary):

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
