### PR TITLE
Added support for TenableAD profile APIs

### DIFF
--- a/docs/api/ad/profiles.rst
+++ b/docs/api/ad/profiles.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.profiles.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -16,6 +16,7 @@ This package covers the Tenable.ad interface.
     api_keys
     dashboard
     directories
+    profiles
     users
     widget
 '''

--- a/tenable/ad/profiles/api.py
+++ b/tenable/ad/profiles/api.py
@@ -1,0 +1,198 @@
+'''
+Profiles
+=============
+
+Methods described in this section relate to the profiles API.
+These methods can be accessed at ``TenableAD.profiles``.
+
+.. rst-class:: hide-signature
+.. autoclass:: ProfilesAPI
+    :members:
+'''
+from typing import List, Dict
+from tenable.base.endpoint import APIEndpoint
+from .schema import ProfileSchema
+
+
+class ProfilesAPI(APIEndpoint):
+    _path = 'profiles'
+    _schema = ProfileSchema()
+
+    def list(self) -> List[Dict]:
+        '''
+        Retrieve all profiles
+
+        Returns:
+            list[dict]:
+                The list of profile objects
+
+        Examples:
+            >>> tad.profiles.list()
+        '''
+        return self._schema.load(self._get(), many=True)
+
+    def create(self,
+               name: str,
+               directories: List[int]
+               ) -> List[Dict]:
+        '''
+        Create a profile
+
+        Args:
+            name (str):
+                The name of new profile.
+            directories (List[int]):
+                The list of directory identifiers.
+
+        Return:
+            list[dict]:
+                The created profile objects
+
+        Example:
+            >>> tad.profiles.create(
+            ...     name='ExampleProfile',
+            ...     directories=[1, 2]
+            ...     )
+        '''
+        payload = [
+            self._schema.dump(self._schema.load({
+                'name': name,
+                'directories': directories
+            }))
+        ]
+
+        return self._schema.load(self._post(json=payload), many=True)
+
+    def details(self,
+                profile_id: str
+                ) -> Dict:
+        '''
+        Retrieves the details for a specific profile
+
+        Args:
+            profile_id (str):
+                The profile instance identifier.
+
+        Returns:
+            dict:
+                The profile object.
+
+        Examples:
+            >>> tad.profiles.details('1')
+        '''
+        return self._schema.load(self._get(f'{profile_id}'))
+
+    def update(self,
+               profile_id: str,
+               **kwargs
+               ) -> Dict:
+        '''
+        Update an existing profile
+
+        Args:
+            profile_id (str):
+                The profile instance identifier.
+            name (optional, str):
+                The name of profile.
+            deleted (optional, bool):
+                is the profile deleted?
+            directories (optional, List[int]):
+                The list of directory ids.
+
+        Returns:
+            dict:
+                The updated profile object.
+
+        Examples:
+            >>> tad.profiles.update(
+            ...     profile_id='1',
+            ...     name='EDITED'
+            ...     )
+        '''
+        payload = self._schema.dump(self._schema.load(kwargs))
+        return self._schema.load(self._patch(f"{profile_id}", json=payload))
+
+    def delete(self, profile_id: str) -> None:
+        '''
+        Delete an existing profile
+
+        Args:
+            profile_id (str):
+                The profile instance identifier.
+
+        Returns:
+            None:
+
+        Examples:
+            >>> tad.profiles.delete(profile_id='1')
+        '''
+        self._delete(f"{profile_id}")
+
+    def copy_profile(self,
+                     from_id: str,
+                     name: str,
+                     directories: List[int]
+                     ) -> Dict:
+        '''
+        Creates a new profile from another profile
+
+        Args:
+            from_id (str):
+                The profile instance identifier user wants to copy.
+            name (str):
+                The name of new profile.
+            directories (List[int]):
+                The list of directory ids.
+
+        Returns:
+            dict:
+                The copied role object.
+
+        Examples:
+            >>> tad.profiles.copy_profile(
+            ...     from_id='1',
+            ...     name='Copied name',
+            ...     directories=[1, 2]
+            ...     )
+        '''
+        payload = self._schema.dump(self._schema.load({
+            'name': name,
+            'directories': directories
+        }))
+        return self._schema.load(self._post(f'from/{from_id}', json=payload))
+
+    def commit(self,
+               profile_id: str
+               ) -> None:
+        '''
+        Commits change of the related profile
+
+        Args:
+            profile_id (str):
+                The profile instance identifier.
+
+        Return:
+            None
+
+        Example:
+            >>> tad.profiles.commit('1')
+        '''
+        self._post(f'{profile_id}/commit')
+
+    def unstage(self,
+                profile_id: str
+                ) -> None:
+        '''
+        Unstages changes of the related profile
+
+        Args:
+            profile_id (str):
+                The profile instance identifier.
+
+        Return:
+            None
+
+        Example:
+            >>> tad.profiles.unstage('1')
+        '''
+        self._post(f'{profile_id}/unstage')

--- a/tenable/ad/profiles/schema.py
+++ b/tenable/ad/profiles/schema.py
@@ -1,0 +1,11 @@
+from marshmallow import fields
+from tenable.ad.base.schema import CamelCaseSchema
+
+
+class ProfileSchema(CamelCaseSchema):
+    id = fields.Int()
+    name = fields.Str()
+    deleted = fields.Bool()
+    directories = fields.List(fields.Int())
+    dirty = fields.Bool()
+    has_ever_been_committed = fields.Bool()

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -10,6 +10,7 @@ from .about import AboutAPI
 from .api_keys import APIKeyAPI
 from .dashboard.api import DashboardAPI
 from .directories.api import DirectoriesAPI
+from .profiles.api import ProfilesAPI
 from .users.api import UsersAPI
 from .widget.api import WidgetsAPI
 
@@ -69,6 +70,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad Directories APIs <directories>`.
         '''
         return DirectoriesAPI(self)
+
+    @property
+    def profiles(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad Profiles APIs <profiles>`.
+        '''
+        return ProfilesAPI(self)
 
     @property
     def users(self):

--- a/tests/ad/profiles/test_profiles_api.py
+++ b/tests/ad/profiles/test_profiles_api.py
@@ -1,0 +1,156 @@
+import responses
+
+from tests.ad.conftest import RE_BASE
+
+
+@responses.activate
+def test_profiles_list(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/profiles',
+                  json=[{
+                      'id': 1,
+                      'name': 'profile name',
+                      'deleted': False,
+                      'directories': [1, 2],
+                      'dirty': True,
+                      'hasEverBeenCommitted': True
+                  }]
+                  )
+    resp = api.profiles.list()
+    assert isinstance(resp, list)
+    assert len(resp) == 1
+    assert resp[0]['id'] == 1
+    assert resp[0]['name'] == 'profile name'
+    assert resp[0]['deleted'] is False
+    assert resp[0]['directories'] == [1, 2]
+    assert resp[0]['dirty'] is True
+    assert resp[0]['has_ever_been_committed'] is True
+
+
+@responses.activate
+def test_profiles_create(api):
+    responses.add(responses.POST,
+                  f'{RE_BASE}/profiles',
+                  json=[{
+                      'id': 1,
+                      'name': 'profile name',
+                      'deleted': False,
+                      'directories': [1, 2],
+                      'dirty': True,
+                      'hasEverBeenCommitted': True
+                  }]
+                  )
+    resp = api.profiles.create(name='profile name',
+                               directories=[1, 2])
+    assert isinstance(resp, list)
+    assert len(resp) == 1
+    assert resp[0]['id'] == 1
+    assert resp[0]['name'] == 'profile name'
+    assert resp[0]['deleted'] is False
+    assert resp[0]['directories'] == [1, 2]
+    assert resp[0]['dirty'] is True
+    assert resp[0]['has_ever_been_committed'] is True
+
+
+@responses.activate
+def test_profiles_details(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/profiles/1',
+                  json={
+                      'id': 1,
+                      'name': 'profile name',
+                      'deleted': False,
+                      'directories': [1, 2],
+                      'dirty': True,
+                      'hasEverBeenCommitted': True
+                  }
+                  )
+    resp = api.profiles.details(profile_id='1')
+    assert isinstance(resp, dict)
+    assert resp['id'] == 1
+    assert resp['name'] == 'profile name'
+    assert resp['deleted'] is False
+    assert resp['directories'] == [1, 2]
+    assert resp['dirty'] is True
+    assert resp['has_ever_been_committed'] is True
+
+
+@responses.activate
+def test_profiles_update(api):
+    responses.add(responses.PATCH,
+                  f'{RE_BASE}/profiles/1',
+                  json={
+                      'id': 1,
+                      'name': 'profile name',
+                      'deleted': False,
+                      'directories': [1, 2],
+                      'dirty': True,
+                      'hasEverBeenCommitted': True
+                  }
+                  )
+    resp = api.profiles.update(profile_id='1',
+                               name='profile name',
+                               deleted=True,
+                               directories=[1, 2])
+    assert isinstance(resp, dict)
+    assert resp['id'] == 1
+    assert resp['name'] == 'profile name'
+    assert resp['deleted'] is False
+    assert resp['directories'] == [1, 2]
+    assert resp['dirty'] is True
+    assert resp['has_ever_been_committed'] is True
+
+
+@responses.activate
+def test_profiles_delete(api):
+    responses.add(responses.DELETE,
+                  f'{RE_BASE}/profiles/1',
+                  json=None
+                  )
+    resp = api.profiles.delete(profile_id='1')
+    assert resp is None
+
+
+@responses.activate
+def test_profiles_copy_profile(api):
+    responses.add(responses.POST,
+                  f'{RE_BASE}/profiles/from/1',
+                  json={
+                      'id': 1,
+                      'name': 'copied profile',
+                      'deleted': False,
+                      'directories': [1, 2],
+                      'dirty': True,
+                      'hasEverBeenCommitted': True
+                  }
+                  )
+    resp = api.profiles.copy_profile(from_id='1',
+                                     name='copied profile',
+                                     directories=[1, 2])
+    assert isinstance(resp, dict)
+    assert resp['id'] == 1
+    assert resp['name'] == 'copied profile'
+    assert resp['deleted'] is False
+    assert resp['directories'] == [1, 2]
+    assert resp['dirty'] is True
+    assert resp['has_ever_been_committed'] is True
+
+
+@responses.activate
+def test_profiles_commit(api):
+    responses.add(responses.POST,
+                  f'{RE_BASE}/profiles/1/commit',
+                  json=None
+                  )
+    resp = api.profiles.commit(profile_id='1')
+    assert resp is None
+
+
+@responses.activate
+def test_profiles_unstage(api):
+    responses.add(responses.POST,
+                  f'{RE_BASE}/profiles/1/unstage',
+                  json=None
+                  )
+    resp = api.profiles.unstage(profile_id='1')
+    assert resp is None

--- a/tests/ad/profiles/test_profiles_schema.py
+++ b/tests/ad/profiles/test_profiles_schema.py
@@ -1,0 +1,37 @@
+'''
+Testing the profiles schemas
+'''
+import pytest
+from marshmallow import ValidationError
+from tenable.ad.profiles.schema import ProfileSchema
+
+
+@pytest.fixture()
+def profile_schema():
+    return {
+        'name': 'name',
+        'directories': [1, 2]
+    }
+
+
+def test_profile_schema(profile_schema):
+    '''
+    Test the profile schema with create payload inputs
+    '''
+    test_resp = [{
+        'id': 1,
+        'name': 'name',
+        'deleted': True,
+        'directories': [1, 2],
+        'dirty': True,
+        'hasEverBeenCommitted': True
+    }]
+
+    schema = ProfileSchema()
+    req = schema.dump(schema.load(profile_schema))
+    assert test_resp[0]['name'] == req['name']
+    assert test_resp[0]['directories'] == req['directories']
+
+    with pytest.raises(ValidationError):
+        profile_schema['some_val'] = 'something'
+        schema.load(profile_schema)


### PR DESCRIPTION
# Description

Added `Tenable.AD profile APIs`

- Retrieve all profile instances. (_list_)
- Create profile instance. (_create_)
- Get profile instance by id. (_details_)
- Update profile instance. (_update_)
- Delete profile instance. (_delete_)
- Creates a new profile from another one (_copy_profile_)
- Commits change of the related profile (_commit_)
- Unstages change of the related profile (_unstage_)


_updated docs to support profile api details_

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added tests for all profile endpoints to test responses
- [x] Added schema tests for testing payload inputs and response dict validation

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
