### PR TITLE
Added is_termination option that was missing from refactor

### DIFF
--- a/tenable/io/exports/api.py
+++ b/tenable/io/exports/api.py
@@ -218,6 +218,8 @@ class ExportsAPI(APIEndpoint):
                 Assets updated after this timestamp will be returned.
             has_plugin_results (bool, optional):
                 Should assets only be returned if they have plugin results?
+            is_deleted (bool, optional):
+                Should we return only assets that have been deleted?
             is_licensed (bool, optional):
                 Should we return only assets that are licensed?
             is_terminated (bool, optional):

--- a/tenable/io/exports/schema.py
+++ b/tenable/io/exports/schema.py
@@ -34,6 +34,7 @@ class AssetExportSchema(Schema):
 
     # Boolean flags
     has_plugin_results = fields.Bool()
+    is_deleted = fields.Bool()
     is_licensed = fields.Bool()
     is_terminated = fields.Bool()
     servicenow_sysid = fields.Bool()


### PR DESCRIPTION
# Description

Re-introduces the `is_deleted` parameter that was missing from the export API refactor as noted in #521.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
