### PR TITLE
Support for SC 6.3.0

### DIFF
--- a/tenable/sc/policies.py
+++ b/tenable/sc/policies.py
@@ -40,11 +40,9 @@ class ScanPolicyAPI(SCEndpoint):
             self._check('tags', kw['tags'], str)
 
         if 'preferences' in kw:
-            # Validate that all of the preferences are K:V pairs of strings.
+            # The values of the preferences K:V pairs can now be any data type..
             for key in self._check('preferences', kw['preferences'], dict):
                 self._check('preference:{}'.format(key), key, str)
-                self._check('preference:{}:value'.format(key),
-                    kw['preferences'][key], str)
 
         if 'audit_files' in kw:
             # unflatten the audit_files list into a list of dictionaries.

--- a/tenable/sc/scans.py
+++ b/tenable/sc/scans.py
@@ -24,6 +24,11 @@ class ScanAPI(SCEndpoint):
         '''
         Handles parsing the keywords and returns a scan definition document
         '''
+        if 'inactivity_timeout' in kw:
+            kw['inactivityTimeout'] = str(self._check(
+                'inactivity_timeout', kw['inactivity_timeout'], int, default=3600))
+            del (kw['inactivity_timeout'])
+
         if 'name' in kw:
             # simply verify that the name attribute is a string.
             self._check('name', kw['name'], str)
@@ -260,6 +265,8 @@ class ScanAPI(SCEndpoint):
             vhosts (bool, optional):
                 Should virtual host logic be enabled for the scan?  The default
                 is ``False``.
+            inactivity_timeout (int):
+                Inactivity Timeout in seconds. The value should be between 3600 and 432000.
 
         Returns:
             :obj:`dict`:

--- a/tests/sc/test_policies.py
+++ b/tests/sc/test_policies.py
@@ -85,13 +85,11 @@ def test_policies_constructor_preference_item_name_typeerror(security_center):
         security_center.policies._constructor(preferences={1: 'value'})
 
 
-def test_policies_constructor_preference_item_value_typeerror(security_center):
+def test_policies_constructor_preference_item_value_should_not_typeerror(security_center):
     '''
     test policies constructor for 'item value' type error
     '''
-    with pytest.raises(TypeError):
-        security_center.policies._constructor(preferences={'name': 1})
-
+    security_center.policies._constructor(preferences={'name': 1})
 
 def test_policies_constructor_audit_files_typeerror(security_center):
     '''

--- a/tests/sc/test_scans.py
+++ b/tests/sc/test_scans.py
@@ -145,6 +145,20 @@ def test_scans_constructor_timeout_typeerror(security_center):
     with pytest.raises(TypeError):
         security_center.scans._constructor(timeout=1)
 
+def test_scans_constructor_inactivity_timeout(security_center):
+    """
+    Tests inactivity_timeout is mapped correctly in the constructor.
+    """
+    scan_params = {
+        "inactivity_timeout": 3600,
+        "policy_id": 1000001
+    }
+
+    scan = security_center.scans._constructor(**scan_params)
+
+    assert "inactivity_timeout" not in scan
+    assert scan["inactivityTimeout"] == "3600"
+
 
 def test_scans_constructor_timeout_unexpectedvalueerror(security_center):
     '''


### PR DESCRIPTION
# Description

This PR includes:
1. Loosened up validations on the preference object in SC policies API.
2. Added support for `inactivity_timeout` during an SC scan creation.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Check test cases in PR

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
