### PR TITLE
orgID should be optional given that it's optional in the API

### DIFF
--- a/tenable/sc/asset_lists.py
+++ b/tenable/sc/asset_lists.py
@@ -440,7 +440,7 @@ class AssetListAPI(SCEndpoint):
         payload = self._constructor(**kw)
         return self._api.post('asset', json=payload).json()['response']
 
-    def details(self, id, orgID, fields=None):
+    def details(self, id, orgID=None, fields=None):
         '''
         Returns the details for a specific asset-list.
 
@@ -448,7 +448,7 @@ class AssetListAPI(SCEndpoint):
 
         Args:
             id (int): The identifier for the asset-list.
-            orgID (int): The organizationID for the asset-list.
+            orgID (int, optional): The organizationID for the asset-list.
             fields (list, optional): A list of attributes to return.
 
         Returns:
@@ -461,7 +461,8 @@ class AssetListAPI(SCEndpoint):
         params = dict()
         if fields:
             params['fields'] = ','.join([self._check('field', f, str) for f in fields])
-        params['orgID']   = orgID
+        if orgID:
+            params['orgID']   = orgID
         return self._api.get('asset/{}'.format(self._check('id', id,int)),params=params).json()['response']
 
     def edit(self, id, **kw):

--- a/tenable/sc/asset_lists.py
+++ b/tenable/sc/asset_lists.py
@@ -440,15 +440,15 @@ class AssetListAPI(SCEndpoint):
         payload = self._constructor(**kw)
         return self._api.post('asset', json=payload).json()['response']
 
-    def details(self, id, orgID=None, fields=None):
+    def details(self, id, org_id=None, fields=None):
         '''
         Returns the details for a specific asset-list.
 
-        :sc-api:`asset-list: details<Asset.html#AssetRESTReference-/asset/{id}?orgID={orgID}>`
+        :sc-api:`asset-list: details<Asset.html#AssetRESTReference-/asset/{id}?orgID={org_id}>`
 
         Args:
             id (int): The identifier for the asset-list.
-            orgID (int, optional): The organizationID for the asset-list.
+            org_id (int, optional): The organizationID for the asset-list.
             fields (list, optional): A list of attributes to return.
 
         Returns:
@@ -461,8 +461,8 @@ class AssetListAPI(SCEndpoint):
         params = dict()
         if fields:
             params['fields'] = ','.join([self._check('field', f, str) for f in fields])
-        if orgID:
-            params['orgID']   = orgID
+        if org_id:
+            params['orgID'] = org_id
         return self._api.get('asset/{}'.format(self._check('id', id,int)),params=params).json()['response']
 
     def edit(self, id, **kw):


### PR DESCRIPTION
orgID was made a required parameter to address issue #294, however orgID is only required by the API if the user is an administrator. Making orgID required means a script needs to know what org its running under which adds more complexity. IMO making it optional addresses #294 without breaking my code.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
