### PR TITLE
Deprecation of T.io V3 Explore APIs

### DIFF
--- a/tenable/io/v3/__init__.py
+++ b/tenable/io/v3/__init__.py
@@ -17,6 +17,8 @@ Methods available on ``tio.v3``:
     explore/index
     access_control
 """
+import warnings
+
 from tenable.base.endpoint import APIEndpoint
 from tenable.io.v3.access_control import AccessControlAPI
 from tenable.io.v3.explore import Explore
@@ -30,9 +32,12 @@ class Version3API(APIEndpoint):
     @property
     def explore(self):
         """
+        Tenable.io V3 Explore APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
         The interface object for the
          :doc:`Tenable.io v3 explore <explore/index>`
         """
+        warnings.warn("Tenable.io V3 Explore APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.",
+                      DeprecationWarning, 2)
         return Explore(self._api)
 
     @property

--- a/tenable/io/v3/explore/__init__.py
+++ b/tenable/io/v3/explore/__init__.py
@@ -26,13 +26,13 @@ from tenable.io.v3.explore.findings.api import FindingsAPI
 
 class Explore(ExploreBaseEndpoint):
     '''
-    This class will contain property for all resources under Explore  i.e. assets, findings etc.
+    Tenable.io V3 Explore APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
     '''
 
     @property
     def assets(self):
         """
-        The interface object for the Assets APIs
+        Tenable.io Assets V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
         :doc:`Tenable.io v3 explore assets APIs <assets>`.
         """
         return AssetsAPI(self._api)
@@ -40,7 +40,7 @@ class Explore(ExploreBaseEndpoint):
     @property
     def findings(self):
         """
-        The interface object for the Findings APIs
+        Tenable.io Findings V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
         :doc:`Tenable.io v3 explore findings APIs <findings>`.
         """
         return FindingsAPI(self._api)

--- a/tenable/io/v3/explore/assets/api.py
+++ b/tenable/io/v3/explore/assets/api.py
@@ -21,6 +21,8 @@ from tenable.io.v3.base.iterators.explore_iterator import (CSVChunkIterator, Sea
 
 class AssetsAPI(ExploreBaseEndpoint):
     '''
+    Tenable.io Assets V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
     This will contain methods related to Explore -> Assets V3 API endpoints.
     '''
     _path = 'api/v3/assets'
@@ -28,6 +30,8 @@ class AssetsAPI(ExploreBaseEndpoint):
 
     def search_webapp(self, **kw) -> Union[SearchIterator, CSVChunkIterator, Response]:
         '''
+        Tenable.io Assets V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
         Retrieves the WAS assets.
 
         Args:
@@ -102,6 +106,8 @@ class AssetsAPI(ExploreBaseEndpoint):
 
     def search_host(self, **kw) -> Union[SearchIterator, CSVChunkIterator, Response]:
         '''
+        Tenable.io Assets V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
         Retrieves the host assets.
 
         Args:
@@ -176,6 +182,8 @@ class AssetsAPI(ExploreBaseEndpoint):
 
     def search_cloud_resource(self, **kw) -> Union[SearchIterator, CSVChunkIterator, Response]:
         '''
+        Tenable.io Assets V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
         Retrieves the cloud resource assets.
 
         Args:
@@ -250,6 +258,8 @@ class AssetsAPI(ExploreBaseEndpoint):
 
     def search_all(self, **kw) -> Union[SearchIterator, CSVChunkIterator, Response]:
         '''
+        Tenable.io Assets V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
         Retrieves all the assets.
 
         Args:

--- a/tenable/io/v3/explore/findings/api.py
+++ b/tenable/io/v3/explore/findings/api.py
@@ -22,6 +22,8 @@ from tenable.io.v3.base.iterators.explore_iterator import (CSVChunkIterator,
 
 class FindingsAPI(ExploreBaseEndpoint):
     '''
+    Tenable.io Findings V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
     API class containing all the methods related to Findings.
     '''
     _path = 'api/v3/findings/vulnerabilities'
@@ -31,6 +33,8 @@ class FindingsAPI(ExploreBaseEndpoint):
                       **kw
                       ) -> Union[SearchIterator, CSVChunkIterator, Response]:
         '''
+        Tenable.io Findings V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
         Search and retrieve the WAS Vulnerabilities based on supported conditions.
         Args:
             fields (list, optional):
@@ -109,6 +113,8 @@ class FindingsAPI(ExploreBaseEndpoint):
                      **kw
                      ) -> Union[SearchIterator, CSVChunkIterator, Response]:
         '''
+        Tenable.io Findings V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
         Search and retrieve the Cloud Resource Vulnerabilities based on supported conditions.
         Args:
             fields (list, optional):
@@ -187,6 +193,8 @@ class FindingsAPI(ExploreBaseEndpoint):
                     **kw
                     ) -> Union[SearchIterator, CSVChunkIterator, Response]:
         '''
+        Tenable.io Findings V3 APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
+
         Search and retrieve the Host Vulnerabilities based on supported conditions.
         Args:
             fields (list, optional):


### PR DESCRIPTION
# Description

This PR adds deprecation warnings, and updates documentation to announce the deprecation of V3 Explore APIs in T.io

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

After adding the deprecation warnings, it was ensured that the warning message is seen on the console when any method inside `tio.v3.explore` property is called.

For example, for the following snippet, 
```python

from tenable.io import TenableIO

tio = TenableIO(access_key="REDACTED", secret_key="REDACTED")
resp = tio.v3.explore.assets.search_all()

```

.. the following warning was displayed on the console.

```
/Users/asavio/Documents/Codebases/pyTenable/pyTenable/playground.py:4: DeprecationWarning: Tenable.io V3 Explore APIs are deprecated. We recommend that you use the equivalent V2 APIs instead.
  resp = tio.v3.explore.assets.search_all()
```

**Test Configuration**:
* Python Version(s) Tested:
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
