### PR TITLE
Refactored to support paginated audit log api. #770

### DIFF
--- a/tenable/io/audit_log.py
+++ b/tenable/io/audit_log.py
@@ -2,8 +2,8 @@
 Audit Log
 =========
 
-The following methods allow for interaction into the Tenable Vulnerability Management
-:devportal:`audit log <audit-log>` API endpoints.
+The following methods allow for interaction into the Tenable Vulnerability
+Management :devportal:`audit log <audit-log>` API endpoints.
 
 Methods available on ``io.audit_log``:
 
@@ -11,10 +11,48 @@ Methods available on ``io.audit_log``:
 .. autoclass:: AuditLogAPI
     :members:
 '''
+from typing_extensions import Literal
+from typing import Tuple, Optional, Dict
+from copy import copy
 from .base import TIOEndpoint
+from restfly.iterator import APIIterator
+
+
+class AuditLogIterator(APIIterator):
+    '''
+    AuditLog Iterator
+    '''
+    _next_token: str = None
+    _payload: Dict
+
+    def _get_page(self) -> None:
+        '''
+        Request the next page of data
+        '''
+        payload = copy(self._payload)
+        print(self._next_token)
+        payload['next'] = self._next_token
+
+        if self.num_pages >= 1 and self._next_token is None:
+            raise StopIteration()
+        resp = self._api.get('audit-log/v1/events', params=payload, box=True)
+        self._next_token = resp.pagination.get('next')
+        self.page = resp.events
+        self.total = resp.pagination.total
+
 
 class AuditLogAPI(TIOEndpoint):
-    def events(self, *filters, **kw):
+    _box = True
+    _path = 'audit-log/v1/events'
+
+    def events(self,
+               *filters: Tuple[str, str, str],
+               limit: int = 1000,
+               filter_type: Literal['and', 'or'] = 'and',
+               sort: Optional[str] = None,
+               token: Optional[str] = '0',
+               return_json: bool = False
+               ):
         '''
         Retrieve audit logs from Tenable Vulnerability Management.
 
@@ -29,27 +67,49 @@ class AuditLogAPI(TIOEndpoint):
 
                 - ``('date', 'gt', '2017-07-05')``
                 - ``('date', 'lt', '2017-07-07')``
-                - ``('actor_id', 'match', '6000a811-8422-4096-83d3-e4d44f44b97d')``
-                - ``('target_id', 'match', '6000a811-8422-4096-83d3-e4d44f44b97d')``
+                - ``('actor_id', 'match', '6000a811-8422-4096-83d3-e4d44f7d')``
+                - ``('target_id', 'match', '6000a811-8422-4096-83d3-e4d447d')``
 
             limit (int, optional):
-                The limit of how many events to return.  The API will default to
-                50 unless otherwise specified.
+                The limit of how many events to return.  The API will default
+                to 50 unless otherwise specified.
+
+            filter_type (str, optional):
+                if multiple filters are present, how should we combine the
+                filters?  Supported values are `and` or `or`.  If left
+                unspecified, the default is `and`.
+
+            sort (str, optional):
+                Should any soerting be performed on the resulting data?  The
+                format is `FIELD_NAME:DIRECTION`.  For example, supplying
+                `received:desc` would sort the results by the received field in
+                descencing order.
+
+            token (str, optional):
+                The `next` token to request the next page.
+
+            return_json (bool, optional):
+                Should we return the JSON response instead of iterable?
 
         Returns:
-            :obj:`list`:
+            :obj:`AuditLogIterator`:
                 List of event records
 
         Examples:
-            >>> events = tio.audit_log.events(
-            ...     ('date', 'gt', '2018-01-01'), limit=100)
+            >>> events = tio.audit_log.events(('date', 'gt', '2018-01-01'))
             >>> for e in events:
             ...     pprint(e)
         '''
-        return self._api.get('audit-log/v1/events', params={
-            'f': ['{}.{}:{}'.format(
-                self._check('filter_field_name', f[0], str),
-                self._check('filter_operator', f[1], str),
-                self._check('filter_value', f[2], str)) for f in filters],
-            'limit': self._check('limit', kw['limit'], int) if 'limit' in kw else 50
-        }).json()['events']
+        payload = {
+            'f': [f'{f[0]}.{f[1]}:{f[2]}' for f in filters],
+            'ft': filter_type,
+            'limit': limit,
+            'next': token,
+            'sort': sort
+        }
+        if return_json:
+            return self._get(params=payload)
+        return AuditLogIterator(self._api,
+                                _payload=payload,
+                                _next_token=token
+                                )


### PR DESCRIPTION
# Description

Adds pagination support and an iterable to handle the pagination needs for the updated audit log events API.

Fixes #770

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested against a live environment to ensure the new iterable worked as expected,.

**Test Configuration**:
* Python Version(s) Tested: 3.10.3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
