### PR TITLE
Added missing RetryError import.

### DIFF
--- a/tenable/base/v1.py
+++ b/tenable/base/v1.py
@@ -26,13 +26,14 @@ from tenable.utils import url_validator
 from tenable import __version__, __author__
 
 from tenable.errors import (
-		UnexpectedValueError,
-		InvalidInputError,
-		PermissionError,
-		NotFoundError,
-		UnsupportedError,
-		FileDownloadError,
-		ServerError
+    UnexpectedValueError,
+    InvalidInputError,
+    PermissionError,
+    NotFoundError,
+    UnsupportedError,
+    FileDownloadError,
+    ServerError,
+    RetryError
 )
 
 class APIResultsIterator(object):


### PR DESCRIPTION
# Description

The base/v1.py module is not importing the RetryError exception class.  This would mean when a RetryError exception is to be reaised, it will instead raise a NameError exception, as the RetryError class doesn't exist within the namespace.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Tested forcing a retry error to be raised with a mock API.  NameError raised instead before patch.
- [X] After import, RetryError is raised as expected.

**Test Configuration**:
* Python Version(s) Tested: 3.6, 3.7, 3.8, 3.9

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
