### PR TITLE
Added support for TenableAD infrastructure APIs

### DIFF
--- a/docs/api/ad/infrastructure.rst
+++ b/docs/api/ad/infrastructure.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.infrastructure.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -18,6 +18,7 @@ This package covers the Tenable.ad interface.
     checker
     dashboard
     directories
+    infrastructure
     profiles
     users
     widget

--- a/tenable/ad/infrastructure/api.py
+++ b/tenable/ad/infrastructure/api.py
@@ -1,0 +1,131 @@
+'''
+Infrastructure
+==============
+
+Methods described in this section relate to the the infrastructure API.
+These methods can be accessed at ``TenableAD.infrastructure``.
+
+.. rst-class:: hide-signature
+.. autoclass:: InfrastructureAPI
+    :members:
+'''
+from typing import List, Dict
+from tenable.ad.infrastructure.schema import InfrastructureSchema
+from tenable.base.endpoint import APIEndpoint
+
+
+class InfrastructureAPI(APIEndpoint):
+    _path = 'infrastructures'
+    _schema = InfrastructureSchema()
+
+    def list(self) -> List[Dict]:
+        '''
+        Retrieves the list of infrastructures.
+
+        Returns:
+            list:
+                List of infrastructure instances.
+
+        Examples:
+
+            >>> tad.infrastructure.list()
+        '''
+        return self._schema.load(self._get(), many=True)
+
+    def create(self, name: str, login: str, password: str) -> List[Dict]:
+        '''
+        Creates a new infrastructure instance with inputs of name, username
+        and password.
+
+        Args:
+            name (str):
+                The new name for the infrastructure instance.
+            login (str):
+                The login name for the infrastructure instance.
+            password (str):
+                The password for the infrastructure instance.
+
+        Returns:
+            list:
+                Newly created infrastructure instance.
+
+        Examples:
+
+            >>> tad.infrastructure.create(
+            ...     name='test_user',
+            ...     login='test_user@gmail.com',
+            ...     password='tenable.ad'))
+        '''
+        payload = [
+            self._schema.dump(self._schema.load({
+                'name': name,
+                'login': login,
+                'password': password
+            }))
+        ]
+        return self._schema.load(self._post(json=payload), many=True)
+
+    def details(self, infrastructure_id: str) -> Dict:
+        '''
+        Gets the details of particular infrastructure instance.
+
+        Args:
+            infrastructure_id (str):
+                The infrastructure instance identifier.
+
+        Returns:
+            dict:
+                Details of particular ``infrastructure_id``.
+
+        Examples:
+
+            >>> tad.infrastructure.details(infrastructure_id='1')
+        '''
+        return self._schema.load(self._get(infrastructure_id))
+
+    def update(self, infrastructure_id: str, **kwargs) -> Dict:
+        '''
+        Updates the infrastructure of the specific infrastructure instance.
+
+        Args:
+            infrastructure_id (str):
+                The infrastructure instance identifier.
+            name (optional, str):
+                New name to be updated.
+            login (optional, str):
+                New login name to be updated.
+            password (optional, str):
+                New password to be updated.
+
+        Returns:
+            dict:
+                Updated infrastructure instance.
+
+        Examples:
+
+            >>> tad.infrastructure.update(
+            ...     infrastructure_id='1',
+            ...     login='updated_login@tenable.com',
+            ...     name='updated_user')
+        '''
+        payload = self._schema.dump(self._schema.load(kwargs))
+        return self._schema.load(
+            self._patch(f'{infrastructure_id}', json=payload))
+
+    def delete(self, infrastructure_id: str):
+        '''
+        Deletes the particular infrastructure instance.
+
+        Args:
+            infrastructure_id (str):
+                The infrastructure instance identifier.
+
+        Returns:
+            None:
+
+        Examples:
+
+            >>> tad.infrastructure.delete(infrastructure_id='1')
+        '''
+        return self._schema.load(self._delete(f'{infrastructure_id}'),
+                                 many=True)

--- a/tenable/ad/infrastructure/schema.py
+++ b/tenable/ad/infrastructure/schema.py
@@ -1,0 +1,10 @@
+from marshmallow import fields, Schema
+
+
+class InfrastructureSchema(Schema):
+    id = fields.Int()
+    name = fields.Str()
+    login = fields.Str()
+    password = fields.Str()
+    directories = fields.List(fields.Int())
+    infrastructure_id = fields.Str()

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -12,6 +12,7 @@ from .category.api import CategoryAPI
 from .checker.api import CheckerAPI
 from .dashboard.api import DashboardAPI
 from .directories.api import DirectoriesAPI
+from .infrastructure.api import InfrastructureAPI
 from .profiles.api import ProfilesAPI
 from .users.api import UsersAPI
 from .widget.api import WidgetsAPI
@@ -88,6 +89,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad Directories APIs <directories>`.
         '''
         return DirectoriesAPI(self)
+
+    @property
+    def infrastructure(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad Infrastructure APIs <infrastructure>`.
+        '''
+        return InfrastructureAPI(self)
 
     @property
     def profiles(self):

--- a/tests/ad/infrastructure/test_infrastructure_api.py
+++ b/tests/ad/infrastructure/test_infrastructure_api.py
@@ -1,0 +1,92 @@
+'''tests for infrastructure api'''
+
+import responses
+
+RE_BASE = 'https://pytenable.tenable.ad/api'
+
+
+@responses.activate
+def test_infrastructure_create(api):
+    '''tests the create API response with actual create response'''
+    responses.add(responses.POST,
+                  f'{RE_BASE}/infrastructures',
+                  json=[{
+                      'id': 1,
+                      'name': 'test',
+                      'login': 'test@gmail.com',
+                      'directories': [0, 1, 2]
+                  }]
+                  )
+    resp = api.infrastructure.create(name='test',
+                                     login='test@gmail.com',
+                                     password='password')
+    assert isinstance(resp, list)
+    assert resp[0]['name'] == 'test'
+
+
+@responses.activate
+def test_infrastructure_delete(api):
+    '''tests the delete API response with actual delete response'''
+    responses.add(responses.DELETE,
+                  f'{RE_BASE}/infrastructures/1',
+                  json=None
+                  )
+    resp = api.infrastructure.delete(infrastructure_id=1)
+    assert isinstance(resp, list)
+    assert len(resp) == 0
+
+
+@responses.activate
+def test_infrastructure_update(api):
+    '''tests the update API response with actual update response'''
+    responses.add(responses.PATCH,
+                  f'{RE_BASE}/infrastructures/1',
+                  json={
+                      'id': 1,
+                      'name': 'test',
+                      'login': 'test@gmail.com'
+                  }
+                  )
+    resp = api.infrastructure.update(
+        infrastructure_id='1',
+        name='test',
+        login='test@gmail.com',
+        password='password')
+    assert isinstance(resp, dict)
+    assert resp['name'] == 'test'
+
+
+@responses.activate
+def test_infrastructure_details(api):
+    '''tests the details API response with actual details response'''
+    responses.add(responses.GET,
+                  f'{RE_BASE}/infrastructures/1',
+                  json={
+                      'id': 1,
+                      'name': 'test',
+                      'login': 'test@gmail.com',
+                      'directories': [0, 1, 2]
+                  }
+                  )
+    resp = api.infrastructure.details(infrastructure_id='1')
+    assert isinstance(resp, dict)
+    assert resp['name'] == 'test'
+    assert resp['directories'] == [0, 1, 2]
+
+
+@responses.activate
+def test_infrastructure_list(api):
+    '''tests the list API response with actual list response'''
+    responses.add(responses.GET,
+                  f'{RE_BASE}/infrastructures',
+                  json=[{
+                      'id': 1,
+                      'name': 'test',
+                      'login': 'test@gmail.com',
+                      'directories': [0, 1, 2]
+                  }]
+                  )
+    resp = api.infrastructure.list()
+    assert isinstance(resp, list)
+    assert resp[0]['name'] == 'test'
+    assert resp[0]['directories'] == [0, 1, 2]

--- a/tests/ad/infrastructure/test_infrastructure_schema.py
+++ b/tests/ad/infrastructure/test_infrastructure_schema.py
@@ -1,0 +1,33 @@
+'''tests for infrastructure schema'''
+import pytest
+from marshmallow.exceptions import ValidationError
+from tenable.ad.infrastructure.schema import InfrastructureSchema
+
+
+@pytest.fixture
+def infrastructure_schema():
+    return {
+        'id': 1,
+        'name': 'test',
+        'login': 'test@tenable.com',
+        'password': 'password',
+        'directories': [0, 1, 2],
+        'infrastructure_id': '1'
+    }
+
+
+def test_infrastructure_schema(infrastructure_schema):
+    test_response = {
+        'id': 1,
+        'name': 'test',
+        'login': 'test@tenable.com',
+        'password': 'password',
+        'directories': [0, 1, 2],
+        'infrastructure_id': '1'
+    }
+    schema = InfrastructureSchema()
+    assert test_response == schema.dump(schema.load(
+        infrastructure_schema))
+    with pytest.raises(ValidationError):
+        infrastructure_schema['new_val'] = 'something'
+        schema.load(infrastructure_schema)


### PR DESCRIPTION
# Description

Added Tenable.AD ``infrastructure`` APIs

Methods available:

- Retrieve all infrastructure instances - `list`
- Create infrastructure instance - `create`
- Get infrastructure instance by id - `details`
- Update infrastructure instance - `update`
- Delete infrastructure instance  - `delete`

Updated docs to support infrastructure API details.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests added to test all the dashboard endpoints and their schema.
- [x] Sphinx build for doc

**Test Configuration**:
* Python Version(s) Tested: 3.9.0
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
