### PR TITLE
Fixed typos in doc-string examples

### DIFF
--- a/tenable/io/policies.py
+++ b/tenable/io/policies.py
@@ -241,7 +241,7 @@ class PoliciesAPI(TIOEndpoint):
 
         Examples:
             >>> with open('example.nessus') as policy:
-            ...     tio.policies.import(policy)
+            ...     tio.policies.policy_import(policy)
         '''
         fid = self._api.files.upload(fobj)
         return self._api.post('policies/import', json={'file': fid}).json()
@@ -266,7 +266,7 @@ class PoliciesAPI(TIOEndpoint):
 
         Examples:
             >>> with open('example.nessus', 'wb') as policy:
-            ...     tio.policies.export(1, policy)
+            ...     tio.policies.policy_export(1, policy)
         '''
         # If no file object was givent to us, then lets create a new BytesIO
         # object to dump the data into.


### PR DESCRIPTION
Doc-strings for _policy_import_ and _policy_export_ had wrong examples:
`tio.policies.import(policy)`  -> should be `tio.policies.policy_import(policy)`
`tio.policies.export(policy)`  -> should be `tio.policies.policy_export(policy)`

# Description

Simple syntax fix, no dependencies. Only changes to doc-strings. Fixed both examples.

Fixes # (409)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [?] This change requires a documentation update (Not sure, since it's about documentation, it might?)
