### PR TITLE
Update credentials.py

### DIFF
--- a/tenable/sc/credentials.py
+++ b/tenable/sc/credentials.py
@@ -797,11 +797,15 @@ class CredentialAPI(SCEndpoint):
                 The password for the credential.
             port (int, optional):
                 A valid port number for a database credential.
+            private_key (file, optional):
+                The fileobject containing the SSH private key.
             privilege_escalation (str, optional):
                 The type of privilege escalation to perform once authenticated.
                 Valid values are ``.k5login``, ``cisco``, ``dzdo``, ``none``,
                 ``pbrun``, ``su``, ``su+sudo``, ``sudo``.  If left unspecified,
                 the default is ``none``.
+            public_key (file, optional):
+                The fileobject containing the SSH public key or certificate.
             oracle_auth_type (str, optional):
                 The type of authentication to use when communicating to an
                 Oracle database server.  Supported values are ``sysdba``,


### PR DESCRIPTION
edit supports private_key and public_key but isn't included in documentation

# Description

When looking at the https://pytenable.readthedocs.io/en/stable/_modules/tenable/sc/credentials.html I was lead to believe that I couldn't use the edit functionality for private_key and public_key, however through testing I've found this does work. This is to update the documentation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Added one - this is just documentation change

# How Has This Been Tested?

fobj = open('id_rsa')
fobj2 = open('id_rsa-cert')
sc = TenableSC('nessusmanager')
sc.login(SC_USERNAME,SC_PASSWORD)
id_rsa_filename = sc.files.upload(fobj)
id_rsa_cert_filename = sc.files.upload(fobj2)
sc.credentials.edit(CREDENTIAL_ID,private_key=fobj,public_key=fobj2)
fobj.close()
fobj2.close()

the above code works.

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
