### PR TITLE
Updated version checking and key auth to handle null versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.4.1]
+### Added
+
+- TenableSC version checking refactored to handle an APIError on the response
+  when unauthenticated. (breaking issue for 5.20.0) #475
+
+[1.4.1]: https://github.com/tenable/pyTenable/compare/1.4.0...1.4.1
+
+## [1.4.0]
+### Added
+
+- GraphQL support for TenableOT #461
+- hard_delete param #465
+
+### Changed
+
+- Updated Github Actions to add style checking and security checking
+- Refactored the API Docsite to be easier to navigate, read, and link. #460 #464
+- Rebased low-level connection logic to use RESTfly instead. (v2 work) #457
+- Refactored Container Security Package to be within the IO package and
+  recoded to properly follow the API docs.  #459 #474
+- Refactored Exports API code to follow v2 standard #463
+
+### Fixed
+
+- OrgID should be optional for repositories #444
+
+[1.4.0]: https://github.com/tenable/pyTenable/compare/1.3.3...1.4.0
+
 ## [1.3.3]
 ### Added
 
@@ -11,16 +41,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added pylint to JenkinsFile #378
 - code owners file is added #366
 - Added export compliance API in IO package #358
-- Added for the session object,in logout ,session close in tenable.sc  
+- Added for the session object,in logout ,session close in tenable.sc
   and Added 'UnknownError' and 'RetryError' (PR #386,PR #363 closed)
   added that changes in PR #387
 
 ### Changed
 
 - Deprecation warning for io session API #391
-- For attribute plugin_version in plugin_detail #389 
+- For attribute plugin_version in plugin_detail #389
 - Reverse of Appsdir dependencies PR #382
-- Requirements patch 1.3.2 for library appdir #379 
+- Requirements patch 1.3.2 for library appdir #379
 
 ### Fixed
 
@@ -34,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed github issue 304 tags.create() function #357
 - Fixed github issue 298 io_exception_handling #354
 - Fixed the documentation issue in exclusions #352
-- Fixed the import os problem of PR 299 #351 
+- Fixed the import os problem of PR 299 #351
 - Fixed invalid creation date in row num  #341
 
 
@@ -80,7 +110,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - added sort arg in tio.scans.history, fixed sort in tio.tags #283
 - added network_id arg to tio.exclusions create/edit #284
 - support bulk delete in tio.tags.delete #295
-- 
+-
 ### Fixed
 - many errors and warnings across the code base #320, #317, #314, #313, #281
 - tio.agent_config.edit now returns payload #287

--- a/tenable/version.py
+++ b/tenable/version.py
@@ -1,2 +1,2 @@
-version = '1.4.0'
+version = '1.4.1'
 version_info = tuple(int(d) for d in version.split("-")[0].split("."))

--- a/tests/sc/cassettes/sc_login_5_20_0.yaml
+++ b/tests/sc/cassettes/sc_login_5_20_0.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Integration/1.0 (unknown; unknown; Build/unknown) pyTenable/1.4.0 (Restfly/1.4.4;
+        Python/3.8.6; Darwin/x86_64)
+      X-APIKey:
+      - accessKey=access_key; secretKey=secret_key
+    method: GET
+    uri: https://localhost/rest/system
+  response:
+    body:
+      string: '{"type":"regular","response":"","error_code":0,"error_msg":"","warnings":[],"timestamp":1638312171}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Connection:
+      - Keep-Alive
+      Content-Length:
+      - '99'
+      Content-Security-Policy:
+      - 'default-src ''self''; script-src ''self'' pendo-io-static.storage.googleapis.com
+        app.pendo.io cdn.pendo.io pendo-static-6165929460760576.storage.googleapis.com
+        data.pendo.io cdn.metarouter.io e.metarouter.io api.amplitude.com cdn.amplitude.com
+        *.cloudfront.net; connect-src ''self'' app.pendo.io data.pendo.io pendo-static-6165929460760576.storage.googleapis.com
+        cdn.metarouter.io e.metarouter.io api.amplitude.com cdn.amplitude.com *.cloudfront.net;
+        img-src ''self'' data: cdn.pendo.io app.pendo.io pendo-static-6165929460760576.storage.googleapis.com
+        data.pendo.io; style-src ''self'' app.pendo.io cdn.pendo.io pendo-static-6165929460760576.storage.googleapis.com;
+        frame-ancestors ''self'' app.pendo.io; form-action ''self''; block-all-mixed-content;
+        Upgrade-Insecure-Requests: 1; object-src ''none'''
+      Content-Type:
+      - text/html; charset=UTF-8
+      Date:
+      - Tue, 30 Nov 2021 22:42:51 GMT
+      Expect-CT:
+      - max-age=31536000
+      Expires:
+      - Thu, 19 Nov 1981 08:52:00 GMT
+      Keep-Alive:
+      - timeout=15, max=100
+      Pragma:
+      - no-cache
+      Server:
+      - Apache
+      Set-Cookie:
+      - TNS_SESSIONID=7ff8456183afc3708902f593f131500b; path=/; secure; HttpOnly;
+        SameSite=Strict
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Vary:
+      - x-apikey
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 403
+      message: Forbidden
+version: 1

--- a/tests/sc/test___init__.py
+++ b/tests/sc/test___init__.py
@@ -65,13 +65,21 @@ def test_resp_error_check(security_center):
     security_center._resp_error_check(response)
 
 
-def test_log_in(security_center):
+def test_log_in(vcr):
     '''
     test log in
     '''
-    security_center._version = '5.12.0'
+    tsc = TenableSC(url='https://localhost')
+    tsc._version = '5.12.0'
     with pytest.raises(ConnectionError):
-        security_center.login(access_key='access_key', secret_key='secret_key')
-    security_center._version = '5.14.0'
-    security_center.login(access_key='access_key', secret_key='secret_key')
-    assert security_center._auth_mech == 'keys'
+        tsc.login(access_key='access_key', secret_key='secret_key')
+
+    tsc._version = '5.14.0'
+    tsc.login(access_key='access_key', secret_key='secret_key')
+    assert tsc._auth_mech == 'keys'
+
+    tsc._version = None
+    tsc._auth_mech = None
+    with vcr.use_cassette('sc_login_5_20_0'):
+        tsc.login(access_key='access_key', secret_key='secret_key')
+        assert tsc._auth_mech == 'keys'


### PR DESCRIPTION
# Description

Newer SC versions won't return a version number unauthenticated, this PR addresses the issue in a backwards-compatible way.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Testing suite has been updated to check for None versions.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
