### PR TITLE
Implicit WAS exclude (backwards compat)

### DIFF
--- a/tenable/sc/analysis.py
+++ b/tenable/sc/analysis.py
@@ -330,6 +330,19 @@ class AnalysisAPI(SCEndpoint):
         if 'scan_id' in kw:
             payload['sourceType'] = 'individual'
             payload['scanID'] = kw['scan_id']
+        else:
+            # If the request is for a cumulative result, then we will an
+            # implicit filter to exclude WAS findings.
+            incl_filter = True
+            for f in filters:
+                if (
+                    (isinstance(f, tuple) and f[0] == 'wasVuln')
+                    or (isinstance(f, dict) and f['filterName'] == 'wasVuln')
+                ):
+                    incl_filter = False
+            if incl_filter:
+                filters = list(filters)
+                filters.append(('wasVuln', '=', 'excludeWas'))
 
         kw['payload'] = payload
         kw['type'] = 'vuln'

--- a/tenable/sc/analysis.py
+++ b/tenable/sc/analysis.py
@@ -248,7 +248,8 @@ class AnalysisAPI(SCEndpoint):
                 ``sumfamily``, ``sumiavm``, ``sumid``, ``sumip``,
                 ``summsbulletin``, ``sumprotocol``, ``sumremediation``,
                 ``sumseverity``, ``sumuserresponsibility``, ``sumport``,
-                ``trend``, ``vulndetails``, ``vulnipdetail``, ``vulnipsummary``
+                ``trend``, ``vulndetails``, ``vulnipdetail``, ``vulnipsummary``,
+                ``sumwasurl``, ``wasvulndetail``, ``waslistvuln``
 
         Returns:
             :obj:`AnalysisResultsIterator`:
@@ -323,6 +324,9 @@ class AnalysisAPI(SCEndpoint):
                 'vulndetails',
                 'vulnipdetail',
                 'vulnipsummary',
+                'sumwasurl',        # Undocumented in 6.3.x
+                'wasvulndetail',    # Undocumented in 6.3.x
+                'waslistvuln',      # Undocumented in 6.3.x
             ], case='lower')
         else:
             kw['tool'] = 'vulndetails'


### PR DESCRIPTION
# Description

Adds implicit WAS data exclusion filter to TSC analysis calls when querying non-individual vuln data.  This should salve for backwards compatability issues with TSC 6.2.x and later.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Manual testing of the implicit filter inclusion.

**Test Configuration**:
* Python Version(s) Tested: 3.9.9
* Tenable.sc version (if necessary): 6.3.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
