### PR TITLE
Added support for TenableAD attack type APIs

### DIFF
--- a/docs/api/ad/attack_types.rst
+++ b/docs/api/ad/attack_types.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.attack_types.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -14,6 +14,7 @@ This package covers the Tenable.ad interface.
 
     about
     api_keys
+    attack_types
     category
     checker
     dashboard

--- a/tenable/ad/attack_types/api.py
+++ b/tenable/ad/attack_types/api.py
@@ -1,0 +1,32 @@
+'''
+Attack Type
+=============
+
+Methods described in this section relate to the the attack type API.
+These methods can be accessed at ``TenableAD.attack_types``.
+
+.. rst-class:: hide-signature
+.. autoclass:: AttackTypesAPI
+    :members:
+
+'''
+from typing import List, Dict
+from tenable.ad.attack_types.schema import AttackTypesSchema
+from tenable.base.endpoint import APIEndpoint
+
+
+class AttackTypesAPI(APIEndpoint):
+    _schema = AttackTypesSchema()
+
+    def list(self) -> List[Dict]:
+        '''
+        Retrieve all attack types
+
+        Returns:
+            list:
+                The list of attack types objects
+
+        Examples:
+            >>> tad.attack_types.list()
+        '''
+        return self._schema.load(self._get('attack-types'), many=True)

--- a/tenable/ad/attack_types/schema.py
+++ b/tenable/ad/attack_types/schema.py
@@ -1,0 +1,27 @@
+from marshmallow import fields
+from tenable.ad.base.schema import CamelCaseSchema
+
+
+class AttackTypesResourceSchema(CamelCaseSchema):
+    name = fields.Str()
+    url = fields.URL()
+    type = fields.Str()
+
+
+class AttackTypesVectorTemplateReplacementsSchema(CamelCaseSchema):
+    name = fields.Str()
+    value_type = fields.Str()
+
+
+class AttackTypesSchema(CamelCaseSchema):
+    id = fields.Int()
+    name = fields.Str()
+    yara_rules = fields.Str()
+    description = fields.Str()
+    workload_quota = fields.Int()
+    mitre_attack_description = fields.Str()
+    criticity = fields.Str()
+    resources = fields.Nested(AttackTypesResourceSchema, many=True)
+    vector_template = fields.Str()
+    vector_template_replacements = fields.Nested(
+        AttackTypesVectorTemplateReplacementsSchema, many=True)

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -8,6 +8,7 @@ from tenable.base.platform import APIPlatform
 
 from .about import AboutAPI
 from .api_keys import APIKeyAPI
+from .attack_types.api import AttackTypesAPI
 from .category.api import CategoryAPI
 from .checker.api import CheckerAPI
 from .dashboard.api import DashboardAPI
@@ -61,6 +62,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad API-Keys APIs <api_keys>`.
         '''
         return APIKeyAPI(self)
+
+    @property
+    def attack_types(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad Attack Types APIs <attack_types>`.
+        '''
+        return AttackTypesAPI(self)
 
     @property
     def category(self):

--- a/tests/ad/attack_types/test_attack_types_api.py
+++ b/tests/ad/attack_types/test_attack_types_api.py
@@ -1,0 +1,37 @@
+import responses
+
+RE_BASE = 'https://pytenable.tenable.ad/api'
+
+
+@responses.activate
+def test_attack_types_list(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/attack-types',
+                  json=[{
+                      "id": 1,
+                      "name": "test",
+                      "yaraRules": "attack type rules",
+                      "description": "attack type description",
+                      "workloadQuota": 3,
+                      "mitreAttackDescription": "mitre_attack_description",
+                      "criticity": "critical",
+                      "resources": [{
+                          "name": "resource name",
+                          "url": "https://test.domain.com",
+                          "type": "resource type"
+                      }],
+                      "vectorTemplate": "vector_template",
+                      "vectorTemplateReplacements": [{
+                          "name": "user",
+                          "valueType": "string"
+                      }]
+                  }]
+                  )
+    resp = api.attack_types.list()
+    assert isinstance(resp, list)
+    assert len(resp) == 1
+    assert resp[0]['id'] == 1
+    assert resp[0]['name'] == 'test'
+    assert resp[0]['yara_rules'] == 'attack type rules'
+    assert resp[0]['mitre_attack_description'] == 'mitre_attack_description'
+

--- a/tests/ad/attack_types/test_attack_types_schema.py
+++ b/tests/ad/attack_types/test_attack_types_schema.py
@@ -1,0 +1,91 @@
+'''
+Testing the attack type schemas
+'''
+import pytest
+from marshmallow import ValidationError
+from tenable.ad.attack_types.schema import (
+    AttackTypesSchema,
+    AttackTypesResourceSchema,
+    AttackTypesVectorTemplateReplacementsSchema
+)
+
+
+def test_attack_type_schema():
+    '''
+    test attack type schema
+    '''
+    test_resp = [{
+        "id": 1,
+        "name": "test",
+        "yaraRules": "attack type rules",
+        "description": "attack type description",
+        "workloadQuota": 3,
+        "mitreAttackDescription": "mitre_attack_description",
+        "criticity": "critical",
+        "resources": [{
+            "name": "resource name",
+            "url": "https://test.domain.com",
+            "type": "resource type"
+        }],
+        "vectorTemplate": "vector_template",
+        "vectorTemplateReplacements": [{
+            "name": "user",
+            "valueType": "string"
+        }]
+    }]
+
+    schema = AttackTypesSchema()
+    req = schema.load(test_resp, many=True)
+    assert test_resp[0]['id'] == req[0]['id']
+    assert test_resp[0]['name'] == req[0]['name']
+    assert test_resp[0]['yaraRules'] == req[0]['yara_rules']
+    assert test_resp[0]['description'] == req[0]['description']
+    assert test_resp[0]['workloadQuota'] == req[0]['workload_quota']
+    assert test_resp[0]['mitreAttackDescription'] == req[0][
+        'mitre_attack_description']
+    assert test_resp[0]['criticity'] == req[0]['criticity']
+    assert test_resp[0]['vectorTemplate'] == req[0]['vector_template']
+
+    with pytest.raises(ValidationError):
+        test_resp[0]['some_val'] = 'something'
+        schema.load(test_resp, many=True)
+
+
+def test_attack_type_resource_schema():
+    '''
+    test attack type resource schema
+    '''
+    test_resp = {
+        "name": "resource name",
+        "url": "https://test.domain.com",
+        "type": "resource type"
+    }
+
+    schema = AttackTypesResourceSchema()
+    req = schema.load(test_resp)
+    assert test_resp['name'] == req['name']
+    assert test_resp['url'] == req['url']
+    assert test_resp['type'] == req['type']
+
+    with pytest.raises(ValidationError):
+        test_resp['some_val'] = 'something'
+        schema.load(test_resp)
+
+
+def test_attack_type_vector_template_replacements_schema():
+    '''
+    test attack type vector template replacements schema
+    '''
+    test_resp = {
+        "name": "user",
+        "valueType": "string"
+    }
+
+    schema = AttackTypesVectorTemplateReplacementsSchema()
+    req = schema.load(test_resp)
+    assert test_resp['name'] == req['name']
+    assert test_resp['valueType'] == req['value_type']
+
+    with pytest.raises(ValidationError):
+        test_resp['some_val'] = 'something'
+        schema.load(test_resp)


### PR DESCRIPTION
# Description

Added `Tenable.AD Attack Type APIs`

- Get attack types (_list_)

_updated docs to support attack type api details_

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added tests for attack type list endpoint to test responses
- [x] Added schema tests for testing payload inputs and response dict validation

**Test Configuration**:
* Python Version(s) Tested: 3.8.6
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
