### PR TITLE
Added support for TenableAD lockout policy APIs

### DIFF
--- a/docs/api/ad/lockout_policy.rst
+++ b/docs/api/ad/lockout_policy.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.lockout_policy.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -19,8 +19,8 @@ This package covers the Tenable.ad interface.
     dashboard
     directories
     infrastructure
+    lockout_policy
     preference
-    infrastructure
     profiles
     roles
     users

--- a/tenable/ad/lockout_policy/api.py
+++ b/tenable/ad/lockout_policy/api.py
@@ -1,0 +1,57 @@
+'''
+Lockout Policy
+=============
+
+Methods described in this section relate to the lockout policy API.
+These methods can be accessed at ``TenableAD.lockout_policy``.
+
+.. rst-class:: hide-signature
+.. autoclass:: LockoutPolicyAPI
+    :members:
+'''
+from typing import Dict
+from tenable.base.endpoint import APIEndpoint
+from .schema import LockoutPolicySchema
+
+
+class LockoutPolicyAPI(APIEndpoint):
+    _path = 'lockout-policy'
+    _schema = LockoutPolicySchema()
+
+    def details(self) -> Dict:
+        '''
+        Get the lockout policy
+
+        Returns:
+            dict:
+                The lockout policy object
+
+        Examples:
+            >>> tad.lockout_policy.details()
+        '''
+        return self._schema.load(self._get())
+
+    def update(self,
+               **kwargs
+               ) -> None:
+        '''
+        Update the lockout policy
+
+        Args:
+            enabled (optional, bool):
+                ???
+            lockout_duration (optional, int):
+                ???
+            failed_attempt_threshold (optional, int):
+                ???
+            failed_attempt_period (optional, int):
+                ???
+
+        Return:
+            None
+
+        Example:
+            >>> tad.lockout_policy.update(enabled=True)
+        '''
+        payload = self._schema.dump(self._schema.load(kwargs))
+        self._patch(json=payload)

--- a/tenable/ad/lockout_policy/schema.py
+++ b/tenable/ad/lockout_policy/schema.py
@@ -1,0 +1,16 @@
+from marshmallow import fields, pre_load
+from tenable.ad.base.schema import CamelCaseSchema, camelcase
+
+
+class LockoutPolicySchema(CamelCaseSchema):
+    enabled = fields.Bool()
+    lockout_duration = fields.Int()
+    failed_attempt_threshold = fields.Int()
+    failed_attempt_period = fields.Int()
+
+    @pre_load
+    def keys_to_camel(self, data, **kwargs):
+        resp = {}
+        for key, value in data.items():
+            resp[camelcase(key)] = value
+        return resp

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -13,6 +13,7 @@ from .checker.api import CheckerAPI
 from .dashboard.api import DashboardAPI
 from .directories.api import DirectoriesAPI
 from .infrastructure.api import InfrastructureAPI
+from .lockout_policy.api import LockoutPolicyAPI
 from .preference.api import PreferenceAPI
 from .profiles.api import ProfilesAPI
 from .roles.api import RolesAPI
@@ -99,6 +100,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad Infrastructure APIs <infrastructure>`.
         '''
         return InfrastructureAPI(self)
+
+    @property
+    def lockout_policy(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad Lockout Policy APIs <lockout_policy>`.
+        '''
+        return LockoutPolicyAPI(self)
       
     @property
     def preference(self):

--- a/tests/ad/lockout_policy/test_lockout_policy_api.py
+++ b/tests/ad/lockout_policy/test_lockout_policy_api.py
@@ -1,0 +1,38 @@
+import responses
+
+from tests.ad.conftest import RE_BASE
+
+
+@responses.activate
+def test_lockout_policy_details(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/lockout-policy',
+                  json={
+                      'enabled': True,
+                      'lockoutDuration': 10,
+                      'failedAttemptThreshold': 2,
+                      'failedAttemptPeriod': 1
+                  }
+                  )
+    resp = api.lockout_policy.details()
+    assert isinstance(resp, dict)
+    assert resp['enabled'] is True
+    assert resp['lockout_duration'] == 10
+    assert resp['failed_attempt_threshold'] == 2
+    assert resp['failed_attempt_period'] == 1
+
+
+@responses.activate
+def test_lockout_policy_update(api):
+    responses.add(responses.PATCH,
+                  f'{RE_BASE}/lockout-policy',
+                  json=None)
+    resp = api.lockout_policy.update(
+        enabled=True,
+        lockout_duration=10,
+        failed_attempt_threshold=2,
+        failed_attempt_period=1
+    )
+    assert resp is None
+
+

--- a/tests/ad/lockout_policy/test_lockout_policy_schema.py
+++ b/tests/ad/lockout_policy/test_lockout_policy_schema.py
@@ -1,0 +1,27 @@
+'''
+Testing the lockout policy schemas
+'''
+import pytest
+from tenable.ad.lockout_policy.schema import LockoutPolicySchema
+
+
+@pytest.fixture()
+def lockout_policy_schema():
+    return {
+        'enabled': True,
+        'lockout_duration': 10,
+        'failed_attempt_threshold': 2,
+        'failed_attempt_period': 1
+    }
+
+
+def test_lockout_policy_schema(lockout_policy_schema):
+    '''
+    test lockout policy update payload input to schema
+    '''
+    schema = LockoutPolicySchema()
+    req = schema.dump(schema.load(lockout_policy_schema))
+    assert req['enabled'] is True
+    assert req['lockoutDuration'] == 10
+    assert req['failedAttemptThreshold'] == 2
+    assert req['failedAttemptPeriod'] == 1


### PR DESCRIPTION
# Description

Added `Tenable.AD lockout policy APIs`

- Get the lockout policy (_details_)
- Update the lockout policy (_update_)


_updated docs to support lockout policy api details_

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added tests for all lockout policy endpoints to test responses
- [x] Added schema tests for testing payload inputs and response dict validation

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
