### PR TITLE
Added support for TenableAD dashboard APIs

### DIFF
--- a/docs/api/ad/dashboard.rst
+++ b/docs/api/ad/dashboard.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.dashboard.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -14,6 +14,7 @@ This package covers the Tenable.ad interface.
 
     about
     api_keys
+    dashboard
     directories
     users
     widget

--- a/tenable/ad/dashboard/api.py
+++ b/tenable/ad/dashboard/api.py
@@ -1,0 +1,114 @@
+'''
+Dashboard
+=========
+
+Methods described in this section relate to the the dashboard API.
+These methods can be accessed at ``TenableAD.dashboard``.
+
+.. rst-class:: hide-signature
+.. autoclass:: DashboardAPI
+    :members:
+'''
+from typing import List, Dict
+from tenable.ad.dashboard.schema import DashboardSchema
+from tenable.base.endpoint import APIEndpoint
+
+
+class DashboardAPI(APIEndpoint):
+    _path = 'dashboards'
+    _schema = DashboardSchema()
+
+    def list(self) -> List[Dict]:
+        '''
+        Retrieve all dashboard instances.
+
+        Returns:
+            list:
+                The list of dashboard objects.
+
+        Examples:
+
+            >>> tad.dashboard.list()
+        '''
+        return self._schema.load(self._get(), many=True)
+
+    def create(self, name: str, order: int) -> Dict:
+        '''
+        Create a new dashboard instance.
+
+        Args:
+            name (str):
+                The name of the new dashboard.
+            order (int):
+                order of the dashboard.
+
+        Returns:
+            dict:
+                The created dashboard instance.
+
+        Examples:
+
+            >>> tad.dashboard.create(
+            ...     name='new_dashboard',
+            ...     order=10)
+        '''
+        payload = {
+            'name': name,
+            'order': order
+        }
+        return self._schema.load(self._post(json=payload))
+
+    def details(self, dashboard_id: str) -> Dict:
+        '''
+        Retrieves the details for a specific dashboard instance.
+
+        Args:
+            dashboard_id (str):
+                The dashboard instance identifier.
+
+        Returns:
+            dict:
+                The details of the dashboard object of specified dashboard_id.
+
+        Examples:
+
+            >>> tad.dashboard.details(dashboard_id='1')
+        '''
+        return self._schema.load(self._get(dashboard_id))
+
+    def update(self, dashboard_id: str, **kwargs):
+        '''
+        Updates the dashboard instance based on ``dashboard_id``.
+
+        Args:
+            dashboard_id (str):
+                The dashboard instance identifier.
+            name (optional, str):
+                The updated name.
+            order (optional, int):
+                The order of the dashboard.
+
+        Examples:
+
+            >>> tad.dashboard.update(
+            ...     dashboard_id='23',
+            ...     name='updated_dashboard_name',
+            ...     order=1)
+        '''
+        payload = self._schema.dump(self._schema.load(kwargs))
+        return self._schema.load(
+            self._patch(f'{dashboard_id}', json=payload),
+            many=True)
+
+    def delete(self, dashboard_id: str) -> None:
+        '''
+        Deletes the dashboard instance
+
+        Args:
+            dashboard_id (str):
+                The dashboard instance identifier.
+
+        Examples:
+            >>> tad.dashboard.delete(dashboard_id='22')
+        '''
+        self._delete(f'{dashboard_id}')

--- a/tenable/ad/dashboard/schema.py
+++ b/tenable/ad/dashboard/schema.py
@@ -1,0 +1,10 @@
+from marshmallow import fields
+from tenable.ad.base.schema import CamelCaseSchema
+
+
+class DashboardSchema(CamelCaseSchema):
+    name = fields.Str()
+    order = fields.Int()
+    id = fields.Int()
+    user_id = fields.Int()
+    dashboard_id = fields.Str()

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -8,6 +8,7 @@ from tenable.base.platform import APIPlatform
 
 from .about import AboutAPI
 from .api_keys import APIKeyAPI
+from .dashboard.api import DashboardAPI
 from .directories.api import DirectoriesAPI
 from .users.api import UsersAPI
 from .widget.api import WidgetsAPI
@@ -52,6 +53,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad API-Keys APIs <api_keys>`.
         '''
         return APIKeyAPI(self)
+
+    @property
+    def dashboard(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad Dashboard APIs <dashboard>`.
+        '''
+        return DashboardAPI(self)
 
     @property
     def directories(self):

--- a/tests/ad/dashboard/test_dashboard_api.py
+++ b/tests/ad/dashboard/test_dashboard_api.py
@@ -1,0 +1,89 @@
+'''tests for dashboard APIs'''
+import responses
+
+RE_BASE = 'https://pytenable.tenable.ad/api'
+
+
+@responses.activate
+def test_dashboard_details(api):
+    '''testing the details response with the actual details response'''
+    responses.add(responses.GET,
+                  f'{RE_BASE}/dashboards/1',
+                  json={
+                      'id': 2,
+                      'name': 'test_name',
+                      'order': 5,
+                      'userId': 10
+                  }
+                  )
+    resp = api.dashboard.details(dashboard_id='1')
+    assert isinstance(resp, dict)
+    assert resp['name'] == 'test_name'
+
+
+@responses.activate
+def test_dashboard_create(api):
+    '''testing the create response with the actual create response'''
+    responses.add(responses.POST,
+                  f'{RE_BASE}/dashboards',
+                  json={
+                      'id': 3,
+                      'name': 'test_dashboard',
+                      'order': 10,
+                      'userId': 20
+                  }
+                  )
+    resp = api.dashboard.create(name='test_dashboard', order=5)
+    assert isinstance(resp, dict)
+    assert resp['name'] == 'test_dashboard'
+
+
+@responses.activate
+def test_dashboard_list(api):
+    '''testing the list response with the actual list response'''
+    responses.add(responses.GET,
+                  f'{RE_BASE}/dashboards',
+                  json=[{
+                      'id': 1,
+                      'name': 'test_dashboard1',
+                      'order': 1,
+                      'userId': 1001
+                  }, {
+                      'id': 2,
+                      'name': 'test_dashboard2',
+                      'order': 2,
+                      'userId': 1002
+                  }]
+                  )
+    resp = api.dashboard.list()
+    assert isinstance(resp, list)
+    assert len(resp) == 2
+
+
+@responses.activate
+def test_dashboard_update(api):
+    '''testing the update response with the actual update response'''
+    responses.add(responses.PATCH,
+                  f'{RE_BASE}/dashboards/1',
+                  json=[{
+                      'id': 1,
+                      'name': 'updated_test_dashboard',
+                      'order': 10,
+                      'userId': 20
+                  }]
+                  )
+    resp = api.dashboard.update(dashboard_id='1',
+                                name='test_dashboard',
+                                order=1)
+    assert isinstance(resp, list)
+    assert resp[0]['name'] == 'updated_test_dashboard'
+
+
+@responses.activate
+def test_dashboard_delete(api):
+    '''testing the delete response with the actual delete response'''
+    responses.add(responses.DELETE,
+                  f'{RE_BASE}/dashboards/1',
+                  json=None)
+    resp = api.dashboard.delete(dashboard_id='1')
+    assert resp is None

--- a/tests/ad/dashboard/test_dashboard_schema.py
+++ b/tests/ad/dashboard/test_dashboard_schema.py
@@ -1,0 +1,29 @@
+'''schema tests for dashboard APIs'''
+import pytest
+from marshmallow.exceptions import ValidationError
+from tenable.ad.dashboard.schema import DashboardSchema
+
+
+@pytest.fixture
+def dashboard_schema():
+    return {
+        'id': 2,
+        'name': 'test_name',
+        'order': 5,
+        'userId': 10
+    }
+
+
+def test_dashboard_schema(dashboard_schema):
+    test_response = {
+        'id': 2,
+        'name': 'test_name',
+        'order': 5,
+        'userId': 10
+    }
+    schema = DashboardSchema()
+    assert test_response['name'] == \
+           schema.dump(schema.load(dashboard_schema))['name']
+    with pytest.raises(ValidationError):
+        dashboard_schema['new_val'] = 'something'
+        schema.load(dashboard_schema)


### PR DESCRIPTION
# Description

Added ``Tenable.AD dashboard APIs``

Methods available:

- Retrieve all dashboard instances - ``list``
- Create dashboard instance - ``create``
- Get dashboard instance by id - ``details``
- Update dashboard instance - ``update``
- Delete dashboard instance with it's associated widgets - ``delete``

Updated docs to support dashboard API details.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests added to test all the dashboard endpoints and their schema.
- [x] Sphinx build for doc

**Test Configuration**:
* Python Version(s) Tested: 3.9
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
