### PR TITLE
Allow specfiying agent uuids for bulk group add

### DIFF
--- a/tenable/io/agent_groups.py
+++ b/tenable/io/agent_groups.py
@@ -23,7 +23,7 @@ class AgentGroupsAPI(TIOEndpoint):
 
         Args:
             group_id (int): The id of the group
-            *agent_ids (int): The id of the agent
+            *agent_ids (int): The id or uuid of the agent.  If passing multiple, they must all be either numeric id or uuid.
             scanner_id (int, optional): The id of the scanner
 
         Returns:
@@ -40,6 +40,10 @@ class AgentGroupsAPI(TIOEndpoint):
             Adding multiple agents:
 
             >>> tio.agent_groups.add_agent(1, 1, 2, 3)
+
+            Adding multiple agents by uuid:
+
+            >>> tio.agent_groups.add_agent(1, 'uuid-1', 'uuid-2', 'uuid-3')
         '''
         scanner_id = 1
         if 'scanner_id' in kw:

--- a/tenable/io/agent_groups.py
+++ b/tenable/io/agent_groups.py
@@ -53,7 +53,7 @@ class AgentGroupsAPI(TIOEndpoint):
             self._api.put('scanners/{}/agent-groups/{}/agents/{}'.format(
                 self._check('scanner_id', scanner_id, int),
                 self._check('group_id', group_id, int),
-                self._check('agent_id', agent_ids[0], str if useUuids else int)
+                self._check('agent_id', agent_ids[0], 'uuid' if useUuids else int)
             ))
         else:
             # If there are many agent_ids, then we will want to perform a bulk
@@ -62,7 +62,7 @@ class AgentGroupsAPI(TIOEndpoint):
                 'scanners/{}/agent-groups/{}/agents/_bulk/add'.format(
                     self._check('scanner_id', scanner_id, int),
                     self._check('group_id', group_id, int)),
-                json={'items': [self._check('agent_id', i, str if useUuids else int) for i in agent_ids]}).json()
+                json={'items': [self._check('agent_id', i, 'uuid' if useUuids else int) for i in agent_ids]}).json()
 
     def configure(self, group_id, name, scanner_id=1):
         '''

--- a/tenable/io/agent_groups.py
+++ b/tenable/io/agent_groups.py
@@ -45,12 +45,15 @@ class AgentGroupsAPI(TIOEndpoint):
         if 'scanner_id' in kw:
             scanner_id = kw['scanner_id']
 
+        # we can handle either ids or uuids as the list of items.
+        useUuids = len(agent_ids) > 0 and isinstance(agent_ids[0], str)
+
         if len(agent_ids) <= 1:
             # if there is only 1 agent id, we will perform a singular add.
             self._api.put('scanners/{}/agent-groups/{}/agents/{}'.format(
                 self._check('scanner_id', scanner_id, int),
                 self._check('group_id', group_id, int),
-                self._check('agent_id', agent_ids[0], int)
+                self._check('agent_id', agent_ids[0], str if useUuids else int)
             ))
         else:
             # If there are many agent_ids, then we will want to perform a bulk
@@ -59,7 +62,7 @@ class AgentGroupsAPI(TIOEndpoint):
                 'scanners/{}/agent-groups/{}/agents/_bulk/add'.format(
                     self._check('scanner_id', scanner_id, int),
                     self._check('group_id', group_id, int)),
-                json={'items': [self._check('agent_id', i, int) for i in agent_ids]}).json()
+                json={'items': [self._check('agent_id', i, str if useUuids else int) for i in agent_ids]}).json()
 
     def configure(self, group_id, name, scanner_id=1):
         '''

--- a/tests/io/test_agent_groups.py
+++ b/tests/io/test_agent_groups.py
@@ -42,8 +42,16 @@ def test_agentgroups_add_agent_to_group_agent_id_typeerror(api):
     '''
     test to raise the exception when type of agent_id is not as defined
     '''
-    with pytest.raises(TypeError):
+    with pytest.raises(UnexpectedValueError):
         api.agent_groups.add_agent(1, 'nope')
+
+@pytest.mark.vcr()
+def test_agentgroups_add_agent_to_group_mixed_ids_typeerror(api):
+    '''
+    test to raise the exception when type of multiple passed ids don't match each other
+    '''
+    with pytest.raises(TypeError):
+        api.agent_groups.add_agent(1, '64e1cc37-4d6a-4a36-a2d3-aca300735829', 2)
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
# Description
This allows specifying Agent UUIDs instead of numeric IDs for bulk group addition.

Fixes #607

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
- [x] Tested single id
- [x] Tested single uuid
- [x] Tested multiple ids
- [x] Tested multiple uuids
- [x] Tested mix of id and uuid (fails)

**Test Configuration**:
* Python Version(s) Tested: 3.9.7
* Tenable.sc version (if necessary): N/A

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
