### PR TITLE
Added source and severity_modification_type filters to vm export

### DIFF
--- a/tenable/io/exports/api.py
+++ b/tenable/io/exports/api.py
@@ -399,6 +399,10 @@ class ExportsAPI(APIEndpoint):
                 Only return findings with the specified plugin type.
             scan_uuid (uuid, optional):
                 Only return findings with the specified scan UUID.
+            source (list[str], optional):
+                Only return vulnerabilities for assets that have the specified asset source.
+            severity_modification_type (list[str], optional):
+                Only return vulnerabilities with the specified severity modification type.
             severity (list[str], optional):
                 Only return findings with the specified severities.
             state (list[str], optional):

--- a/tenable/io/exports/api.py
+++ b/tenable/io/exports/api.py
@@ -400,7 +400,7 @@ class ExportsAPI(APIEndpoint):
             scan_uuid (uuid, optional):
                 Only return findings with the specified scan UUID.
             source (list[str], optional):
-                Only return vulnerabilities for assets that have the specified asset source.
+                Only return vulnerabilities for assets that have the specified scan source.
             severity_modification_type (list[str], optional):
                 Only return vulnerabilities with the specified severity modification type.
             severity (list[str], optional):

--- a/tenable/io/exports/schema.py
+++ b/tenable/io/exports/schema.py
@@ -86,6 +86,8 @@ class VulnExportSchema(Schema):
     state = fields.List(LowerCase(fields.Str()))
     vpr_score = fields.Nested(VPRSchema())
     scan_uuid = fields.Str()
+    source = fields.List(fields.Str())
+    severity_modification_type = fields.List(fields.Str())
 
     # Asset fields
     tags = fields.List(fields.Tuple((fields.Str(), fields.Str())))


### PR DESCRIPTION
# Description

Added the `source` and `severity_modification_type` filters to vm export.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] This was tested locally.

The following code resulted in the request that follows it.
```
vulns = tio.exports.vulns(
        num_assets=5000,
        since=1699700761,
        source=[
            "NESSUS"
        ],
        severity_modification_type=[
            "ACCEPTED"
        ]
    )
```

Request JSON:
```
{
  "num_assets": 5000,
  "filters": {
    "since": 1699700761,
    "severity_modification_type": [
      "ACCEPTED"
    ],
    "source": [
      "NESSUS"
    ]
  }
}}
```

And, documentation has been successfully generated.
<img width="874" alt="image" src="https://github.com/tenable/pyTenable/assets/14077275/1bb91dde-850c-4fd0-ac47-23b0d747e905">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
