### PR TITLE
Added support for Python 3.11

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ Welcome to pyTenable's documentation!
    :target: https://github.com/tenable/pyTenable/actions
 .. image:: https://img.shields.io/pypi/v/pytenable.svg
    :target: https://pypi.org/project/pyTenable/
-.. image:: https://img.shields.io/badge/python-3.7%203.8%203.9-blue
+.. image:: https://img.shields.io/badge/python-3.7%203.8%203.9%203.10%203.11-blue
    :target: https://pypi.org/project/pyTenable/
 .. image:: https://img.shields.io/pypi/dm/pytenable
    :target: https://github.com/tenable/pytenable


### PR DESCRIPTION
# Description

Added support for Python 3.11. For this, version 3.11 was added to the Python Version Matrix in the testing workflow. 

Fixes #672

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update
- [x] This change adds support to a new Python Version

# How Has This Been Tested?

Automated tests ran with Python Version 3.11

**Test Configuration**:
* Python Version(s) Tested: 3.7, 8, 9, 10, 11
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
