### PR TITLE
Updated SC Files method as per #762

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-box>=4.0
 defusedxml>=0.5.0
 urllib3==1.26.18
 typing-extensions>=3.10.0.2
+requests-toolbelt==1.0.0

--- a/setup.py
+++ b/setup.py
@@ -48,5 +48,6 @@ setup(
         'urllib3>=1.26.18',
         'typing-extensions>=4.0.1',
         'dataclasses>=0.8;python_version=="3.6"',
+        'requests-toolbelt>=1.0.0'
     ],
 )

--- a/tenable/sc/files.py
+++ b/tenable/sc/files.py
@@ -11,9 +11,13 @@ Methods available on ``sc.files``:
 .. autoclass:: FileAPI
     :members:
 '''
+from requests_toolbelt.multipart.encoder import MultipartEncoder
 from .base import SCEndpoint
 
 class FileAPI(SCEndpoint):
+    _path = 'file'
+    _box = True
+
     def upload(self, fobj):
         '''
         Uploads a file into SecurityCenter and returns the file identifier
@@ -29,8 +33,11 @@ class FileAPI(SCEndpoint):
                 The filename identifier to use for subsequent calls in
                 Tenable Security Center.
         '''
-        return self._api.post('file/upload', files={
-            'Filedata': fobj}).json()['response']['filename']
+        encoder = MultipartEncoder({'Filedata': ('filedata', fobj)})
+        return self._post('upload',
+                          data=encoder,
+                          headers={'Content-Type': encoder.content_type}
+                          ).response.filename
 
     def clear(self, filename):
         '''
@@ -45,6 +52,6 @@ class FileAPI(SCEndpoint):
             :obj:`str`:
                 The file location on disk that was removed.
         '''
-        return self._api.post('file/clear', json={
-            'filename': self._check('filename', filename, str)
-        }).json()['response']['filename']
+        return self._post('clear',
+                          json={'filename': filename}
+                          ).response.filename

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -18,3 +18,4 @@ docker>=3.7.2
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.31.0 # not directly required, pinned by Snyk to avoid a vulnerability
 black>=24.3.0 # not directly required, pinned by Snyk to avoid a vulnerability
+requests-toolbelt==1.0.0

--- a/tests/sc/cassettes/sc_login.yaml
+++ b/tests/sc/cassettes/sc_login.yaml
@@ -14,7 +14,7 @@ interactions:
       "enabled":"true","attributeSets":[]},{"name":"CSV","type":"csv","enabled":"true","attributeSets":[]},
       {"name":"RTF","type":"rtf","enabled":"true","attributeSets":[]},{"name":"DISA ARF","type":"arf","enabled":"false",
       "attributeSets":["arf"]},{"name":"DISA ASR","type":"asr","enabled":"false","attributeSets":[]},
-      {"name":"CyberScope","type":"lasr","enabled":"true","attributeSets":["lasr"]}],"version":"5.8.0",
+      {"name":"CyberScope","type":"lasr","enabled":"true","attributeSets":["lasr"]}],"version":"6.4.0",
       "buildID":"201810303290","banner":"","releaseID":"201810303290","uuid":"3ae050e2-486c-5c1a-a6a5-45305557cec3",
       "logo":"assets\/mariana\/images\/sc4icon.png","serverAuth":"any","serverClassification":"None",
       "sessionTimeout":"3600","licenseStatus":"Valid","ACAS":"false","freshInstall":"no","headerText":"",

--- a/tests/sc/conftest.py
+++ b/tests/sc/conftest.py
@@ -2,7 +2,7 @@
 configuration which would be used for testing sc.
 '''
 import os
-
+import responses
 import pytest
 
 from tenable.errors import APIError, NotFoundError
@@ -112,3 +112,18 @@ def group(request, security_center, vcr):
 
     request.addfinalizer(teardown)
     return grp
+
+
+@pytest.fixture
+def tsc():
+    with responses.RequestsMock() as rsps:
+        rsps.get('https://nourl/rest/system',
+                 json={
+                    'error_code': None,
+                    'response': {'version': '6.4.0'}
+                 }
+                 )
+        return TenableSC(url='https://nourl',
+                         access_key='SOMETHING',
+                         secret_key='SECRET'
+                         )

--- a/tests/sc/test_files.py
+++ b/tests/sc/test_files.py
@@ -1,18 +1,33 @@
 '''
 test file for testing various scenarios in file functionality
 '''
-import os
-
+from io import BytesIO
+import responses
+from responses.matchers import json_params_matcher
 import pytest
 
 
-@pytest.mark.vcr()
-def test_files_upload_clear_success(security_center):
-    '''
-    test files upload and clear for success
-    '''
-    with open('1000003.xml', 'w+') as file:
-        response = security_center.files.upload(fobj=file)
-        filename = security_center.files.clear(response)
-        assert filename == 'filename'
-    os.remove('1000003.xml')
+@responses.activate
+def test_files_upload(tsc):
+    fake = BytesIO(b'Test File')
+    responses.post('https://nourl/rest/file/upload',
+                   json={
+                       'error_code': 0,
+                       'response': {'filename': 'something'}
+                   },
+                   )
+
+    assert 'something' == tsc.files.upload(fake)
+
+@responses.activate
+def test_files_clear(tsc):
+    responses.post('https://nourl/rest/file/delete',
+                   match=[
+                       json_params_matcher({'filename': 'testfile'})
+                   ],
+                   json={
+                       'error_code': 0,
+                       'response': {'filename': 'testfile'}
+                   }
+                   )
+    assert 'testfile' == tsc.files.clear('testfile')


### PR DESCRIPTION
# Description

Addresses the 2G limitation that seems to occur with the file upload API.  This converts the method from loading the entire file into memory to streaming the file to the remote API.

Fixes #762

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested by uploading the tarball to a test environment && checking memory usage.

**Test Configuration**:
* Python Version(s) Tested: 3.9.9
* Tenable.sc version (if necessary): 6.3.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
