### PR TITLE
Added support for TenableAD preference APIs

### DIFF
--- a/docs/api/ad/preference.rst
+++ b/docs/api/ad/preference.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.preference.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -18,6 +18,7 @@ This package covers the Tenable.ad interface.
     checker
     dashboard
     directories
+    preference
     profiles
     users
     widget

--- a/tenable/ad/preference/api.py
+++ b/tenable/ad/preference/api.py
@@ -1,0 +1,56 @@
+'''
+Preference
+=============
+
+Methods described in this section relate to the preferences API.
+These methods can be accessed at ``TenableAD.preference``.
+
+.. rst-class:: hide-signature
+.. autoclass:: PreferenceAPI
+    :members:
+'''
+from typing import Dict
+from tenable.base.endpoint import APIEndpoint
+from .schema import PreferenceSchema
+
+
+class PreferenceAPI(APIEndpoint):
+    _path = 'preferences'
+    _schema = PreferenceSchema()
+
+    def details(self) -> Dict:
+        '''
+        Get the user's preferences
+
+        Returns:
+            dict:
+                The user's preferences object
+
+        Examples:
+            >>> tad.preference.details()
+        '''
+        return self._schema.load(self._get())
+
+    def update(self,
+               **kwargs
+               ) -> Dict:
+        '''
+        Update the user's preferences
+
+        Args:
+            language (optional, str):
+                ???
+            preferred_profile_id (optional, int):
+                ???
+
+        Return:
+            The user's preferences object
+
+        Example:
+            >>> tad.preference.update(
+            ...     language='en',
+            ...     preferred_profile_id=1
+            ... )
+        '''
+        payload = self._schema.dump(self._schema.load(kwargs))
+        return self._schema.load(self._patch(json=payload))

--- a/tenable/ad/preference/schema.py
+++ b/tenable/ad/preference/schema.py
@@ -1,0 +1,14 @@
+from marshmallow import fields, pre_load
+from tenable.ad.base.schema import CamelCaseSchema, camelcase
+
+
+class PreferenceSchema(CamelCaseSchema):
+    language = fields.Str()
+    preferred_profile_id = fields.Int()
+
+    @pre_load
+    def keys_to_camel(self, data, **kwargs):
+        resp = {}
+        for key, value in data.items():
+            resp[camelcase(key)] = value
+        return resp

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -12,6 +12,7 @@ from .category.api import CategoryAPI
 from .checker.api import CheckerAPI
 from .dashboard.api import DashboardAPI
 from .directories.api import DirectoriesAPI
+from .preference.api import PreferenceAPI
 from .profiles.api import ProfilesAPI
 from .users.api import UsersAPI
 from .widget.api import WidgetsAPI
@@ -88,6 +89,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad Directories APIs <directories>`.
         '''
         return DirectoriesAPI(self)
+
+    @property
+    def preference(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad Preference APIs <preference>`.
+        '''
+        return PreferenceAPI(self)
 
     @property
     def profiles(self):

--- a/tests/ad/preference/test_preferences_api.py
+++ b/tests/ad/preference/test_preferences_api.py
@@ -1,0 +1,33 @@
+import responses
+
+from tests.ad.conftest import RE_BASE
+
+
+@responses.activate
+def test_preference_details(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/preferences',
+                  json={
+                      'language': 'en',
+                      'preferredProfileId': 1
+                  }
+                  )
+    resp = api.preference.details()
+    assert isinstance(resp, dict)
+    assert resp['language'] == 'en'
+    assert resp['preferred_profile_id'] == 1
+
+
+@responses.activate
+def test_preference_update(api):
+    responses.add(responses.PATCH,
+                  f'{RE_BASE}/preferences',
+                  json={
+                      'language': 'en',
+                      'preferredProfileId': 2
+                  })
+    resp = api.preference.update(language='en',
+                                  preferred_profile_id='2')
+    assert isinstance(resp, dict)
+    assert resp['language'] == 'en'
+    assert resp['preferred_profile_id'] == 2

--- a/tests/ad/preference/test_preferences_schema.py
+++ b/tests/ad/preference/test_preferences_schema.py
@@ -1,0 +1,27 @@
+'''
+Testing the preferences schemas
+'''
+import pytest
+from tenable.ad.preference.schema import PreferenceSchema
+
+
+@pytest.fixture()
+def preferences_schema():
+    return {
+        'language': 'en',
+        'preferred_profile_id': 1
+    }
+
+
+def test_preferences_schema(preferences_schema):
+    '''
+    test preference schema
+    '''
+    test_resp = {
+        'language': 'en',
+        'preferredProfileId': 1
+    }
+    schema = PreferenceSchema()
+    req = schema.dump(schema.load(preferences_schema))
+    assert test_resp['language'] == req['language']
+    assert test_resp['preferredProfileId'] == req['preferredProfileId']


### PR DESCRIPTION
# Description

Added `Tenable.AD preference APIs`

- Get a user's preferences (_details_)
- Update a user's preferences (_update_)

_updated docs to support preference api details_

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added tests for all preference endpoints to test responses
- [x] Added schema tests for testing payload inputs and response dict validation

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
