### PR TITLE
Publish wheel to PyPI

### DIFF
--- a/.github/workflows/master_pipeline.yml
+++ b/.github/workflows/master_pipeline.yml
@@ -105,9 +105,12 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip install wheel
       - name: Build Package
         run: |
-          python setup.py sdist
+          python setup.py sdist bdist_wheel
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.4.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docs/source/tenable*.rst
 /test_certs
 .python-version
 /build
+/dist
 /tests/sc/cassettes/sc_login.yaml-backup
 /tests/sc/cassettes/sc_logout.yaml-backup
 /tests/sc/cassettes/scan_policy.yml-backup

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 3.9',
     ],
     keywords='tenable tenable_io securitycenter containersecurity',
-    packages=find_packages(exclude=['docs', 'tests']),
+    packages=find_packages(exclude=['docs', 'tests', 'tests.*']),
     install_requires=[
         'requests>=2.26',
         'python-dateutil>=2.6',


### PR DESCRIPTION
# Description

Wheels are faster to install then source distributions. 

See also: [Source Distributions vs Wheels](https://packaging.python.org/en/latest/tutorials/installing-packages/?highlight=wheel#source-distributions-vs-wheels).

In this implementation, I'm installing the `wheel` package in the GitHub workflow; an alternative would be to put it in `setup_requires` of `setup.py`.

Also, I removed the `test.*` packages from being included in distributions.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've tried to run the commands of the GitHub workflow locally, and installed in a separated venv the generated wheel.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
