### PR TITLE
Corrected empty lists being returned instead of none for uniqued lists

### DIFF
--- a/tenable/io/sync/models/common.py
+++ b/tenable/io/sync/models/common.py
@@ -91,7 +91,9 @@ def upper_if_exist(value: Any, default=None) -> Any:
 
 
 UpperCaseStr = BeforeValidator(lambda v: str(v).upper() if v else None)
-UniqueListSerializer = PlainSerializer(lambda v: list(set(v)))
+UniqueListSerializer = PlainSerializer(
+    lambda v: list(set(v)) if v and len(v) > 0 else None
+)
 TruncListValidator = WrapValidator(trunc_list)
 
 intpos = Annotated[int, Field(gt=0)]

--- a/tenable/version.py
+++ b/tenable/version.py
@@ -1,2 +1,2 @@
-version = "1.7.0"
+version = "1.7.1"
 version_info = tuple(int(d) for d in version.split("-")[0].split("."))


### PR DESCRIPTION
# Description

Sync API datamodels use a lambda-based serializer for unique lists that created empty lists in the output models when
they are unsupported upstream.  This simple fix corrects that.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```python
❯ ptpython
>>> test = lambda v: list(set(v)) if v and len(v) > 0 else None
>>> test([1, 2, 3, 3, 4, 5, 6, 7])
[1, 2, 3, 4, 5, 6, 7]
>>> test([])
>>>
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
