### PR TITLE
Fix regression in TIO: vulnerability export parameters

### DIFF
--- a/tenable/io/exports/api.py
+++ b/tenable/io/exports/api.py
@@ -350,8 +350,8 @@ class ExportsAPI(APIEndpoint):
                 Findings last observed in any state after this timestamp will
                 be returned.  Cannot be used with ``last_found``,
                 ``first_found``, or ``last_fixed``.
-            plugin_family (str, optional):
-                Only return findings from the specified plugin family.
+            plugin_family (list[str], optional):
+                Only return findings from the specified plugin families.
             plugin_id (list[int], optional):
                 Only return findings from the specified plugin ids.
             plugin_type (str, optional):
@@ -395,6 +395,9 @@ class ExportsAPI(APIEndpoint):
             network_id (str, optional):
                 Only findings within the specified network UUID will be
                 returned.
+            cidr_range (str, optional):
+                Restrict the export to only vulns assigned to assets within the
+                CIDR range specified.
             tags (list[tuple[str, str]], optional):
                 A list of tag pairs to filter the results on.  The tag pairs
                 should be presented as ``('CATEGORY', 'VALUE')``.
@@ -403,7 +406,7 @@ class ExportsAPI(APIEndpoint):
                 the results?
             num_assets (int, optional):
                 As findings are grouped by asset, how many assets's findings
-                should exist within each data chunk?  If left unspecifed the
+                should exist within each data chunk?  If left unspecified the
                 default is ``500``.
             uuid (str, optional):
                 A predefined export UUID to use for generating an

--- a/tenable/io/exports/schema.py
+++ b/tenable/io/exports/schema.py
@@ -76,7 +76,7 @@ class VulnExportSchema(Schema):
     since = fields.Int()
 
     # Plugin fields
-    plugin_family = fields.Str()
+    plugin_family = fields.List(fields.Str())
     plugin_id = fields.List(fields.Int())
     plugin_type = fields.Str()
 
@@ -88,6 +88,7 @@ class VulnExportSchema(Schema):
     # Asset fields
     tags = fields.List(fields.Tuple((fields.Str(), fields.Str())))
     network_id = fields.UUID()
+    cidr_range = fields.Str()
     include_unlicensed = fields.Bool()
 
     # Chunking fields

--- a/tests/io/exports/test_schema.py
+++ b/tests/io/exports/test_schema.py
@@ -65,7 +65,7 @@ def vuln_export():
         'indexed_at': 1635798607,
         'last_fixed': 1635798607,
         'since': 1635798607,
-        'plugin_family': 'Family Name',
+        'plugin_family': ['Family Name'],
         'plugin_id': [19506, 21745, 66334],
         'severity': ['CRITICAL', 'High', 'medium', 'LoW', 'InfO'],
         'state': ['OPENED', 'reopened', 'Fixed'],
@@ -84,6 +84,7 @@ def vuln_export():
             ('test3', 'val4')
         ],
         'network_id': 'f634d639-cc33-4149-a683-5ad6b8f29d9c',
+        'cidr_range': '192.0.2.0/24',
         'include_unlicensed': True,
     }
 
@@ -157,7 +158,7 @@ def test_vulnerabilityschema(vuln_export):
             'indexed_at': 1635798607,
             'last_fixed': 1635798607,
             'since': 1635798607,
-            'plugin_family': 'Family Name',
+            'plugin_family': ['Family Name'],
             'plugin_id': [19506, 21745, 66334],
             'severity': ['critical', 'high', 'medium', 'low', 'info'],
             'state': ['opened', 'reopened', 'fixed'],
@@ -170,6 +171,7 @@ def test_vulnerabilityschema(vuln_export):
                 'lte': 0.4
             },
             'network_id': 'f634d639-cc33-4149-a683-5ad6b8f29d9c',
+            'cidr_range': '192.0.2.0/24',
             'tag.test1': ['val1'],
             'tag.test2': ['val2'],
             'tag.test3': ['val3', 'val4']


### PR DESCRIPTION
# Description

This PR fixes the following two points on TIO vulnerability exports parameters:
 - `plugin_family`: expected a list of string, not a string
 - `cidr_range`: was missing

[Link to the API doc for reference](https://developer.tenable.com/reference/exports-vulns-request-export)

I believe the regression was introduced in a0e0d7ce409704001fc893d9a646e305d19eddf0 (ping @SteveMcGrath)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Against live TIO.

**Test Configuration**:
* Python Version(s) Tested: Python 3.10

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
