### PR TITLE
allows T.sc version to be set on initialization

### DIFF
--- a/tests/sc/cassettes/sc_login_no_version.yaml
+++ b/tests/sc/cassettes/sc_login_no_version.yaml
@@ -1,0 +1,139 @@
+---
+interactions:
+  - request:
+      body: null
+      headers:
+        Accept: ['*/*']
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [keep-alive]
+        User-Agent: [pyTenable/1.0.0 (pyTenable/1.0.0; Python/2.7.15)]
+      method: GET
+      uri: https://securitycenter.home.cugnet.net/rest/system
+    response:
+      body: {string: !!python/unicode '{"type":"regular","response":{"reportTypes":[{"name":"PDF","type":"pdf",
+      "enabled":"true","attributeSets":[]},{"name":"CSV","type":"csv","enabled":"true","attributeSets":[]},
+      {"name":"RTF","type":"rtf","enabled":"true","attributeSets":[]},{"name":"DISA ARF","type":"arf","enabled":"false",
+      "attributeSets":["arf"]},{"name":"DISA ASR","type":"asr","enabled":"false","attributeSets":[]},
+      {"name":"CyberScope","type":"lasr","enabled":"true","attributeSets":["lasr"]}],
+      "buildID":"201810303290","banner":"","releaseID":"201810303290","uuid":"3ae050e2-486c-5c1a-a6a5-45305557cec3",
+      "logo":"assets\/mariana\/images\/sc4icon.png","serverAuth":"any","serverClassification":"None",
+      "sessionTimeout":"3600","licenseStatus":"Valid","ACAS":"false","freshInstall":"no","headerText":"",
+      "loginNotifications":"false","PasswordComplexity":"false","telemetryEnabled":"false", "token":"0000000000",
+      "timezones":[{"name":"Africa\/Abidjan","gmtOffset":0},{"name":"Africa\/Accra","gmtOffset":0},
+      {"name":"Africa\/Addis_Ababa","gmtOffset":3},{"name":"Africa\/Algiers","gmtOffset":1},
+      {"name":"Africa\/Asmara","gmtOffset":3},{"name":"Africa\/Bamako","gmtOffset":0},
+      {"name":"Africa\/Bangui","gmtOffset":1},{"name":"Africa\/Banjul","gmtOffset":0},
+      {"name":"Africa\/Bissau","gmtOffset":0},{"name":"Africa\/Blantyre","gmtOffset":2},
+      {"name":"Africa\/Brazzaville","gmtOffset":1},{"name":"Africa\/Bujumbura","gmtOffset":2},
+      {"name":"Africa\/Cairo","gmtOffset":2},{"name":"Africa\/Casablanca","gmtOffset":0},
+      {"name":"Africa\/Ceuta","gmtOffset":1},{"name":"Africa\/Conakry","gmtOffset":0},
+      {"name":"Africa\/Dakar","gmtOffset":0},{"name":"Africa\/Dar_es_Salaam","gmtOffset":3},
+      {"name":"Africa\/Djibouti","gmtOffset":3},{"name":"Africa\/Douala","gmtOffset":1},
+      {"name":"Africa\/El_Aaiun","gmtOffset":0},{"name":"Africa\/Freetown","gmtOffset":0},
+      {"name":"Africa\/Gaborone","gmtOffset":2},{"name":"Africa\/Harare","gmtOffset":2},
+      {"name":"Africa\/Johannesburg","gmtOffset":2},{"name":"Africa\/Juba","gmtOffset":3},
+      {"name":"Africa\/Kampala","gmtOffset":3},{"name":"Africa\/Khartoum","gmtOffset":2},
+      {"name":"Africa\/Kigali","gmtOffset":2},{"name":"Africa\/Kinshasa","gmtOffset":1},
+      {"name":"Africa\/Lagos","gmtOffset":1},{"name":"Africa\/Libreville","gmtOffset":1},
+      {"name":"Africa\/Lome","gmtOffset":0},{"name":"Africa\/Luanda","gmtOffset":1},
+      {"name":"Africa\/Lubumbashi","gmtOffset":2},{"name":"Africa\/Lusaka","gmtOffset":2},
+      {"name":"Africa\/Malabo","gmtOffset":1},{"name":"Africa\/Maputo","gmtOffset":2},
+      {"name":"Africa\/Maseru","gmtOffset":2},{"name":"Africa\/Mbabane","gmtOffset":2},
+      {"name":"Africa\/Mogadishu","gmtOffset":3},{"name":"Africa\/Monrovia","gmtOffset":0},
+      {"name":"Africa\/Nairobi","gmtOffset":3},{"name":"Africa\/Ndjamena","gmtOffset":1},
+      {"name":"Africa\/Niamey","gmtOffset":1},{"name":"Africa\/Nouakchott","gmtOffset":0},
+      {"name":"Africa\/Ouagadougou","gmtOffset":0},{"name":"Africa\/Porto-Novo","gmtOffset":1},
+      {"name":"Africa\/Sao_Tome","gmtOffset":1},{"name":"Africa\/Tripoli","gmtOffset":2},
+      {"name":"Africa\/Tunis","gmtOffset":1},{"name":"Africa\/Windhoek","gmtOffset":2},
+      {"name":"America\/Adak","gmtOffset":-10},{"name":"America\/Anchorage","gmtOffset":-9},
+      {"name":"America\/Anguilla","gmtOffset":-4},{"name":"America\/Antigua","gmtOffset":-4},
+      {"name":"America\/Araguaina","gmtOffset":-3},{"name":"America\/Argentina\/Buenos_Aires","gmtOffset":-3},
+      {"name":"America\/Argentina\/Catamarca","gmtOffset":-3},{"name":"America\/Argentina\/Cordoba","gmtOffset":-3},
+      {"name":"America\/Argentina\/Jujuy","gmtOffset":-3},{"name":"America\/Argentina\/La_Rioja","gmtOffset":-3},
+      {"name":"America\/Argentina\/Mendoza","gmtOffset":-3},{"name":"America\/Argentina\/Rio_Gallegos","gmtOffset":-3},
+      {"name":"America\/Argentina\/Salta","gmtOffset":-3},{"name":"America\/Argentina\/San_Juan","gmtOffset":-3},
+      {"name":"America\/Argentina\/San_Luis","gmtOffset":-3},{"name":"America\/Argentina\/Tucuman","gmtOffset":-3},
+      {"name":"America\/Argentina\/Ushuaia","gmtOffset":-3},{"name":"America\/Aruba","gmtOffset":-4},
+      {"name":"America\/Asuncion","gmtOffset":-3},{"name":"America\/Atikokan","gmtOffset":-5},
+      {"name":"America\/Bahia","gmtOffset":-3},{"name":"America\/Bahia_Banderas","gmtOffset":-6},
+      {"name":"America\/Barbados","gmtOffset":-4},{"name":"America\/Belem","gmtOffset":-3},{"name":"America\/Belize","gmtOffset":-6},{"name":"America\/Blanc-Sablon","gmtOffset":-4},{"name":"America\/Boa_Vista","gmtOffset":-4},{"name":"America\/Bogota","gmtOffset":-5},{"name":"America\/Boise","gmtOffset":-7},{"name":"America\/Cambridge_Bay","gmtOffset":-7},{"name":"America\/Campo_Grande","gmtOffset":-3},{"name":"America\/Cancun","gmtOffset":-5},{"name":"America\/Caracas","gmtOffset":-4},{"name":"America\/Cayenne","gmtOffset":-3},{"name":"America\/Cayman","gmtOffset":-5},{"name":"America\/Chicago","gmtOffset":-6},{"name":"America\/Chihuahua","gmtOffset":-7},{"name":"America\/Costa_Rica","gmtOffset":-6},{"name":"America\/Creston","gmtOffset":-7},{"name":"America\/Cuiaba","gmtOffset":-3},{"name":"America\/Curacao","gmtOffset":-4},{"name":"America\/Danmarkshavn","gmtOffset":0},{"name":"America\/Dawson","gmtOffset":-8},{"name":"America\/Dawson_Creek","gmtOffset":-7},{"name":"America\/Denver","gmtOffset":-7},{"name":"America\/Detroit","gmtOffset":-5},{"name":"America\/Dominica","gmtOffset":-4},{"name":"America\/Edmonton","gmtOffset":-7},{"name":"America\/Eirunepe","gmtOffset":-5},{"name":"America\/El_Salvador","gmtOffset":-6},{"name":"America\/Fort_Nelson","gmtOffset":-7},{"name":"America\/Fortaleza","gmtOffset":-3},{"name":"America\/Glace_Bay","gmtOffset":-4},{"name":"America\/Godthab","gmtOffset":-3},{"name":"America\/Goose_Bay","gmtOffset":-4},{"name":"America\/Grand_Turk","gmtOffset":-5},{"name":"America\/Grenada","gmtOffset":-4},{"name":"America\/Guadeloupe","gmtOffset":-4},{"name":"America\/Guatemala","gmtOffset":-6},{"name":"America\/Guayaquil","gmtOffset":-5},{"name":"America\/Guyana","gmtOffset":-4},{"name":"America\/Halifax","gmtOffset":-4},{"name":"America\/Havana","gmtOffset":-5},{"name":"America\/Hermosillo","gmtOffset":-7},{"name":"America\/Indiana\/Indianapolis","gmtOffset":-5},{"name":"America\/Indiana\/Knox","gmtOffset":-6},{"name":"America\/Indiana\/Marengo","gmtOffset":-5},{"name":"America\/Indiana\/Petersburg","gmtOffset":-5},{"name":"America\/Indiana\/Tell_City","gmtOffset":-6},{"name":"America\/Indiana\/Vevay","gmtOffset":-5},{"name":"America\/Indiana\/Vincennes","gmtOffset":-5},{"name":"America\/Indiana\/Winamac","gmtOffset":-5},{"name":"America\/Inuvik","gmtOffset":-7},{"name":"America\/Iqaluit","gmtOffset":-5},{"name":"America\/Jamaica","gmtOffset":-5},{"name":"America\/Juneau","gmtOffset":-9},{"name":"America\/Kentucky\/Louisville","gmtOffset":-5},{"name":"America\/Kentucky\/Monticello","gmtOffset":-5},{"name":"America\/Kralendijk","gmtOffset":-4},{"name":"America\/La_Paz","gmtOffset":-4},{"name":"America\/Lima","gmtOffset":-5},{"name":"America\/Los_Angeles","gmtOffset":-8},{"name":"America\/Lower_Princes","gmtOffset":-4},{"name":"America\/Maceio","gmtOffset":-3},{"name":"America\/Managua","gmtOffset":-6},{"name":"America\/Manaus","gmtOffset":-4},{"name":"America\/Marigot","gmtOffset":-4},{"name":"America\/Martinique","gmtOffset":-4},{"name":"America\/Matamoros","gmtOffset":-6},{"name":"America\/Mazatlan","gmtOffset":-7},{"name":"America\/Menominee","gmtOffset":-6},{"name":"America\/Merida","gmtOffset":-6},{"name":"America\/Metlakatla","gmtOffset":-9},{"name":"America\/Mexico_City","gmtOffset":-6},{"name":"America\/Miquelon","gmtOffset":-3},{"name":"America\/Moncton","gmtOffset":-4},{"name":"America\/Monterrey","gmtOffset":-6},{"name":"America\/Montevideo","gmtOffset":-3},{"name":"America\/Montserrat","gmtOffset":-4},{"name":"America\/Nassau","gmtOffset":-5},{"name":"America\/New_York","gmtOffset":-5},{"name":"America\/Nipigon","gmtOffset":-5},{"name":"America\/Nome","gmtOffset":-9},{"name":"America\/Noronha","gmtOffset":-2},{"name":"America\/North_Dakota\/Beulah","gmtOffset":-6},{"name":"America\/North_Dakota\/Center","gmtOffset":-6},{"name":"America\/North_Dakota\/New_Salem","gmtOffset":-6},{"name":"America\/Ojinaga","gmtOffset":-7},{"name":"America\/Panama","gmtOffset":-5},{"name":"America\/Pangnirtung","gmtOffset":-5},{"name":"America\/Paramaribo","gmtOffset":-3},{"name":"America\/Phoenix","gmtOffset":-7},{"name":"America\/Port-au-Prince","gmtOffset":-5},{"name":"America\/Port_of_Spain","gmtOffset":-4},{"name":"America\/Porto_Velho","gmtOffset":-4},{"name":"America\/Puerto_Rico","gmtOffset":-4},{"name":"America\/Punta_Arenas","gmtOffset":-3},{"name":"America\/Rainy_River","gmtOffset":-6},{"name":"America\/Rankin_Inlet","gmtOffset":-6},{"name":"America\/Recife","gmtOffset":-3},{"name":"America\/Regina","gmtOffset":-6},{"name":"America\/Resolute","gmtOffset":-6},{"name":"America\/Rio_Branco","gmtOffset":-5},{"name":"America\/Santarem","gmtOffset":-3},{"name":"America\/Santiago","gmtOffset":-3},{"name":"America\/Santo_Domingo","gmtOffset":-4},{"name":"America\/Sao_Paulo","gmtOffset":-2},{"name":"America\/Scoresbysund","gmtOffset":-1},{"name":"America\/Sitka","gmtOffset":-9},{"name":"America\/St_Barthelemy","gmtOffset":-4},{"name":"America\/St_Johns","gmtOffset":-3.5},{"name":"America\/St_Kitts","gmtOffset":-4},{"name":"America\/St_Lucia","gmtOffset":-4},{"name":"America\/St_Thomas","gmtOffset":-4},{"name":"America\/St_Vincent","gmtOffset":-4},{"name":"America\/Swift_Current","gmtOffset":-6},{"name":"America\/Tegucigalpa","gmtOffset":-6},{"name":"America\/Thule","gmtOffset":-4},{"name":"America\/Thunder_Bay","gmtOffset":-5},{"name":"America\/Tijuana","gmtOffset":-8},{"name":"America\/Toronto","gmtOffset":-5},{"name":"America\/Tortola","gmtOffset":-4},{"name":"America\/Vancouver","gmtOffset":-8},{"name":"America\/Whitehorse","gmtOffset":-8},{"name":"America\/Winnipeg","gmtOffset":-6},{"name":"America\/Yakutat","gmtOffset":-9},{"name":"America\/Yellowknife","gmtOffset":-7},{"name":"Antarctica\/Casey","gmtOffset":8},{"name":"Antarctica\/Davis","gmtOffset":7},{"name":"Antarctica\/DumontDUrville","gmtOffset":10},{"name":"Antarctica\/Macquarie","gmtOffset":11},{"name":"Antarctica\/Mawson","gmtOffset":5},{"name":"Antarctica\/McMurdo","gmtOffset":13},{"name":"Antarctica\/Palmer","gmtOffset":-3},{"name":"Antarctica\/Rothera","gmtOffset":-3},{"name":"Antarctica\/Syowa","gmtOffset":3},{"name":"Antarctica\/Troll","gmtOffset":0},{"name":"Antarctica\/Vostok","gmtOffset":6},{"name":"Arctic\/Longyearbyen","gmtOffset":1},{"name":"Asia\/Aden","gmtOffset":3},{"name":"Asia\/Almaty","gmtOffset":6},{"name":"Asia\/Amman","gmtOffset":2},{"name":"Asia\/Anadyr","gmtOffset":12},{"name":"Asia\/Aqtau","gmtOffset":5},{"name":"Asia\/Aqtobe","gmtOffset":5},{"name":"Asia\/Ashgabat","gmtOffset":5},{"name":"Asia\/Atyrau","gmtOffset":5},{"name":"Asia\/Baghdad","gmtOffset":3},{"name":"Asia\/Bahrain","gmtOffset":3},{"name":"Asia\/Baku","gmtOffset":4},{"name":"Asia\/Bangkok","gmtOffset":7},{"name":"Asia\/Barnaul","gmtOffset":7},{"name":"Asia\/Beirut","gmtOffset":2},{"name":"Asia\/Bishkek","gmtOffset":6},{"name":"Asia\/Brunei","gmtOffset":8},{"name":"Asia\/Chita","gmtOffset":9},{"name":"Asia\/Choibalsan","gmtOffset":8},{"name":"Asia\/Colombo","gmtOffset":5.5},{"name":"Asia\/Damascus","gmtOffset":2},{"name":"Asia\/Dhaka","gmtOffset":6},{"name":"Asia\/Dili","gmtOffset":9},{"name":"Asia\/Dubai","gmtOffset":4},{"name":"Asia\/Dushanbe","gmtOffset":5},{"name":"Asia\/Famagusta","gmtOffset":2},{"name":"Asia\/Gaza","gmtOffset":2},{"name":"Asia\/Hebron","gmtOffset":2},{"name":"Asia\/Ho_Chi_Minh","gmtOffset":7},{"name":"Asia\/Hong_Kong","gmtOffset":8},{"name":"Asia\/Hovd","gmtOffset":7},{"name":"Asia\/Irkutsk","gmtOffset":8},{"name":"Asia\/Jakarta","gmtOffset":7},{"name":"Asia\/Jayapura","gmtOffset":9},{"name":"Asia\/Jerusalem","gmtOffset":2},{"name":"Asia\/Kabul","gmtOffset":4.5},{"name":"Asia\/Kamchatka","gmtOffset":12},{"name":"Asia\/Karachi","gmtOffset":5},{"name":"Asia\/Kathmandu","gmtOffset":5.75},{"name":"Asia\/Khandyga","gmtOffset":9},{"name":"Asia\/Kolkata","gmtOffset":5.5},{"name":"Asia\/Krasnoyarsk","gmtOffset":7},{"name":"Asia\/Kuala_Lumpur","gmtOffset":8},{"name":"Asia\/Kuching","gmtOffset":8},{"name":"Asia\/Kuwait","gmtOffset":3},{"name":"Asia\/Macau","gmtOffset":8},{"name":"Asia\/Magadan","gmtOffset":11},{"name":"Asia\/Makassar","gmtOffset":8},{"name":"Asia\/Manila","gmtOffset":8},{"name":"Asia\/Muscat","gmtOffset":4},{"name":"Asia\/Nicosia","gmtOffset":2},{"name":"Asia\/Novokuznetsk","gmtOffset":7},{"name":"Asia\/Novosibirsk","gmtOffset":7},{"name":"Asia\/Omsk","gmtOffset":6},{"name":"Asia\/Oral","gmtOffset":5},{"name":"Asia\/Phnom_Penh","gmtOffset":7},{"name":"Asia\/Pontianak","gmtOffset":7},{"name":"Asia\/Pyongyang","gmtOffset":9},{"name":"Asia\/Qatar","gmtOffset":3},{"name":"Asia\/Qyzylorda","gmtOffset":6},{"name":"Asia\/Riyadh","gmtOffset":3},{"name":"Asia\/Sakhalin","gmtOffset":11},{"name":"Asia\/Samarkand","gmtOffset":5},{"name":"Asia\/Seoul","gmtOffset":9},{"name":"Asia\/Shanghai","gmtOffset":8},{"name":"Asia\/Singapore","gmtOffset":8},{"name":"Asia\/Srednekolymsk","gmtOffset":11},{"name":"Asia\/Taipei","gmtOffset":8},{"name":"Asia\/Tashkent","gmtOffset":5},{"name":"Asia\/Tbilisi","gmtOffset":4},{"name":"Asia\/Tehran","gmtOffset":3.5},{"name":"Asia\/Thimphu","gmtOffset":6},{"name":"Asia\/Tokyo","gmtOffset":9},{"name":"Asia\/Tomsk","gmtOffset":7},{"name":"Asia\/Ulaanbaatar","gmtOffset":8},{"name":"Asia\/Urumqi","gmtOffset":6},{"name":"Asia\/Ust-Nera","gmtOffset":10},{"name":"Asia\/Vientiane","gmtOffset":7},{"name":"Asia\/Vladivostok","gmtOffset":10},{"name":"Asia\/Yakutsk","gmtOffset":9},{"name":"Asia\/Yangon","gmtOffset":6.5},{"name":"Asia\/Yekaterinburg","gmtOffset":5},{"name":"Asia\/Yerevan","gmtOffset":4},{"name":"Atlantic\/Azores","gmtOffset":-1},{"name":"Atlantic\/Bermuda","gmtOffset":-4},{"name":"Atlantic\/Canary","gmtOffset":0},{"name":"Atlantic\/Cape_Verde","gmtOffset":-1},{"name":"Atlantic\/Faroe","gmtOffset":0},{"name":"Atlantic\/Madeira","gmtOffset":0},{"name":"Atlantic\/Reykjavik","gmtOffset":0},{"name":"Atlantic\/South_Georgia","gmtOffset":-2},{"name":"Atlantic\/St_Helena","gmtOffset":0},{"name":"Atlantic\/Stanley","gmtOffset":-3},{"name":"Australia\/Adelaide","gmtOffset":10.5},{"name":"Australia\/Brisbane","gmtOffset":10},{"name":"Australia\/Broken_Hill","gmtOffset":10.5},{"name":"Australia\/Currie","gmtOffset":11},{"name":"Australia\/Darwin","gmtOffset":9.5},{"name":"Australia\/Eucla","gmtOffset":8.75},{"name":"Australia\/Hobart","gmtOffset":11},{"name":"Australia\/Lindeman","gmtOffset":10},{"name":"Australia\/Lord_Howe","gmtOffset":11},{"name":"Australia\/Melbourne","gmtOffset":11},{"name":"Australia\/Perth","gmtOffset":8},{"name":"Australia\/Sydney","gmtOffset":11},{"name":"Europe\/Amsterdam","gmtOffset":1},{"name":"Europe\/Andorra","gmtOffset":1},{"name":"Europe\/Astrakhan","gmtOffset":4},{"name":"Europe\/Athens","gmtOffset":2},{"name":"Europe\/Belgrade","gmtOffset":1},{"name":"Europe\/Berlin","gmtOffset":1},{"name":"Europe\/Bratislava","gmtOffset":1},{"name":"Europe\/Brussels","gmtOffset":1},{"name":"Europe\/Bucharest","gmtOffset":2},{"name":"Europe\/Budapest","gmtOffset":1},{"name":"Europe\/Busingen","gmtOffset":1},{"name":"Europe\/Chisinau","gmtOffset":2},{"name":"Europe\/Copenhagen","gmtOffset":1},{"name":"Europe\/Dublin","gmtOffset":0},{"name":"Europe\/Gibraltar","gmtOffset":1},{"name":"Europe\/Guernsey","gmtOffset":0},{"name":"Europe\/Helsinki","gmtOffset":2},{"name":"Europe\/Isle_of_Man","gmtOffset":0},{"name":"Europe\/Istanbul","gmtOffset":3},{"name":"Europe\/Jersey","gmtOffset":0},{"name":"Europe\/Kaliningrad","gmtOffset":2},{"name":"Europe\/Kiev","gmtOffset":2},{"name":"Europe\/Kirov","gmtOffset":3},{"name":"Europe\/Lisbon","gmtOffset":0},{"name":"Europe\/Ljubljana","gmtOffset":1},{"name":"Europe\/London","gmtOffset":0},{"name":"Europe\/Luxembourg","gmtOffset":1},{"name":"Europe\/Madrid","gmtOffset":1},{"name":"Europe\/Malta","gmtOffset":1},{"name":"Europe\/Mariehamn","gmtOffset":2},{"name":"Europe\/Minsk","gmtOffset":3},{"name":"Europe\/Monaco","gmtOffset":1},{"name":"Europe\/Moscow","gmtOffset":3},{"name":"Europe\/Oslo","gmtOffset":1},{"name":"Europe\/Paris","gmtOffset":1},{"name":"Europe\/Podgorica","gmtOffset":1},{"name":"Europe\/Prague","gmtOffset":1},{"name":"Europe\/Riga","gmtOffset":2},{"name":"Europe\/Rome","gmtOffset":1},{"name":"Europe\/Samara","gmtOffset":4},{"name":"Europe\/San_Marino","gmtOffset":1},{"name":"Europe\/Sarajevo","gmtOffset":1},{"name":"Europe\/Saratov","gmtOffset":4},{"name":"Europe\/Simferopol","gmtOffset":3},{"name":"Europe\/Skopje","gmtOffset":1},{"name":"Europe\/Sofia","gmtOffset":2},{"name":"Europe\/Stockholm","gmtOffset":1},{"name":"Europe\/Tallinn","gmtOffset":2},{"name":"Europe\/Tirane","gmtOffset":1},{"name":"Europe\/Ulyanovsk","gmtOffset":4},{"name":"Europe\/Uzhgorod","gmtOffset":2},{"name":"Europe\/Vaduz","gmtOffset":1},{"name":"Europe\/Vatican","gmtOffset":1},{"name":"Europe\/Vienna","gmtOffset":1},{"name":"Europe\/Vilnius","gmtOffset":2},{"name":"Europe\/Volgograd","gmtOffset":3},{"name":"Europe\/Warsaw","gmtOffset":1},{"name":"Europe\/Zagreb","gmtOffset":1},{"name":"Europe\/Zaporozhye","gmtOffset":2},{"name":"Europe\/Zurich","gmtOffset":1},{"name":"Indian\/Antananarivo","gmtOffset":3},{"name":"Indian\/Chagos","gmtOffset":6},{"name":"Indian\/Christmas","gmtOffset":7},{"name":"Indian\/Cocos","gmtOffset":6.5},{"name":"Indian\/Comoro","gmtOffset":3},{"name":"Indian\/Kerguelen","gmtOffset":5},{"name":"Indian\/Mahe","gmtOffset":4},{"name":"Indian\/Maldives","gmtOffset":5},{"name":"Indian\/Mauritius","gmtOffset":4},{"name":"Indian\/Mayotte","gmtOffset":3},{"name":"Indian\/Reunion","gmtOffset":4},{"name":"Pacific\/Apia","gmtOffset":14},{"name":"Pacific\/Auckland","gmtOffset":13},{"name":"Pacific\/Bougainville","gmtOffset":11},{"name":"Pacific\/Chatham","gmtOffset":13.75},{"name":"Pacific\/Chuuk","gmtOffset":10},{"name":"Pacific\/Easter","gmtOffset":-5},{"name":"Pacific\/Efate","gmtOffset":11},{"name":"Pacific\/Enderbury","gmtOffset":13},{"name":"Pacific\/Fakaofo","gmtOffset":13},{"name":"Pacific\/Fiji","gmtOffset":12},{"name":"Pacific\/Funafuti","gmtOffset":12},{"name":"Pacific\/Galapagos","gmtOffset":-6},{"name":"Pacific\/Gambier","gmtOffset":-9},{"name":"Pacific\/Guadalcanal","gmtOffset":11},{"name":"Pacific\/Guam","gmtOffset":10},{"name":"Pacific\/Honolulu","gmtOffset":-10},{"name":"Pacific\/Kiritimati","gmtOffset":14},{"name":"Pacific\/Kosrae","gmtOffset":11},{"name":"Pacific\/Kwajalein","gmtOffset":12},{"name":"Pacific\/Majuro","gmtOffset":12},{"name":"Pacific\/Marquesas","gmtOffset":-9.5},{"name":"Pacific\/Midway","gmtOffset":-11},{"name":"Pacific\/Nauru","gmtOffset":12},{"name":"Pacific\/Niue","gmtOffset":-11},{"name":"Pacific\/Norfolk","gmtOffset":11},{"name":"Pacific\/Noumea","gmtOffset":11},{"name":"Pacific\/Pago_Pago","gmtOffset":-11},{"name":"Pacific\/Palau","gmtOffset":9},{"name":"Pacific\/Pitcairn","gmtOffset":-8},{"name":"Pacific\/Pohnpei","gmtOffset":11},{"name":"Pacific\/Port_Moresby","gmtOffset":10},{"name":"Pacific\/Rarotonga","gmtOffset":-10},{"name":"Pacific\/Saipan","gmtOffset":10},{"name":"Pacific\/Tahiti","gmtOffset":-10},{"name":"Pacific\/Tarawa","gmtOffset":12},{"name":"Pacific\/Tongatapu","gmtOffset":13},{"name":"Pacific\/Wake","gmtOffset":12},{"name":"Pacific\/Wallis","gmtOffset":12},{"name":"UTC","gmtOffset":0}]},"error_code":0,"error_msg":"","warnings":[],"timestamp":1550189100}'}
+      headers:
+        cache-control: ['no-store, no-cache, must-revalidate']
+        connection: [Keep-Alive]
+        content-type: [application/json]
+        date: ['Fri, 15 Feb 2019 00:05:00 GMT']
+        expires: ['Thu, 19 Nov 1981 08:52:00 GMT']
+        keep-alive: ['timeout=15, max=100']
+        pragma: [no-cache]
+        server: [Apache]
+        set-cookie: [TNS_SESSIONID=SESSIONID; path=/; secure; HttpOnly]
+        strict-transport-security: [max-age=31536000; includeSubDomains]
+        transfer-encoding: [chunked]
+        x-content-type-options: [nosniff]
+        x-frame-options: [DENY]
+        x-xss-protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: !!python/unicode '{}'
+      headers:
+        Accept: ['*/*']
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [keep-alive]
+        Content-Length: ['46']
+        Content-Type: [application/json]
+        Cookie: [TNS_SESSIONID=SESSIONID]
+        User-Agent: [pyTenable/1.0.0 (pyTenable/1.0.0; Python/2.7.15)]
+      method: POST
+      uri: https://securitycenter.home.cugnet.net/rest/token
+    response:
+      body: {string: !!python/unicode '{"type":"regular","response":{"lastLogin":"1550188299",
+          "lastLoginIP":"192.168.100.136","failedLogins":"0","failedLoginIP":"192.168.100.136",
+          "lastFailedLogin":"1550183971","token":"0000000000","unassociatedCert":"false"},
+          "error_code":0,"error_msg":"","warnings":[],"timestamp":1550189100}'}
+      headers:
+        cache-control: ['no-store, no-cache, must-revalidate']
+        connection: [Keep-Alive]
+        content-length: ['286']
+        content-type: [application/json]
+        date: ['Fri, 15 Feb 2019 00:05:00 GMT']
+        expires: ['Thu, 19 Nov 1981 08:52:00 GMT']
+        keep-alive: ['timeout=15, max=99']
+        pragma: [no-cache]
+        securitycenter: [5.8.0]
+        server: [Apache]
+        set-cookie: [TNS_SESSIONID=SESSIONID; path=/; secure; HttpOnly]
+        strict-transport-security: [max-age=31536000; includeSubDomains]
+        x-content-type-options: [nosniff]
+        x-frame-options: [DENY]
+        x-xss-protection: [1; mode=block]
+      status: {code: 200, message: OK}
+  - request:
+      body: null
+      headers:
+        Accept: ['*/*']
+        Accept-Encoding: ['gzip, deflate']
+        Connection: [keep-alive]
+        Content-Length: ['0']
+        Cookie: [TNS_SESSIONID=SESSIONID]
+        User-Agent: [pyTenable/1.0.0 (pyTenable/1.0.0; Python/2.7.15)]
+        X-SecurityCenter: ['0000000000']
+      method: DELETE
+      uri: https://securitycenter.home.cugnet.net/rest/token
+    response:
+      body: {string: !!python/unicode '{"type":"regular","response":"","error_code":0,"error_msg":"","warnings":[],"timestamp":1550189107}'}
+      headers:
+        cache-control: ['no-store, no-cache, must-revalidate']
+        connection: [Keep-Alive]
+        content-length: ['100']
+        content-type: [application/json]
+        date: ['Fri, 15 Feb 2019 00:05:07 GMT']
+        expires: ['Thu, 19 Nov 1981 08:52:00 GMT']
+        keep-alive: ['timeout=15, max=100']
+        pragma: [no-cache]
+        securitycenter: [5.8.0]
+        server: [Apache]
+        strict-transport-security: [max-age=31536000; includeSubDomains]
+        x-content-type-options: [nosniff]
+        x-frame-options: [DENY]
+        x-xss-protection: [1; mode=block]
+      status: {code: 200, message: OK}

--- a/tests/sc/test___init__.py
+++ b/tests/sc/test___init__.py
@@ -75,3 +75,14 @@ def test_log_in(security_center):
     security_center._version = '5.14.0'
     security_center.login(access_key='access_key', secret_key='secret_key')
     assert security_center._auth_mech == 'keys'
+
+
+def test_init_version(security_center_with_version):
+    '''
+    test version set at initialization
+    '''
+    security_center_with_version.login(
+        access_key='access_key',
+        secret_key='secret_key'
+    )
+    assert security_center_with_version._version == '5.20.0'

--- a/tests/sc/test_system.py
+++ b/tests/sc/test_system.py
@@ -33,7 +33,7 @@ def test_system_details(unauth):
         check(i, 'gmtOffset', (int, float))
         check(i, 'name', str)
     check(s, 'uuid', str)
-    check(s, 'version', str)
+    check(s, 'version', str, True)
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
# Description
* Allow usage of Tenable.sc versions 5.20.0 and greater by setting the
  version when the connection object is initialized

## Details
* As of Tenable.sc 5.20.0, the version is no longer sent along with
  the other system details, and therefore, needs to be set explicitly by
  pyTenable.
* The connection constructor will now take an optional keyword argument of
  `version`, and will bypass any other checks for the version in other
  API responses.
* If the Tenable.sc instance does not return the version in its
  response, and the version has not been passed in as an argument, then
  an error will be thrown that the version has not been set.
Fixes # (issue)

## Type of change
Addition of version keyword argument for the TenableSC connection object.

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test using version of 5.20.0
- [ ] Test using version of 5.19.x

**Test Configuration**:
* Python Version(s) Tested: 3.9.1
* Tenable.sc version (if necessary): 5.20.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
