### PR TITLE
Added metadata change field to default response

### DIFF
--- a/tenable/asm/inventory.py
+++ b/tenable/asm/inventory.py
@@ -99,6 +99,7 @@ class InventoryAPI(APIEndpoint):
                 'bd.addedtoportfolio',
                 'bd.smartfolders',
                 'bd.app_updates',
+                'bd.last_metadata_change',
                 'ports.ports',
                 'screenshot.redirect_chain',
                 'screenshot.finalurl',


### PR DESCRIPTION
# Description

Adds additional field `bd.last_metadata_change` to the default response for the inventory result.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
