### PR TITLE
In 409

### DIFF
--- a/tenable/io/scans.py
+++ b/tenable/io/scans.py
@@ -582,24 +582,18 @@ class ScansAPI(TIOEndpoint):
                 The scan with updated credentials.
         '''
         if 'credentials' in scan:
-            aws_existing_credential = list()
-            aws_new_credential = list()
-            change_needed = True
+            aws_existing_credential = None
             if 'current' in scan['credentials'] \
                     and 'Cloud Services' in scan['credentials']['current'] \
                     and 'Amazon AWS' in scan['credentials']['current']['Cloud Services']:
                 aws_existing_credential = scan['credentials']['current']['Cloud Services']['Amazon AWS']
-            else:
-                change_needed = False
-            if change_needed and 'add' in scan['credentials'] \
+            if 'add' in scan['credentials'] \
                     and 'Cloud Services' in scan['credentials']['add'] \
                     and 'Amazon AWS' in scan['credentials']['add']['Cloud Services']:
                 aws_new_credential = scan['credentials']['add']['Cloud Services']['Amazon AWS']
-            else:
-                change_needed = False
-            if change_needed and aws_existing_credential != aws_new_credential:
-                scan['credentials']['edit'] = {'Cloud Services': {'Amazon AWS': aws_new_credential}}
-                del scan['credentials']['add']['Cloud Services']['Amazon AWS']
+                if aws_existing_credential is not None and aws_existing_credential != aws_new_credential:
+                    scan['credentials']['edit'] = {'Cloud Services': {'Amazon AWS': aws_new_credential}}
+                    del scan['credentials']['add']['Cloud Services']['Amazon AWS']
         return scan
 
     def copy(self, scan_id, folder_id=None, name=None):

--- a/tenable/io/scans.py
+++ b/tenable/io/scans.py
@@ -188,7 +188,7 @@ class ScansAPI(TIOEndpoint):
             self._check('schedule_scan', kwargs['schedule_scan'], dict)
             if kwargs['schedule_scan']['enabled']:
                 keys = [self.schedule_const.enabled, self.schedule_const.launch, self.schedule_const.rrules,
-                    self.schedule_const.schedule_scan, self.schedule_const.start_time, self.schedule_const.timezone]
+                        self.schedule_const.schedule_scan, self.schedule_const.start_time, self.schedule_const.timezone]
             else:
                 keys = [self.schedule_const.enabled, self.schedule_const.schedule_scan]
 
@@ -226,14 +226,14 @@ class ScansAPI(TIOEndpoint):
                 self.schedule_const.day_of_month: rrules.get('BYMONTHDAY', None),
                 self.schedule_const.start_time: datetime.strptime(
                     details[self.schedule_const.start_time], self.schedule_const.time_format)
-                    if details[self.schedule_const.start_time] is not None else None,
+                if details[self.schedule_const.start_time] is not None else None,
                 self.schedule_const.timezone: details[self.schedule_const.timezone]
-                    if details[self.schedule_const.timezone] is not None else None,
+                if details[self.schedule_const.timezone] is not None else None,
             }
         return schedule
 
     def create_scan_schedule(self, enabled=False, frequency=None, interval=None,
-            weekdays=None, day_of_month=None, starttime=None, timezone=None):
+                             weekdays=None, day_of_month=None, starttime=None, timezone=None):
         '''
         Create dictionary of keys required for scan schedule
 
@@ -270,15 +270,15 @@ class ScansAPI(TIOEndpoint):
 
         if enabled is True:
             launch = self._check(self.schedule_const.frequency, frequency, str,
-                choices=self.schedule_const.frequency_choice,
-                default=self.schedule_const.frequency_default,
-                case=self.case_const.uppercase)
+                                 choices=self.schedule_const.frequency_choice,
+                                 default=self.schedule_const.frequency_default,
+                                 case=self.case_const.uppercase)
             frequency = self.schedule_const.ffrequency.format(launch)
             rrules = {
                 self.schedule_const.frequency: frequency,
                 self.schedule_const.interval: self.schedule_const.finterval.format(
                     self._check(self.schedule_const.interval, interval, int,
-                    default=self.schedule_const.interval_default)),
+                                default=self.schedule_const.interval_default)),
                 self.schedule_const.weekdays: None,
                 self.schedule_const.day_of_month: None
             }
@@ -301,8 +301,8 @@ class ScansAPI(TIOEndpoint):
             if frequency == self.schedule_const.monthly_frequency:
                 rrules[self.schedule_const.day_of_month] = self.schedule_const.fbymonthday.format(
                     self._check(self.schedule_const.day_of_month, day_of_month, int,
-                        choices=self.schedule_const.day_of_month_choice,
-                        default=self.schedule_const.day_of_month_default))
+                                choices=self.schedule_const.day_of_month_choice,
+                                default=self.schedule_const.day_of_month_default))
 
             # Now we have to remove unused keys from rrules and create rrules structure required by scan
             # 'FREQ=ONETIME;INTERVAL=1', FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TH,FR', 'FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=22'
@@ -315,13 +315,14 @@ class ScansAPI(TIOEndpoint):
             # starttime is rounded-off to 30 min schedule to match with values used in UI
             # will assign schedule datetime in (19700101T013000) format
             starttime = self._check(self.schedule_const.start_time, starttime, datetime,
-                default=self.schedule_const.start_time_default)
+                                    default=self.schedule_const.start_time_default)
             secs = timedelta(minutes=30).total_seconds()
             starttime = datetime.fromtimestamp(starttime.timestamp() + secs - starttime.timestamp() % secs)
             schedule[self.schedule_const.start_time] = starttime.strftime(self.schedule_const.time_format)
 
             schedule[self.schedule_const.timezone] = self._check(self.schedule_const.timezone, timezone, str,
-                choices=self._api._tz, default=self.schedule_const.timezone_default)
+                                                                 choices=self._api._tz,
+                                                                 default=self.schedule_const.timezone_default)
 
             schedule[self.schedule_const.schedule_scan] = 'yes'
 
@@ -333,7 +334,7 @@ class ScansAPI(TIOEndpoint):
         return schedule
 
     def configure_scan_schedule(self, id, enabled=None, frequency=None, interval=None,
-            weekdays=None, day_of_month=None, starttime=None, timezone=None):
+                                weekdays=None, day_of_month=None, starttime=None, timezone=None):
         '''
         Create dictionary of keys required for scan schedule
 
@@ -387,10 +388,10 @@ class ScansAPI(TIOEndpoint):
                 existing_rrules = {}
 
             launch = self._check(self.schedule_const.frequency, frequency, str,
-                choices=self.schedule_const.frequency_choice,
-                default=existing_rrules.get(self.schedule_const.frequency, None) or
-                   self.schedule_const.frequency_default,
-                case=self.case_const.uppercase)
+                                 choices=self.schedule_const.frequency_choice,
+                                 default=existing_rrules.get(self.schedule_const.frequency, None) or
+                                         self.schedule_const.frequency_default,
+                                 case=self.case_const.uppercase)
 
             frequency = self.schedule_const.ffrequency.format(launch)
 
@@ -398,8 +399,8 @@ class ScansAPI(TIOEndpoint):
                 self.schedule_const.frequency: frequency,
                 self.schedule_const.interval: self.schedule_const.finterval.format(
                     self._check(self.schedule_const.interval, interval, int,
-                    default=existing_rrules.get(self.schedule_const.interval, None)
-                        or self.schedule_const.interval_default)),
+                                default=existing_rrules.get(self.schedule_const.interval, None)
+                                        or self.schedule_const.interval_default)),
                 self.schedule_const.weekdays: None,
                 self.schedule_const.day_of_month: None
             }
@@ -411,7 +412,7 @@ class ScansAPI(TIOEndpoint):
                     self.schedule_const.weekdays, weekdays, list,
                     choices=self.schedule_const.weekdays_default,
                     default=existing_rrules.get(self.schedule_const.weekdays, '') or
-                        self.schedule_const.weekdays_default,
+                            self.schedule_const.weekdays_default,
                     case=self.case_const.uppercase)))
                 # In the same vein as the frequency check, we're accepting
                 # case-insensitive input, comparing it to our known list of
@@ -423,9 +424,9 @@ class ScansAPI(TIOEndpoint):
             if frequency == self.schedule_const.monthly_frequency:
                 rrules[self.schedule_const.day_of_month] = self.schedule_const.fbymonthday.format(
                     self._check(self.schedule_const.day_of_month, day_of_month, int,
-                    choices=self.schedule_const.day_of_month_choice,
-                    default=existing_rrules.get(self.schedule_const.day_of_month, None)
-                        or self.schedule_const.day_of_month_default))
+                                choices=self.schedule_const.day_of_month_choice,
+                                default=existing_rrules.get(self.schedule_const.day_of_month, None)
+                                        or self.schedule_const.day_of_month_default))
 
             # Now we have to remove unused keys from rrules and create rrules structure required by scan
             # 'FREQ=ONETIME;INTERVAL=1', FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TH,FR', 'FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=22'
@@ -438,15 +439,16 @@ class ScansAPI(TIOEndpoint):
             # starttime is rounded-off to 30 min schedule and
             # will assign schedule datetime in (19700101T011223) manner
             starttime = self._check(self.schedule_const.start_time, starttime, datetime,
-                default=existing_rrules.get(self.schedule_const.start_time, None)
-                    or self.schedule_const.start_time_default)
+                                    default=existing_rrules.get(self.schedule_const.start_time, None)
+                                            or self.schedule_const.start_time_default)
             secs = timedelta(minutes=30).total_seconds()
             starttime = datetime.fromtimestamp(starttime.timestamp() + secs - starttime.timestamp() % secs)
             schedule[self.schedule_const.start_time] = starttime.strftime(self.schedule_const.time_format)
 
             schedule[self.schedule_const.timezone] = self._check(self.schedule_const.timezone, timezone, str,
-                choices=self._api._tz, default=existing_rrules.get(self.schedule_const.timezone, None)
-                    or self.schedule_const.timezone_default)
+                                                                 choices=self._api._tz, default=existing_rrules.get(
+                    self.schedule_const.timezone, None)
+                                                                                                or self.schedule_const.timezone_default)
 
             schedule[self.schedule_const.schedule_scan] = 'yes'
 
@@ -458,7 +460,7 @@ class ScansAPI(TIOEndpoint):
                     self.schedule_const.weekdays, self.schedule_const.day_of_month]
             for k in keys:
                 if k in existing_rrules:
-                    del(existing_rrules[k])
+                    del (existing_rrules[k])
 
             return existing_rrules
 
@@ -499,7 +501,7 @@ class ScansAPI(TIOEndpoint):
         resp = self._api.get('scans/{}/attachments/{}'.format(
             scan_id,
             attachment_id
-            ), params={'key': self._check('key', key, str)}, stream=True)
+        ), params={'key': self._check('key', key, str)}, stream=True)
         for chunk in resp.iter_content(chunk_size=1024):
             if chunk:
                 fobj.write(chunk)
@@ -563,14 +565,16 @@ class ScansAPI(TIOEndpoint):
         current = self.details(scan_id)
         updated = self._create_scan_document(kw)
         scan = dict_merge(current, updated)
-        scan = self._check_add_edit_aws_credentials(scan)
+        scan = self.upsert_aws_credentials(scan)
         # Performing the actual call to the API with the updated scan record.
         return self._api.put('scans/{}'.format(scan_id),
-                    json=scan).json()
+                             json=scan).json()
 
-    def _check_add_edit_aws_credentials(self, scan):
+    def upsert_aws_credentials(self, scan):
         '''
-        checks the credential dict of scan dict to derive operation add or edit.
+        Checks the credential dict of scan dict to derive operation add or edit.
+        This function assumes there are no edit credentials in the credentials dict.
+        If there is any edit credentials,it would override the same.
         Args:
             scan: scan object to update edit credential if it matches criteria
         Returns:
@@ -578,20 +582,23 @@ class ScansAPI(TIOEndpoint):
                 The scan with updated credentials.
         '''
         if 'credentials' in scan:
-            aws_existing_credential = {}
-            aws_new_credential = {}
-            if 'current' in scan['credentials'] and 'Cloud Services' in scan['credentials']['current'] and 'Amazon AWS' in scan['credentials']['current']['Cloud Services']:
+            aws_existing_credential = list()
+            aws_new_credential = list()
+            if 'current' in scan['credentials'] \
+                    and 'Cloud Services' in scan['credentials']['current'] \
+                    and 'Amazon AWS' in scan['credentials']['current']['Cloud Services']:
                 aws_existing_credential = scan['credentials']['current']['Cloud Services']['Amazon AWS']
             else:
                 return scan
-            if 'add' in scan['credentials'] and 'Cloud Services' in scan['credentials']['add'] and 'Amazon AWS' in scan['credentials']['add']['Cloud Services']:
+            if 'add' in scan['credentials'] \
+                    and 'Cloud Services' in scan['credentials']['add'] \
+                    and 'Amazon AWS' in scan['credentials']['add']['Cloud Services']:
                 aws_new_credential = scan['credentials']['add']['Cloud Services']['Amazon AWS']
             else:
                 return scan
             if aws_existing_credential != aws_new_credential:
-                aws_edit_credential = scan['credentials']['add']['Cloud Services']['Amazon Aws']
-                scan['credentials']['edit'] = {'Cloud Services': {'Amazon AWS', aws_edit_credential}}
-                del scan['credentials']['add']['Cloud Services']['Amazon Aws']
+                scan['credentials']['edit'] = {'Cloud Services': {'Amazon AWS': aws_new_credential}}
+                del scan['credentials']['add']['Cloud Services']['Amazon AWS']
         return scan
 
     def copy(self, scan_id, folder_id=None, name=None):
@@ -622,7 +629,7 @@ class ScansAPI(TIOEndpoint):
 
         # make the call and return the resulting JSON document to the caller.
         return self._api.post('scans/{}/copy'.format(scan_id),
-            json=payload).json()
+                              json=payload).json()
 
     def create(self, **kw):
         '''
@@ -762,13 +769,13 @@ class ScansAPI(TIOEndpoint):
             ) for i in sort])
 
         return ScanHistoryIterator(self._api,
-            _limit=limit if limit else 50,
-            _offset=offset if offset else 0,
-            _pages_total=pages,
-            _query=query,
-            _path='scans/{}/history'.format(scan_id),
-            _resource='history'
-        )
+                                   _limit=limit if limit else 50,
+                                   _offset=offset if offset else 0,
+                                   _pages_total=pages,
+                                   _query=query,
+                                   _path='scans/{}/history'.format(scan_id),
+                                   _resource='history'
+                                   )
 
     def delete_history(self, scan_id, history_id):
         '''
@@ -937,9 +944,9 @@ class ScansAPI(TIOEndpoint):
         # instead of as an argument list.  As this seems to be a common
         # issue, we should be supporting this methodology.
         filters = self._check('filters',
-            kw.get('filters', filters), (list, tuple))
+                              kw.get('filters', filters), (list, tuple))
         payload = self._parse_filters(filters,
-            self._api.filters.scan_filters(), rtype='sjson')
+                                      self._api.filters.scan_filters(), rtype='sjson')
         params = dict()
         dl_params = dict()
 
@@ -960,19 +967,19 @@ class ScansAPI(TIOEndpoint):
             payload['password'] = self._check('password', kw['password'], str)
 
         payload['format'] = self._check('format',
-            kw['format'] if 'format' in kw else None,
-            str, choices=['nessus', 'html', 'pdf', 'csv', 'db'],
-            default='nessus')
+                                        kw['format'] if 'format' in kw else None,
+                                        str, choices=['nessus', 'html', 'pdf', 'csv', 'db'],
+                                        default='nessus')
 
         # The chapters are sent to us in a list, and we need to collapse that
         # down to a comma-delimited string.
         payload['chapters'] = ';'.join(
             self._check('chapters',
-                kw['chapters'] if 'chapters' in kw else None,
-                list,
-                choices=['vuln_hosts_summary', 'vuln_by_host', 'vuln_by_plugin',
-                    'compliance_exec', 'compliance', 'remediations'],
-                default=['vuln_by_host']))
+                        kw['chapters'] if 'chapters' in kw else None,
+                        list,
+                        choices=['vuln_hosts_summary', 'vuln_by_host', 'vuln_by_plugin',
+                                 'compliance_exec', 'compliance', 'remediations'],
+                        default=['vuln_by_host']))
 
         if 'filter_type' in kw:
             payload['filter.search_type'] = self._check(
@@ -989,7 +996,7 @@ class ScansAPI(TIOEndpoint):
         # The first thing that we need to do is make the request and get the
         # File id for the job.
         fid = self._api.post('scans/{}/export'.format(scan_id),
-            params=params, json=payload).json()['file']
+                             params=params, json=payload).json()['file']
         self._api._log.debug('Initiated scan export {}'.format(fid))
 
         # Next we will wait for the status of the export request to become
@@ -1050,10 +1057,9 @@ class ScansAPI(TIOEndpoint):
                 'history_uuid', history_uuid, 'scanner-uuid')
 
         return self._api.get('scans/{}/hosts/{}'.format(
-                scan_id,
-                self._check('host_id', host_id, int)),
+            scan_id,
+            self._check('host_id', host_id, int)),
             params=params).json()
-
 
     def import_scan(self, fobj, folder_id=None, password=None, aggregate=None):
         '''
@@ -1136,7 +1142,7 @@ class ScansAPI(TIOEndpoint):
             payload['alt_targets'] = self._check('targets', targets, list)
 
         return self._api.post('scans/{}/launch'.format(
-                scan_id),
+            scan_id),
             json=payload).json()['scan_uuid']
 
     def list(self, folder_id=None, last_modified=None):
@@ -1378,7 +1384,7 @@ class ScansAPI(TIOEndpoint):
             self._check('history_uuid', history_uuid, 'scanner-uuid'))).json()
 
     def check_auto_targets(self, limit, matched_resource_limit,
-            network_uuid=None, tags=None, targets=None):
+                           network_uuid=None, tags=None, targets=None):
         '''
         Evaluates a list of targets and/or tags against
         the scan route configuration of scanner groups.
@@ -1414,7 +1420,7 @@ class ScansAPI(TIOEndpoint):
         payload = dict()
 
         payload['network_uuid'] = self._check('network_uuid', network_uuid, 'uuid',
-            default='00000000-0000-0000-0000-000000000000')
+                                              default='00000000-0000-0000-0000-000000000000')
 
         if tags:
             payload['tags'] = [

--- a/tenable/io/scans.py
+++ b/tenable/io/scans.py
@@ -333,13 +333,13 @@ class ScansAPI(TIOEndpoint):
 
         return schedule
 
-    def configure_scan_schedule(self, id, enabled=None, frequency=None, interval=None,
+    def configure_scan_schedule(self, scan_id, enabled=None, frequency=None, interval=None,
                                 weekdays=None, day_of_month=None, starttime=None, timezone=None):
         '''
         Create dictionary of keys required for scan schedule
 
         Args:
-            id (int): The id of the Scan object in Tenable.io
+            scan_id (int): The id of the Scan object in Tenable.io
             enabled (bool, optional): To enable/disable scan schedule
             frequency (str, optional):
                 The frequency of the rule. The string inputted will be up-cased.
@@ -367,7 +367,7 @@ class ScansAPI(TIOEndpoint):
                 Dictionary of the keys required for scan schedule.
 
         '''
-        current = self.details(self._check('id', id, int))['settings']
+        current = self.details(self._check('scan_id', scan_id, int))['settings']
         if enabled in [True, False]:
             current[self.schedule_const.enabled] = self._check(self.schedule_const.enabled, enabled, bool)
         schedule = {}
@@ -584,19 +584,20 @@ class ScansAPI(TIOEndpoint):
         if 'credentials' in scan:
             aws_existing_credential = list()
             aws_new_credential = list()
+            change_needed = True
             if 'current' in scan['credentials'] \
                     and 'Cloud Services' in scan['credentials']['current'] \
                     and 'Amazon AWS' in scan['credentials']['current']['Cloud Services']:
                 aws_existing_credential = scan['credentials']['current']['Cloud Services']['Amazon AWS']
             else:
-                return scan
-            if 'add' in scan['credentials'] \
+                change_needed = False
+            if change_needed and 'add' in scan['credentials'] \
                     and 'Cloud Services' in scan['credentials']['add'] \
                     and 'Amazon AWS' in scan['credentials']['add']['Cloud Services']:
                 aws_new_credential = scan['credentials']['add']['Cloud Services']['Amazon AWS']
             else:
-                return scan
-            if aws_existing_credential != aws_new_credential:
+                change_needed = False
+            if change_needed and aws_existing_credential != aws_new_credential:
                 scan['credentials']['edit'] = {'Cloud Services': {'Amazon AWS': aws_new_credential}}
                 del scan['credentials']['add']['Cloud Services']['Amazon AWS']
         return scan

--- a/tenable/io/scans.py
+++ b/tenable/io/scans.py
@@ -582,17 +582,23 @@ class ScansAPI(TIOEndpoint):
                 The scan with updated credentials.
         '''
         if 'credentials' in scan:
-            aws_existing_credential = None
+            aws_existing_credential_id = None
             if 'current' in scan['credentials'] \
                     and 'Cloud Services' in scan['credentials']['current'] \
                     and 'Amazon AWS' in scan['credentials']['current']['Cloud Services']:
                 aws_existing_credential = scan['credentials']['current']['Cloud Services']['Amazon AWS']
+                if len(aws_existing_credential) == 1:
+                    aws_existing_credential_id = aws_existing_credential[0]['id']
             if 'add' in scan['credentials'] \
                     and 'Cloud Services' in scan['credentials']['add'] \
                     and 'Amazon AWS' in scan['credentials']['add']['Cloud Services']:
                 aws_new_credential = scan['credentials']['add']['Cloud Services']['Amazon AWS']
-                if aws_existing_credential is not None and aws_existing_credential != aws_new_credential:
-                    scan['credentials']['edit'] = {'Cloud Services': {'Amazon AWS': aws_new_credential}}
+                aws_new_credential_id = None
+                if len(aws_new_credential) == 1:
+                    aws_new_credential_id = aws_new_credential[0]['id']
+                if aws_existing_credential_id is not None and aws_existing_credential_id != aws_new_credential_id:
+                    scan['credentials']['edit'] = \
+                        {'Cloud Services': {'Amazon AWS': scan['credentials']['add']['Cloud Services']['Amazon AWS']}}
                     del scan['credentials']['add']['Cloud Services']['Amazon AWS']
         return scan
 

--- a/tests/io/test_scans.py
+++ b/tests/io/test_scans.py
@@ -528,16 +528,20 @@ def test_upsert_aws_credentials(api):
         dict of scan
     '''
     scan = {
-        'credentials': {'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS1', 'secret_key': 'SECRET1'}]}},
-                        'add': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}}
+        'credentials': {'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS1',
+                                                                       'secret_key': 'SECRET1', 'id': 12346}]}},
+                        'add': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2',
+                                                                   'id': 12347}]}}
                         },
     }
 
     scan_output = {
         'credentials': {
-            'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS1', 'secret_key': 'SECRET1'}]}},
+            'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS1',
+                                                           'secret_key': 'SECRET1', 'id': 12346}]}},
             'add': {'Cloud Services': {}},
-            'edit': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}}
+            'edit': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2',
+                                                        'id': 12347}]}}
             },
     }
     scan_actual = api.scans.upsert_aws_credentials(scan)
@@ -552,12 +556,14 @@ def test_upsert_aws_credentials_no_current(api):
     '''
     scan = {
         'credentials': {'current': {},
-                        'add': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}}
+                        'add': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2',
+                                                                   'id': 12347}]}}
                         },
     }
     scan_expected = {
         'credentials': {'current': {},
-                        'add': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}}
+                        'add': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2',
+                                                                   'id': 12347}]}}
                         },
     }
     scan_actual = api.scans.upsert_aws_credentials(scan)
@@ -571,12 +577,14 @@ def test_upsert_aws_credentials_no_add(api):
         dict of scan when there is no add
     '''
     scan = {
-        'credentials': {'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}},
+        'credentials': {'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2',
+                                                                       'id': 12346}]}},
                         'add': {}
                         },
     }
     scan_expected = {
-        'credentials': {'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}},
+        'credentials': {'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2',
+                                                                       'id': 12346}]}},
                         'add': {}
                         },
     }

--- a/tests/io/test_scans.py
+++ b/tests/io/test_scans.py
@@ -486,14 +486,26 @@ def test_scan_configure_schedule_freq_weekly_valavailable(api):
     '''
     create_schedule = api.scans.create_scan_schedule(
         enabled=True, frequency='weekly', weekdays=['MO', 'TU'])
+    scan_creds = {
+        'Cloud Services': {
+            'Amazon AWS': [{'access_key_id': 'ACCESS1', 'secret_key': 'SECRET1'}]
+        }
+    }
     scan = api.scans.create(
         name='pytest: {}'.format(uuid.uuid4()),
         template='basic',
         targets=['127.0.0.1'],
+        credentials=scan_creds,
         schedule_scan=create_schedule)
     update_schedule = api.scans.configure_scan_schedule(id=scan['id'], interval=2)
+
+    scan_creds_new = {
+        'Cloud Services': {
+            'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]
+        }
+    }
     mod = api.scans.configure(scan['id'],
-                              schedule_scan=update_schedule)
+                              schedule_scan=update_schedule, credentials=scan_creds_new)
     assert isinstance(mod, dict)
     check(mod, 'creation_date', int)
     check(mod, 'custom_targets', str)

--- a/tests/io/test_scans.py
+++ b/tests/io/test_scans.py
@@ -13,6 +13,7 @@ from tests.checker import check, single
 from tests.io.conftest import SCAN_ID_WITH_RESULTS
 from tests.pytenable_log_handler import log_exception
 
+
 @pytest.fixture(name='scheduled_scan')
 def fixture_scheduled_scan(request, api):
     '''
@@ -491,7 +492,7 @@ def test_scan_configure_schedule_freq_weekly_valavailable(api):
         template='basic',
         targets=['127.0.0.1'],
         schedule_scan=create_schedule)
-    update_schedule = api.scans.configure_scan_schedule(id=scan['id'], interval=2)
+    update_schedule = api.scans.configure_scan_schedule(scan_id=scan['id'], interval=2)
     mod = api.scans.configure(scan['id'],
                               schedule_scan=update_schedule)
     assert isinstance(mod, dict)
@@ -1563,8 +1564,8 @@ def test_scan_host_details(api, scan_results):
             check(compliance, 'severity_index', int)
             check(compliance, 'plugin_family', str)
     except KeyError as key:
-       log_exception(key)
-       print('Key error: ', key)
+        log_exception(key)
+        print('Key error: ', key)
 
 
 @pytest.mark.vcr()

--- a/tests/io/test_scans.py
+++ b/tests/io/test_scans.py
@@ -555,9 +555,14 @@ def test_upsert_aws_credentials_no_current(api):
                         'add': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}}
                         },
     }
+    scan_expected = {
+        'credentials': {'current': {},
+                        'add': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}}
+                        },
+    }
     scan_actual = api.scans.upsert_aws_credentials(scan)
     assert isinstance(scan_actual, dict)
-    assert scan == scan_actual
+    assert scan_expected == scan_actual
 
 
 def test_upsert_aws_credentials_no_add(api):
@@ -570,9 +575,14 @@ def test_upsert_aws_credentials_no_add(api):
                         'add': {}
                         },
     }
+    scan_expected = {
+        'credentials': {'current': {'Cloud Services': {'Amazon AWS': [{'access_key_id': 'ACCESS2', 'secret_key': 'SECRET2'}]}},
+                        'add': {}
+                        },
+    }
     scan_actual = api.scans.upsert_aws_credentials(scan)
     assert isinstance(scan_actual, dict)
-    assert scan == scan_actual
+    assert scan_expected == scan_actual
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
# Description

The current tio.scans.configure(scan_id, credentials) is making a PUT /scans/{scan_id} call with { 'credentials : { 'add': {} }}` no matter what was provided.

The solution would be that it will compare the id of the <credentials> provided into the function with the id of the existing credentials it gets back from the GET /scans/{scan_id} call and then decide if it should do an add or edit operation.

we can also "auto-magically" do that in the case the credentials provided are of type Cloud Services -> Amazon AWS since we know that it is limited to one set of credentials.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Python Version(s) Tested: 3.8.0
* Tenable.sc version (if necessary):

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
