### PR TITLE
Starting with SC6, the scanID is now requires both in the base reques…

### DIFF
--- a/tenable/sc/analysis.py
+++ b/tenable/sc/analysis.py
@@ -176,6 +176,9 @@ class AnalysisAPI(SCEndpoint):
             pages = self._check('pages', kw['pages'], int)
 
         if payload.get('sourceType') in ['individual']:
+            payload['query']['scanID'] = self._check(
+                'scan_id', kw.get('scan_id'), int
+            )
             payload['query']['view'] = self._check(
                 'view', kw.get('view', 'all'), str,
                 choices=['all', 'new', 'patched'], default='all')


### PR DESCRIPTION
…t as well as within the query #673

# Description

SC 6.0's Analysis API had changed to start requiring the scanID attribute within the query object as well as within the base request (as was previously only required).  This change will apply the parameter into both locations.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

# Example Test:

Expected: **StopIteration**

Actual:

```python
>>> sc.analysis.scan(25677, ('ip', '=', '10.238.64.0/24')).next()
DEBUG:tenable.sc.TenableSC:Request: {"method": "POST", "url": "https://sc.tenalab.online/rest/analysis", "params": {}, "body": {"type": "vuln", "sourceType": "individual", "scanID": 25677, "query": {"tool": "vulndetails", "type": "vuln", "filters": [{"filterName": "ip", "operator": "=", "value": "10.238.64.0/24"}], "scanID": 25677, "view
": "all", "startOffset": 0, "endOffset": 1000}}}
DEBUG:urllib3.connectionpool:https://sc.tenalab.online:443 "POST /rest/analysis HTTP/1.1" 200 220
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    sc.analysis.scan(25677, ('ip', '=', '10.238.64.0/24')).next()
  File "/Users/steve/Dropbox/Repositories/python_modules/pytenable/tenable/base/v1.py", line 93, in next
    raise StopIteration()
StopIteration
>>>
```