### PR TITLE
Added support for Tenable AD Reason APIs

### DIFF
--- a/docs/api/ad/reason.rst
+++ b/docs/api/ad/reason.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.ad.reason.api

--- a/tenable/ad/__init__.py
+++ b/tenable/ad/__init__.py
@@ -25,6 +25,7 @@ This package covers the Tenable.ad interface.
     lockout_policy
     preference
     profiles
+    reason
     roles
     saml_configuration
     score

--- a/tenable/ad/reason/api.py
+++ b/tenable/ad/reason/api.py
@@ -1,0 +1,112 @@
+'''
+Reason
+======
+Methods described in this section relate to the the reason API.
+These methods can be accessed at ``TenableAD.reason``.
+
+.. rst-class:: hide-signature
+.. autoclass:: ReasonAPI
+    :members:
+'''
+from typing import List, Dict
+from tenable.ad.reason.schema import ReasonSchema
+from tenable.base.endpoint import APIEndpoint
+
+
+class ReasonAPI(APIEndpoint):
+    _schema = ReasonSchema()
+    _path = 'reasons'
+
+    def list(self) -> List[Dict]:
+        '''
+        Retrieves the list of reason instances.
+
+        Returns:
+            list:
+                The list of reason instances.
+
+        Examples:
+            >>> tad.reason.list()
+        '''
+        return self._schema.load(self._get(), many=True)
+
+    def details(self, reason_id: str) -> Dict:
+        '''
+        Retrieves the details of the reason based on reason_id
+
+        Args:
+            reason_id (str):
+                The reason instance identifier.
+
+        Returns:
+            dict:
+                Details of the reason object .
+
+        Examples:
+            >>> tad.reason.details(reason_id='1')
+        '''
+        return self._schema.load(self._get(f'{reason_id}'))
+
+    def list_by_checker(self,
+                        profile_id: str,
+                        checker_id: str
+                        ) -> List[Dict]:
+        '''
+        Retrieves the details of the reason based on profile_id and checker_id.
+
+        Args:
+            profile_id (str):
+                The profile instance identifier
+            checker_id (str):
+                The checker instance identifier
+
+        Returns:
+            list:
+                Details of the reason object.
+
+        Examples:
+            >>> tad.reason.list_by_checker(
+            ...     profile_id='1',
+            ...     checker_id='1'
+            ...     )
+        '''
+        return self._schema.load(self._api.get(
+            f'profiles/{profile_id}/checkers/{checker_id}/reasons'),
+            many=True)
+
+    def list_by_directory_and_event(self,
+                                    profile_id: str,
+                                    infrastructure_id: str,
+                                    directory_id: str,
+                                    event_id: str
+                                    ) -> List[Dict]:
+        '''
+        Retrieves the details of the reason object based on profile_id,
+        directory_id and event_id.
+
+        Args:
+            profile_id (str):
+                The profile instance identifier.
+            infrastructure_id (str):
+                The infrastructure instance identifier.
+            directory_id (str):
+                The directory instance identifier.
+            event_id (str):
+                The event instance identifier.
+
+        Returns:
+            list:
+                Details of the reason object.
+
+        Examples:
+            >>> tad.reason.list_by_directory_and_event(
+            ...     profile_id='1',
+            ...     infrastructure_id='1',
+            ...     directory_id='1',
+            ...     event_id='1'
+            ...     )
+        '''
+        return self._schema.load(self._api.get(
+            f'profiles/{profile_id}/infrastructures/{infrastructure_id}'
+            f'/directories/{directory_id}/events/{event_id}/reasons'),
+            many=True)

--- a/tenable/ad/reason/schema.py
+++ b/tenable/ad/reason/schema.py
@@ -1,0 +1,9 @@
+from marshmallow import fields
+from tenable.ad.base.schema import CamelCaseSchema
+
+
+class ReasonSchema(CamelCaseSchema):
+    id = fields.Int()
+    codename = fields.Str()
+    name = fields.Str(allow_none=True)
+    description = fields.Str(allow_none=True)

--- a/tenable/ad/session.py
+++ b/tenable/ad/session.py
@@ -19,6 +19,7 @@ from .ldap_configuration.api import LDAPConfigurationAPI
 from .lockout_policy.api import LockoutPolicyAPI
 from .preference.api import PreferenceAPI
 from .profiles.api import ProfilesAPI
+from .reason.api import ReasonAPI
 from .roles.api import RolesAPI
 from .saml_configuration.api import SAMLConfigurationAPI
 from .score.api import ScoreAPI
@@ -153,6 +154,14 @@ class TenableAD(APIPlatform):
         :doc:`Tenable.ad Profiles APIs <profiles>`.
         '''
         return ProfilesAPI(self)
+
+    @property
+    def reason(self):
+        '''
+        The interface object for the
+        :doc:`Tenable.ad Reason APIs <reason>`.
+        '''
+        return ReasonAPI(self)
 
     @property
     def roles(self):

--- a/tests/ad/reason/test_reason_api.py
+++ b/tests/ad/reason/test_reason_api.py
@@ -1,0 +1,76 @@
+'''tests for reason APIs'''
+import responses
+from tests.ad.conftest import RE_BASE
+
+
+@responses.activate
+def test_reason_list(api):
+    responses.add(responses.GET, f'{RE_BASE}/reasons',
+                  json=[{
+                      'id': 1,
+                      'codename': 'codename',
+                      'name': 'some_name',
+                      'description': 'DESCRIPTION'
+                  }])
+    req = api.reason.list()
+    assert isinstance(req, list)
+    assert req[0]['id'] == 1
+    assert req[0]['codename'] == 'codename'
+    assert req[0]['description'] == 'DESCRIPTION'
+    assert req[0]['name'] == 'some_name'
+
+
+@responses.activate
+def test_reason_details(api):
+    responses.add(responses.GET, f'{RE_BASE}/reasons/1',
+                  json={
+                      'id': 1,
+                      'codename': 'codename',
+                      'name': 'some_name',
+                      'description': 'DESCRIPTION'
+                  })
+    req = api.reason.details(reason_id='1')
+    assert isinstance(req, dict)
+    assert req['id'] == 1
+    assert req['codename'] == 'codename'
+    assert req['description'] == 'DESCRIPTION'
+    assert req['name'] == 'some_name'
+
+
+@responses.activate
+def test_reason_list_having_deviances(api):
+    responses.add(responses.GET, f'{RE_BASE}/profiles/1/checkers/1/reasons',
+                  json=[{
+                      'id': 1,
+                      'codename': 'codename',
+                      'name': 'some_name',
+                      'description': 'DESCRIPTION'
+                  }])
+    req = api.reason.list_by_checker(profile_id='1', checker_id='1')
+    assert isinstance(req, list)
+    assert req[0]['id'] == 1
+    assert req[0]['codename'] == 'codename'
+    assert req[0]['description'] == 'DESCRIPTION'
+    assert req[0]['name'] == 'some_name'
+
+
+@responses.activate
+def test_reason_list_having_deviance_with_profile_directory_event(api):
+    responses.add(responses.GET,
+                  f'{RE_BASE}/profiles/1/infrastructures/1/directories/1/'
+                  f'events/1/reasons',
+                  json=[{
+                      'codename': 'codename',
+                      'description': 'DESCRIPTION',
+                      'id': 1,
+                      'name': 'some_name'
+                  }])
+    req = api.reason.list_by_directory_and_event(profile_id='1',
+                                                 infrastructure_id='1',
+                                                 directory_id='1',
+                                                 event_id='1')
+    assert isinstance(req, list)
+    assert req[0]['id'] == 1
+    assert req[0]['codename'] == 'codename'
+    assert req[0]['description'] == 'DESCRIPTION'
+    assert req[0]['name'] == 'some_name'

--- a/tests/ad/reason/test_reason_schema.py
+++ b/tests/ad/reason/test_reason_schema.py
@@ -1,0 +1,29 @@
+'''schea test for reason API schema'''
+import pytest
+from marshmallow import ValidationError
+from tenable.ad.reason.schema import ReasonSchema
+
+
+@pytest.fixture
+def reason_schema():
+    return {
+        'id': 0,
+        'codename': 'codename',
+        'name': 'some_name',
+        'description': 'some_desc'
+    }
+
+
+def test_reason_schema(reason_schema):
+    test_response = {
+        'id': 0,
+        'codename': 'codename',
+        'name': 'some_name',
+        'description': 'some_desc'
+    }
+    schema = ReasonSchema()
+    for key, value in test_response.items():
+        assert schema.dump(schema.load(reason_schema))[key] == value
+    with pytest.raises(ValidationError):
+        reason_schema['new_val'] = 'something'
+        schema.load(reason_schema)


### PR DESCRIPTION
# Description

Added Tenable AD Reason APIs

Methods:

- Retrieve all reason instances - ``list``
- Get reason instance by id - ``details``
- Retrieve all reason instances that have deviances for a specific profile and checker - ``list_by_checker``
- Retrieve all reason instances for which we have deviances for a specific profile, directory and event - ``list_by_directory_and_event``

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tests added to test all the reason endpoints and their schema.
- [x] Sphinx build for doc

**Test Configuration**:
* Python Version(s) Tested: 3.9.0
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
