### PR TITLE
checking if arg is "unlimited" for max_time because api waiting unlim…

### DIFF
--- a/tenable/sc/scans.py
+++ b/tenable/sc/scans.py
@@ -138,11 +138,13 @@ class ScanAPI(SCEndpoint):
             del kw["targets"]
 
         if "max_time" in kw:
-            # maxScanTime is a integer encased in a string value.  the snake
-            # cased version of that expects an integer and converts it into the
-            # string equivalent.
-            max_time = int(kw.pop("max_time", None))
-            kw["maxScanTime"] = str(max_time)
+            # Handle the maxScanTime parameter, which expects a string in API
+            # representing either a number or "unlimited"
+            # keep unlimited because details get "unlimited" not 0 or -
+            max_time_val = kw.pop("max_time")
+            kw["maxScanTime"] = (
+                "unlimited" if max_time_val == "unlimited" 
+                else str(int(max_time_val)))
 
         if "auto_mitigation" in kw:
             # As classifyMitigatedAge is effectively a string interpretation of


### PR DESCRIPTION
# Description

    This change improves the handling of the max_time parameter in scan configuration.
    
    Previously, the value was blindly casted to int, which caused errors when using the "unlimited" string (a valid value returned by scan details export).
    Now, the code properly supports the "unlimited" keyword alongside numerical values.

## Type of change

    Bug fix (non-breaking change which fixes an issue)

## Motivation and Context

    Tenable.sc scan configurations can return "unlimited" as a string for maxScanTime.
    The previous implementation casted all values to int, which broke compatibility and raised exceptions.
    This change keeps "unlimited" as-is, while still converting numerical values to the expected string format.
# How Has This Been Tested?
Tests Performed:
  
    Scan creation with max_time="unlimited" → ✅ accepted
    
    Scan creation with max_time=60 → ✅ accepted and converted to string
    
    Scan creation with max_time=0 → ❌ properly rejected by Tenable as expected

Test Configuration:

    Python Version(s) Tested: 3.11