### PR TITLE
Added support for TenableAD SAML configuration APIs

### DIFF
--- a/docs/api/ad/saml_configuration.rst
+++ b/docs/api/ad/saml_configuration.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.saml_configuration.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -23,6 +23,7 @@ This package covers the Tenable.ad interface.
     preference
     profiles
     roles
+    saml_configuration
     score
     users
     widget

--- a/tenable/ad/saml_configuration/api.py
+++ b/tenable/ad/saml_configuration/api.py
@@ -1,0 +1,91 @@
+'''
+SAML Configuration
+==================
+
+Methods described in this section relate to the the SAML Configuration API.
+These methods can be accessed at ``TenableAD.saml_configuration``.
+
+.. rst-class:: hide-signature
+.. autoclass:: SAMLConfigurationAPI
+    :members:
+'''
+from typing import Dict
+from tenable.ad.saml_configuration.schema import SAMLConfigurationSchema
+from tenable.base.endpoint import APIEndpoint
+
+
+class SAMLConfigurationAPI(APIEndpoint):
+    _path = 'saml-configuration'
+    _schema = SAMLConfigurationSchema()
+
+    def details(self) -> Dict:
+        '''
+        Retrieves the details of the SAML-configuration singleton.
+
+        Returns:
+            dict:
+                The details of saml configuration singleton.
+
+        Examples:
+            >>> tad.saml_configuration.details()
+        '''
+        return self._schema.load(self._get())
+
+    def update(self,
+               **kwargs
+               ) -> Dict:
+        '''
+        Updates the SAML-configuration.
+
+        Args:
+            enabled (optional, bool):
+                Whether the SAML configuration is enabled or not.
+            provider_login_url (optional, str):
+                The URL of the identity provider to reach for
+                SAML authentication.
+            signature_certificate (optional, str):
+                The certificate used to sign the SAML authentication.
+            activate_created_users (optional, bool):
+                Whether the created users through SAML authentication should be
+                activated. If false, created users will be disabled until an
+                admin comes and activate them.
+            allowed_groups (optional, List[Dict]):
+                The group names from the identity provider whose members are
+                allowed to use Tenable.ad. The below listed params are
+                expected in allowed_groups dict.
+            name (required, str):
+                The name of SAML Configuration.
+            default_profile_id (required, int):
+                The default profile instance identifier of SAML Configuration.
+            default_role_ids (required, list(int)):
+                The default role instance identifier of SAML Configuration.
+
+        Returns:
+            dict:
+                The updated saml-configuration.
+
+        Examples:
+            >>> tad.saml_configuration.update(
+            ...     enabled=True,
+            ...     allowed_groups=[{
+            ...         'name': 'updated_name',
+            ...         'default_profile_id': 1,
+            ...         'default_role_ids': [1, 2]
+            ...     }]
+            ...     )
+        '''
+        payload = self._schema.dump(self._schema.load(kwargs))
+        return self._schema.load(self._patch(json=payload))
+
+    def generate_saml_certificate(self) -> Dict:
+        '''
+        Generates a SAML certificate.
+
+        Returns:
+            dict:
+                Generated certificate.
+
+        Examples:
+            >>> tad.saml_configuration.generate_saml_certificate()
+        '''
+        return self._schema.load(self._get('generate-certificate'))

--- a/tenable/ad/saml_configuration/schema.py
+++ b/tenable/ad/saml_configuration/schema.py
@@ -1,0 +1,34 @@
+from marshmallow import fields, pre_load, validate as v
+from tenable.ad.base.schema import CamelCaseSchema, camelcase
+
+
+class AllowedGroupSchema(CamelCaseSchema):
+    name = fields.Str(required=True)
+    default_profile_id = fields.Int(required=True)
+    default_role_ids = fields.List(fields.Int(required=True),
+                                   validate=v.Length(min=1))
+
+    @pre_load
+    def keys_to_camel(self, data, **kwargs):
+        resp = {}
+        for key, value in data.items():
+            resp[camelcase(key)] = value
+        return resp
+
+
+class SAMLConfigurationSchema(CamelCaseSchema):
+    enabled = fields.Bool()
+    provider_login_url = fields.Str(allow_none=True)
+    encryption_certificate = fields.Str()
+    signature_certificate = fields.Str(allow_none=True)
+    service_provider_url = fields.Str()
+    assert_endpoint = fields.Str()
+    activate_created_users = fields.Bool()
+    allowed_groups = fields.Nested(AllowedGroupSchema, many=True)
+
+    @pre_load
+    def keys_to_camel(self, data, **kwargs):
+        resp = {}
+        for key, value in data.items():
+            resp[camelcase(key)] = value
+        return resp

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -17,6 +17,7 @@ from .lockout_policy.api import LockoutPolicyAPI
 from .preference.api import PreferenceAPI
 from .profiles.api import ProfilesAPI
 from .roles.api import RolesAPI
+from .saml_configuration.api import SAMLConfigurationAPI
 from .score.api import ScoreAPI
 from .users.api import UsersAPI
 from .widget.api import WidgetsAPI
@@ -133,6 +134,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad Roles APIs <roles>`.
         '''
         return RolesAPI(self)
+
+    @property
+    def saml_configuration(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad SAML configuration APIs <saml_configuration>`.
+        '''
+        return SAMLConfigurationAPI(self)
 
     @property
     def score(self):

--- a/tests/ad/saml-configuration/test_saml_configuration_api.py
+++ b/tests/ad/saml-configuration/test_saml_configuration_api.py
@@ -1,0 +1,78 @@
+'''tests for saml_configuration API endpoints'''
+import responses
+
+RE_BASE = 'https://pytenable.tenable.ad/api'
+
+
+@responses.activate
+def test_saml_configuration_singleton(api):
+    '''tests the saml_configuration_singleton API response with
+    actual saml_configuration_singleton response'''
+    responses.add(responses.GET,
+                  f'{RE_BASE}/saml-configuration',
+                  json={
+                      'activateCreatedUsers': True,
+                      'allowedGroups': [{
+                          'defaultProfileId': 1,
+                          'defaultRoleIds': [1, 2],
+                          'name': 'test'
+                      }],
+                      'assertEndpoint':
+                          'assert_endpoint_url',
+                      'enabled': True,
+                      'encryptionCertificate': 'certificate',
+                      'providerLoginUrl': 'url',
+                      'serviceProviderUrl': 'https://pytenable.tenable.ad',
+                      'signatureCertificate': 'certificate'
+                  }
+                  )
+    resp = api.saml_configuration.details()
+    assert isinstance(resp, dict)
+    assert resp['allowed_groups'][0]['name'] == 'test'
+
+
+@responses.activate
+def test_saml_configuration_update(api):
+    '''tests the update API response with actual update response'''
+    responses.add(responses.PATCH,
+                  f'{RE_BASE}/saml-configuration',
+                  json={
+                      'activateCreatedUsers': True,
+                      'allowedGroups': [{
+                          'defaultProfileId': 1,
+                          'defaultRoleIds': [1, 2],
+                          'name': 'updated_name'
+                      }],
+                      'assertEndpoint': 'assert_endpoint_url',
+                      'enabled': True,
+                      'encryptionCertificate': 'certificate',
+                      'providerLoginUrl': 'url',
+                      'serviceProviderUrl': 'https://pytenable.tenable.ad',
+                      'signatureCertificate': 'certificate'
+                  }
+                  )
+    resp = api.saml_configuration.update(allowed_groups=[{
+        'name': 'updated_name',
+        'default_profile_id': 1,
+        'default_role_ids': [1, 2]
+    }]
+    )
+
+    assert isinstance(resp, dict)
+    assert resp['allowed_groups'][0]['name'] == 'updated_name'
+
+
+@responses.activate
+def test_saml_configuration_generate_saml_certificate(api):
+    '''tests the generate saml certificate API response with actual
+    saml certificate response'''
+    responses.add(responses.GET,
+                  f'{RE_BASE}/saml-configuration/generate-certificate',
+                  json={
+                      'encryptionCertificate': 'generated_certificate',
+                  }
+                  )
+    resp = api.saml_configuration.generate_saml_certificate()
+
+    assert isinstance(resp, dict)
+    assert resp['encryption_certificate'] == 'generated_certificate'

--- a/tests/ad/saml-configuration/test_saml_configuration_schema.py
+++ b/tests/ad/saml-configuration/test_saml_configuration_schema.py
@@ -1,0 +1,46 @@
+'''tests for saml_configuration schema'''
+import pytest
+from marshmallow.exceptions import ValidationError
+from tenable.ad.saml_configuration.schema import SAMLConfigurationSchema
+
+
+@pytest.fixture
+def saml_configuration_schema():
+    return {
+        'activateCreatedUsers': True,
+        'allowedGroups': [{
+                'defaultProfileId': 1,
+                'defaultRoleIds': [1, 2],
+                'name': 'test'
+            }],
+        'assertEndpoint': 'assert_endpoint_url',
+        'enabled': True,
+        'encryptionCertificate': 'certificate',
+        'providerLoginUrl': 'url',
+        'serviceProviderUrl': 'https://pytenable.tenable.ad',
+        'signatureCertificate': 'certificate'
+    }
+
+
+def test_saml_configuration_schema(saml_configuration_schema):
+    test_response = {
+        'activateCreatedUsers': True,
+        'allowedGroups': [{
+                'defaultProfileId': 1,
+                'defaultRoleIds': [1, 2],
+                'name': 'test'
+            }],
+        'assertEndpoint': 'assert_endpoint_url',
+        'enabled': True,
+        'encryptionCertificate': 'certificate',
+        'providerLoginUrl': 'url',
+        'serviceProviderUrl': 'https://pytenable.tenable.ad',
+        'signatureCertificate': 'certificate'
+    }
+    schema = SAMLConfigurationSchema()
+    req = schema.dump(schema.load(
+        saml_configuration_schema))['allowedGroups'][0]
+    assert test_response['allowedGroups'][0]['name'] == req['name']
+    with pytest.raises(ValidationError):
+        saml_configuration_schema['new_val'] = 'something'
+        schema.load(saml_configuration_schema)


### PR DESCRIPTION
# Description

Added TenableAD `SAML Configuration` APIs

Methods available:
- Get saml-configuration singleton - `details`
- Update saml-configuration singleton - `update`
- Generates SAML certificate - `generate_saml_certificate`

Updated docs to support SAML Configuration API details.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests added to test all the dashboard endpoints and their schema.
- [x] Sphinx build for docs

**Test Configuration**:
* Python Version(s) Tested:3.9.0
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
