### PR TITLE
Added support for TenableAD roles APIs

### DIFF
--- a/docs/api/ad/roles.rst
+++ b/docs/api/ad/roles.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.roles.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -18,6 +18,7 @@ This package covers the Tenable.ad interface.
     dashboard
     directories
     profiles
+    roles
     users
     widget
 '''

--- a/tenable/ad/roles/api.py
+++ b/tenable/ad/roles/api.py
@@ -209,27 +209,6 @@ class RolesAPI(APIEndpoint):
             ... )
         '''
         schema = RolePermissionsSchema()
-
-        payload = []
-        required_fields = ['action', 'entity_ids', 'entity_name']
-
-        # loop through all permissions and create payload for API call
-        # and if any of required fields is missing then it will raise
-        # validationError
-        for permission in permissions:
-            if all(key in permission for key in required_fields):
-                payload.append({
-                    'dynamicId': permission.get('dynamic_id'),
-                    'entityIds': permission.get('entity_ids'),
-                    'entityName': permission.get('entity_name'),
-                    'action': permission.get('action')
-                })
-            else:
-                raise ValidationError(
-                    'Missing required fields. '
-                    'Required: ["action", "entity_name", "entity_ids"]')
-
-        payload = schema.dump(schema.load(payload, many=True), many=True)
-
+        payload = schema.dump(schema.load(permissions, many=True), many=True)
         return self._schema.load(
             self._put(f'{role_id}/permissions', json=payload))

--- a/tenable/ad/roles/api.py
+++ b/tenable/ad/roles/api.py
@@ -1,0 +1,235 @@
+'''
+Roles
+=============
+
+Methods described in this section relate to the roles API.
+These methods can be accessed at ``TenableAD.roles``.
+
+.. rst-class:: hide-signature
+.. autoclass:: RolesAPI
+    :members:
+'''
+from typing import List, Dict
+from marshmallow import ValidationError
+from tenable.base.endpoint import APIEndpoint
+from .schema import RoleSchema, RolePermissionsSchema
+
+
+class RolesAPI(APIEndpoint):
+    _path = 'roles'
+    _schema = RoleSchema()
+
+    def list(self) -> List[Dict]:
+        '''
+        Retrieve all roles
+
+        Returns:
+            list[dict]:
+                The list of roles objects
+
+        Examples:
+            >>> tad.roles.list()
+        '''
+        return self._schema.load(self._get(), many=True)
+
+    def create(self,
+               name: str,
+               description: int
+               ) -> List[Dict]:
+        '''
+        Create a new role
+
+        Args:
+            name (str):
+                The name of role.
+            description (str):
+               The description of role.
+
+        Returns:
+            list[dict]:
+                The created role object.
+
+        Examples:
+            >>> tad.roles.create(
+            ...     name='Admin',
+            ...     description="all privileges"
+            ...     )
+        '''
+        payload = [
+            self._schema.dump(self._schema.load({
+                'name': name,
+                'description': description
+            }))
+        ]
+
+        return self._schema.load(self._post(json=payload), many=True)
+
+    def default_roles(self) -> List[Dict]:
+        '''
+        Return the default roles for user creation
+
+        Returns:
+            list[dict]:
+                The default roles object.
+
+        Examples:
+            >>> tad.roles.default_roles()
+        '''
+        return self._schema.load(
+            self._get('user-creation-defaults'), many=True)
+
+    def details(self, role_id: str) -> Dict:
+        '''
+        Retrieves the details of a specific role.
+
+        Args:
+            role_id (str):
+                The role instance identifier.
+
+        Returns:
+            dict:
+                the role object.
+
+        Examples:
+            >>> tad.roles.details(
+            ...     role_id='1'
+            ...     )
+        '''
+        return self._schema.load(self._get(f"{role_id}"))
+
+    def update(self,
+               role_id: str,
+               **kwargs
+               ) -> Dict:
+        '''
+        Update an existing role
+
+        Args:
+            role_id (str):
+                The role instance identifier.
+            name (optional, str):
+                The name of role.
+            description (optional, str):
+               The description of role.
+
+        Returns:
+            dict:
+                The updated widget object.
+
+        Examples:
+            >>> tad.roles.update(
+            ...     role_id='1',
+            ...     name='Basic'
+            ...     )
+        '''
+        payload = self._schema.dump(self._schema.load(kwargs))
+        return self._schema.load(self._patch(f"{role_id}", json=payload))
+
+    def delete(self, role_id: str) -> None:
+        '''
+        Delete an existing role
+
+        Args:
+            role_id (str):
+                The role instance identifier.
+
+        Returns:
+            None:
+
+        Examples:
+            >>> tad.roles.delete(
+            ...     role_id='1',
+            ...     )
+        '''
+        self._delete(f"{role_id}")
+
+    def copy_role(self,
+                  from_id: str,
+                  name: str
+                  ) -> Dict:
+        '''
+        Creates a new role from another role
+
+        Args:
+            from_id (str):
+                The role instance identifier user wants to copy.
+            name (str):
+                The name of new role.
+
+        Returns:
+            dict:
+                the copied role object.
+
+        Examples:
+            >>> tad.roles.copy_role(
+            ...     from_id='1',
+            ...     name='Copied name'
+            ...     )
+        '''
+        payload = self._schema.dump(self._schema.load({
+            'name': name
+        }))
+        return self._schema.load(self._post(f'from/{from_id}', json=payload))
+
+    def replace_role_permissions(self,
+                                 role_id: str,
+                                 permissions: List[Dict]
+                                 ) -> Dict:
+        '''
+        Replace permission list for a role
+
+        Args:
+            role_id (str):
+                The role instance identifier.
+            permissions (List[Dict]) :
+                The list of permissions dictionaries.
+                Below are the values expected in dictionaries
+            entity_name (str):
+                The name of entity.
+            action (str):
+                ???
+            entity_ids (List[int]):
+                The list of entity identifiers.
+            dynamic_id (optional, str):
+                ???
+
+        Returns:
+            dict:
+                the update permissions role object.
+
+        Examples:
+            >>> tad.roles.replace_role_permissions(
+            ...     role_id='1',
+            ...     permissions=[{
+            ...         'entity_name':'dashboard',
+            ...         'action':'action',
+            ...         'entity_ids':[1, 2],
+            ...         'dynamic_id': None
+            ...     }]
+            ... )
+        '''
+        schema = RolePermissionsSchema()
+
+        payload = []
+        required_fields = ['action', 'entity_ids', 'entity_name']
+
+        # loop through all permissions and create payload for API call
+        # and if any of required fields is missing then it will raise
+        # validationError
+        for permission in permissions:
+            if all(key in permission for key in required_fields):
+                payload.append({
+                    'dynamicId': permission.get('dynamic_id'),
+                    'entityIds': permission.get('entity_ids'),
+                    'entityName': permission.get('entity_name'),
+                    'action': permission.get('action')
+                })
+            else:
+                raise ValidationError(
+                    'Missing required fields. '
+                    'Required: ["action", "entity_name", "entity_ids"]')
+
+        payload = schema.dump(schema.load(payload, many=True), many=True)
+
+        return self._schema.load(
+            self._put(f'{role_id}/permissions', json=payload))

--- a/tenable/ad/roles/schema.py
+++ b/tenable/ad/roles/schema.py
@@ -1,12 +1,19 @@
-from marshmallow import fields, pre_load, post_load
-from tenable.ad.base.schema import CamelCaseSchema
+from marshmallow import fields, pre_load
+from tenable.ad.base.schema import CamelCaseSchema, camelcase
 
 
 class RolePermissionsSchema(CamelCaseSchema):
-    entity_name = fields.Str()
-    action = fields.Str()
-    entity_ids = fields.List(fields.Int(), allow_none=True)
+    entity_name = fields.Str(required=True)
+    action = fields.Str(required=True)
+    entity_ids = fields.List(fields.Int(), allow_none=True, required=True)
     dynamic_id = fields.Str(allow_none=True)
+
+    @pre_load
+    def keys_to_camel(self, data, **kwargs):
+        resp = {}
+        for key, value in data.items():
+            resp[camelcase(key)] = value
+        return resp
 
 
 class RoleSchema(CamelCaseSchema):

--- a/tenable/ad/roles/schema.py
+++ b/tenable/ad/roles/schema.py
@@ -1,0 +1,16 @@
+from marshmallow import fields, pre_load, post_load
+from tenable.ad.base.schema import CamelCaseSchema
+
+
+class RolePermissionsSchema(CamelCaseSchema):
+    entity_name = fields.Str()
+    action = fields.Str()
+    entity_ids = fields.List(fields.Int(), allow_none=True)
+    dynamic_id = fields.Str(allow_none=True)
+
+
+class RoleSchema(CamelCaseSchema):
+    id = fields.Int()
+    name = fields.Str()
+    description = fields.Str()
+    permissions = fields.Nested(RolePermissionsSchema, many=True)

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -12,6 +12,7 @@ from .category.api import CategoryAPI
 from .dashboard.api import DashboardAPI
 from .directories.api import DirectoriesAPI
 from .profiles.api import ProfilesAPI
+from .roles.api import RolesAPI
 from .users.api import UsersAPI
 from .widget.api import WidgetsAPI
 
@@ -87,6 +88,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad Profiles APIs <profiles>`.
         '''
         return ProfilesAPI(self)
+
+    @property
+    def roles(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad Roles APIs <roles>`.
+        '''
+        return RolesAPI(self)
 
     @property
     def users(self):

--- a/tests/ad/roles/test_roles_api.py
+++ b/tests/ad/roles/test_roles_api.py
@@ -1,0 +1,220 @@
+import responses
+
+from tests.ad.conftest import RE_BASE
+
+
+@responses.activate
+def test_roles_list(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/roles',
+                  json=[{
+                      'id': 1,
+                      'name': 'Admin',
+                      'description': 'full access',
+                      'permissions': [{
+                          'entityName': 'entityName',
+                          'action': 'action',
+                          'entityIds': [1, 2],
+                          'dynamicId': 'some id'
+                      }]
+                  }, {
+                      'id': 2,
+                      'name': 'Basic',
+                      'description': 'basic access',
+                      'permissions': [{
+                          'entityName': 'entityName',
+                          'action': 'action',
+                          'entityIds': [3, 4],
+                          'dynamicId': 'some other id'
+                      }]
+                  }]
+                  )
+    resp = api.roles.list()
+    assert isinstance(resp, list)
+    assert len(resp) == 2
+    assert resp[0]['name'] == 'Admin'
+    assert resp[0]['description'] == 'full access'
+    assert resp[0]['permissions'][0]['entity_name'] == 'entityName'
+    assert resp[0]['permissions'][0]['action'] == 'action'
+    assert resp[0]['permissions'][0]['entity_ids'] == [1, 2]
+    assert resp[0]['permissions'][0]['dynamic_id'] == 'some id'
+    assert resp[1]['name'] == 'Basic'
+    assert resp[1]['description'] == 'basic access'
+    assert resp[1]['permissions'][0]['entity_name'] == 'entityName'
+    assert resp[1]['permissions'][0]['action'] == 'action'
+    assert resp[1]['permissions'][0]['entity_ids'] == [3, 4]
+    assert resp[1]['permissions'][0]['dynamic_id'] == 'some other id'
+
+
+@responses.activate
+def test_roles_create(api):
+    responses.add(responses.POST,
+                  f'{RE_BASE}/roles',
+                  json=[{
+                      'id': 1,
+                      'name': 'Admin',
+                      'description': 'full access',
+                      'permissions': [{
+                          'entityName': 'entityName',
+                          'action': 'action',
+                          'entityIds': [1, 2],
+                          'dynamicId': 'some id'
+                      }]
+                  }]
+                  )
+    resp = api.roles.create(name='Admin',
+                            description='full access')
+    assert isinstance(resp, list)
+    assert len(resp) == 1
+    assert resp[0]['name'] == 'Admin'
+    assert resp[0]['description'] == 'full access'
+    assert resp[0]['permissions'][0]['entity_name'] == 'entityName'
+    assert resp[0]['permissions'][0]['action'] == 'action'
+    assert resp[0]['permissions'][0]['entity_ids'] == [1, 2]
+    assert resp[0]['permissions'][0]['dynamic_id'] == 'some id'
+
+
+@responses.activate
+def test_roles_default_role(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/roles/user-creation-defaults',
+                  json=[{
+                      'id': 1,
+                      'name': 'Admin',
+                      'description': 'full access',
+                      'permissions': [{
+                          'entityName': 'entityName',
+                          'action': 'action',
+                          'entityIds': [1, 2],
+                          'dynamicId': 'some id'
+                      }]
+                  }]
+                  )
+    resp = api.roles.default_roles()
+    assert isinstance(resp, list)
+    assert len(resp) == 1
+    assert resp[0]['name'] == 'Admin'
+    assert resp[0]['description'] == 'full access'
+    assert resp[0]['permissions'][0]['entity_name'] == 'entityName'
+    assert resp[0]['permissions'][0]['action'] == 'action'
+    assert resp[0]['permissions'][0]['entity_ids'] == [1, 2]
+    assert resp[0]['permissions'][0]['dynamic_id'] == 'some id'
+
+
+@responses.activate
+def test_roles_details(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/roles/1',
+                  json={
+                      'id': 1,
+                      'name': 'Admin',
+                      'description': 'full access',
+                      'permissions': [{
+                          'entityName': 'entityName',
+                          'action': 'action',
+                          'entityIds': [1, 2],
+                          'dynamicId': 'some id'
+                      }]
+                  }
+                  )
+    resp = api.roles.details('1')
+    assert isinstance(resp, dict)
+    assert resp['name'] == 'Admin'
+    assert resp['description'] == 'full access'
+    assert resp['permissions'][0]['entity_name'] == 'entityName'
+    assert resp['permissions'][0]['action'] == 'action'
+    assert resp['permissions'][0]['entity_ids'] == [1, 2]
+    assert resp['permissions'][0]['dynamic_id'] == 'some id'
+
+
+@responses.activate
+def test_roles_update(api):
+    responses.add(responses.PATCH,
+                  f'{RE_BASE}/roles/1',
+                  json={
+                      'id': 1,
+                      'name': 'EDITED',
+                      'description': 'full access',
+                      'permissions': [{
+                          'entityName': 'entityName',
+                          'action': 'action',
+                          'entityIds': [1, 2],
+                          'dynamicId': 'some id'
+                      }]
+                  }
+                  )
+    resp = api.roles.update('1', name='EDITED')
+    assert isinstance(resp, dict)
+    assert resp['name'] == 'EDITED'
+    assert resp['description'] == 'full access'
+    assert resp['permissions'][0]['entity_name'] == 'entityName'
+    assert resp['permissions'][0]['action'] == 'action'
+    assert resp['permissions'][0]['entity_ids'] == [1, 2]
+    assert resp['permissions'][0]['dynamic_id'] == 'some id'
+
+
+@responses.activate
+def test_roles_delete(api):
+    responses.add(responses.DELETE,
+                  f'{RE_BASE}/roles/1',
+                  json=None)
+    resp = api.roles.delete('1')
+    assert resp is None
+
+
+@responses.activate
+def test_roles_copy_role(api):
+    responses.add(responses.POST,
+                  f'{RE_BASE}/roles/from/1',
+                  json={
+                      'id': 1,
+                      'name': 'EDITED',
+                      'description': 'full access',
+                      'permissions': [{
+                          'entityName': 'entityName',
+                          'action': 'action',
+                          'entityIds': [1, 2],
+                          'dynamicId': 'some id'
+                      }]
+                  }
+                  )
+    resp = api.roles.copy_role(from_id='1', name='EDITED')
+    assert isinstance(resp, dict)
+    assert resp['name'] == 'EDITED'
+    assert resp['description'] == 'full access'
+    assert resp['permissions'][0]['entity_name'] == 'entityName'
+    assert resp['permissions'][0]['action'] == 'action'
+    assert resp['permissions'][0]['entity_ids'] == [1, 2]
+    assert resp['permissions'][0]['dynamic_id'] == 'some id'
+
+
+@responses.activate
+def test_roles_replace_role_permissions(api):
+    responses.add(responses.PUT,
+                  f'{RE_BASE}/roles/1/permissions',
+                  json={
+                      'id': 1,
+                      'name': 'Admin',
+                      'description': 'full access',
+                      'permissions': [{
+                          'entityName': 'entityName',
+                          'action': 'action',
+                          'entityIds': [1, 2],
+                          'dynamicId': 'some id'
+                      }]
+                  }
+                  )
+    resp = api.roles.replace_role_permissions('1',
+                                              permissions=[{
+                                                  'entity_name': 'entityName',
+                                                  'action': 'action',
+                                                  'entity_ids': [1, 2],
+                                                  'dynamic_id': 'some id'
+                                              }])
+    assert isinstance(resp, dict)
+    assert resp['name'] == 'Admin'
+    assert resp['description'] == 'full access'
+    assert resp['permissions'][0]['entity_name'] == 'entityName'
+    assert resp['permissions'][0]['action'] == 'action'
+    assert resp['permissions'][0]['entity_ids'] == [1, 2]
+    assert resp['permissions'][0]['dynamic_id'] == 'some id'

--- a/tests/ad/roles/test_roles_schema.py
+++ b/tests/ad/roles/test_roles_schema.py
@@ -1,0 +1,80 @@
+'''
+Testing the roles schemas
+'''
+import pytest
+from marshmallow import ValidationError
+from tenable.ad.roles.schema import RoleSchema, RolePermissionsSchema
+
+
+@pytest.fixture()
+def role_schema():
+    return [{
+        'name': 'name',
+        'description': 'description'
+    }]
+
+
+def test_role_schema(role_schema):
+    '''
+    Test the role schema with create payload inputs
+    '''
+    test_resp = [{
+        'id': 1,
+        'name': 'name',
+        'description': 'description',
+        'permissions': [{
+            'entityName': 'entity_name',
+            'action': 'action',
+            'entityIds': [1, 2],
+            'dynamicId': 'some dynamic id'
+        }]
+    }]
+
+    schema = RoleSchema()
+    req = schema.dump(schema.load(role_schema, many=True), many=True)[0]
+    assert test_resp[0]['name'] == req['name']
+    assert test_resp[0]['description'] == req['description']
+
+    with pytest.raises(ValidationError):
+        role_schema[0]['some_val'] = 'something'
+        schema.load(role_schema, many=True)
+
+
+@pytest.fixture()
+def role_permission_schema():
+    return [{
+        'entityName': 'entity_name',
+        'action': 'action',
+        'entityIds': [1, 2],
+        'dynamicId': 'some dynamic id'
+    }]
+
+
+def test_role_permission_schema(role_permission_schema):
+    '''
+    Test the role schema with replace role permissions payload inputs
+    '''
+    test_resp = [{
+        'id': 1,
+        'name': 'name',
+        'description': 'description',
+        'permissions': [{
+            'entityName': 'entity_name',
+            'action': 'action',
+            'entityIds': [1, 2],
+            'dynamicId': 'some dynamic id'
+        }]
+    }]
+
+    schema = RolePermissionsSchema()
+    req = schema.dump(
+        schema.load(role_permission_schema, many=True),
+        many=True)[0]
+    assert test_resp[0]['permissions'][0]['entityName'] == req['entityName']
+    assert test_resp[0]['permissions'][0]['action'] == req['action']
+    assert test_resp[0]['permissions'][0]['entityIds'] == req['entityIds']
+    assert test_resp[0]['permissions'][0]['dynamicId'] == req['dynamicId']
+
+    with pytest.raises(ValidationError):
+        role_permission_schema[0]['some_val'] = 'something'
+        schema.load(role_permission_schema, many=True)


### PR DESCRIPTION
# Description

Added Tenable.AD role APIs

- Retrieve all role instances. (_list_)
- Create role instance. (_create_)
- Return the default roles for user creation (_default_roles_)
- Get role instance by id. (_details_)
- Update role instance. (_update_)
- Delete role instance. (_delete_)
- Creates a new role from another one (_copy_role_)
- Replace permission list for a role (_replace_role_permissions_)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added tests for all role endpoints to test responses
- [x] Added schema tests for testing payload inputs and response dict validation

**Test Configuration**:
* Python Version(s) Tested:3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
