### PR TITLE
Improve OTGraphIterator error handling

### DIFF
--- a/tenable/base/schema/fields.py
+++ b/tenable/base/schema/fields.py
@@ -44,3 +44,16 @@ class UpperCase(BaseField):
         if hasattr(value, 'upper'):
             value = value.upper()
         return super()._deserialize(value, *args, **kwargs)
+
+
+class ForcedStr(fields.Str):
+    '''
+    The field value will be converted to a string.
+    '''
+
+    def _deserialize(self, value, attr, data, **kwargs):
+        try:
+            value = str(value)
+        except Exception:
+            pass
+        return super()._deserialize(value, attr, data, **kwargs)

--- a/tenable/ot/graphql/definitions.py
+++ b/tenable/ot/graphql/definitions.py
@@ -81,12 +81,25 @@ class Location:
 
 
 @dataclass
+class ExtensionException:
+    """
+    This class holds the exception part of the error extensions.
+    """
+
+    message: str
+    type: Optional[str]
+    errno: Optional[str]
+    code: Optional[str]
+
+
+@dataclass
 class Extension:
     """
     This class holds the extensions part of the error.
     """
 
     code: Optional[str] = None
+    exception: Optional[ExtensionException] = None
 
 
 @dataclass
@@ -115,6 +128,18 @@ class LocationSchema(SchemaBase):
     column = fields.Int(required=True)
 
 
+class ExtensionExceptionSchema(SchemaBase):
+    """
+    Schema for GraphQL exception part of the error extensions.
+    """
+
+    dataclass = ExtensionException
+    message = fields.Str()
+    type = fields.Str()
+    errno = fields.Str()
+    code = fields.Str()
+
+
 class ExtensionsSchema(SchemaBase):
     """
     Schema for GraphQL extensions part of the error.
@@ -122,6 +147,7 @@ class ExtensionsSchema(SchemaBase):
 
     dataclass = Extension
     code = fields.Str()
+    exception = fields.Nested(ExtensionExceptionSchema, allow_none=True)
 
 
 class GraphqlErrorSchema(Schema):

--- a/tenable/ot/graphql/definitions.py
+++ b/tenable/ot/graphql/definitions.py
@@ -9,6 +9,8 @@ from marshmallow import fields
 from marshmallow.decorators import post_load
 from marshmallow.schema import Schema
 
+from tenable.base.schema.fields import ForcedStr
+
 
 class GraphObject:
     """
@@ -128,7 +130,7 @@ class GraphqlErrorSchema(Schema):
     """
 
     message = fields.Str(required=True)
-    path = fields.List(fields.Str())
+    path = fields.List(ForcedStr())
     locations = fields.List(fields.Nested(LocationSchema), allow_none=True)
     extensions = fields.Nested(ExtensionsSchema, allow_none=True)
 

--- a/tenable/ot/graphql/iterators.py
+++ b/tenable/ot/graphql/iterators.py
@@ -67,10 +67,15 @@ class OTGraphIterator(APIIterator):
                 resp["error"].get("errors", None), unknown=EXCLUDE
             )
             raise errors[0]
+        if "errors" in resp:
+            errors = GraphqlErrorSchema(many=True).load(resp["errors"], unknown=EXCLUDE)
+            raise errors[0]
         if "data" not in resp:
             raise GraphqlParsingError(
                 "graphql data field was not returned but no error occurred"
             )
+        if resp["data"] is None:
+            raise GraphqlParsingError("graphql data field was null")
 
         graphql_response_object = resp["data"][self._graph_object.object_name]
         if graphql_response_object is None:

--- a/tests/ot/test__ot_graph_iterator.py
+++ b/tests/ot/test__ot_graph_iterator.py
@@ -4,24 +4,82 @@ import responses
 from tenable.ot.graphql.definitions import GraphqlParsingError, GraphqlError
 
 
+@pytest.mark.parametrize(
+    "resp_json",
+    [
+        pytest.param(
+            {
+                "error": {
+                    "errors": [
+                        {
+                            "message": 'Variable "$sort" of required type "[AssetSortParams!]!" was not provided.',  # noqa: E501
+                            "locations": [{"line": 1, "column": 64}],
+                            "extensions": {"code": "BAD_USER_INPUT"},
+                        }
+                    ]
+                }
+            },
+            id="error_dict",
+        ),
+        pytest.param(
+            {
+                "errors": [
+                    {
+                        "message": "Syntax Error: Expected Name, found <EOF>.",
+                        "locations": [{"line": 23, "column": 1}],
+                        "extensions": {"code": "GRAPHQL_PARSE_FAILED"},
+                    }
+                ]
+            },
+            id="errors_list_single",
+        ),
+        pytest.param(
+            {
+                "errors": [
+                    {
+                        "message": "request to http://127.0.0.1:8083/v1/assets/osinfo failed, reason: connect EADDRNOTAVAIL 127.0.0.1:8083 - Local (127.0.0.1:0)",  # noqa: E501
+                        "locations": [{"line": 46, "column": 7}],
+                        "path": ["assets", "nodes", 0, "osDetails"],
+                        "extensions": {
+                            "code": "INTERNAL_SERVER_ERROR",
+                            "exception": {
+                                "message": "request to http://127.0.0.1:8083/v1/assets/osinfo failed, reason: connect EADDRNOTAVAIL 127.0.0.1:8083 - Local (127.0.0.1:0)",  # noqa: E501
+                                "type": "system",
+                                "errno": "EADDRNOTAVAIL",
+                                "code": "EADDRNOTAVAIL",
+                            },
+                        },
+                    },
+                    {
+                        "message": "request to http://127.0.0.1:8083/v1/assets/osinfo failed, reason: connect EADDRNOTAVAIL 127.0.0.1:8083 - Local (127.0.0.1:0)",  # noqa: E501
+                        "locations": [{"line": 46, "column": 7}],
+                        "path": ["assets", "nodes", 1, "osDetails"],
+                        "extensions": {
+                            "code": "INTERNAL_SERVER_ERROR",
+                            "exception": {
+                                "message": "request to http://127.0.0.1:8083/v1/assets/osinfo failed, reason: connect EADDRNOTAVAIL 127.0.0.1:8083 - Local (127.0.0.1:0)",  # noqa: E501
+                                "type": "system",
+                                "errno": "EADDRNOTAVAIL",
+                                "code": "EADDRNOTAVAIL",
+                            },
+                        },
+                    },
+                ],
+                "data": None,
+            },
+            id="errors_list_multiple_with_data_none",
+        ),
+    ],
+)
 @responses.activate
-def test_perform_request_errors(fixture_ot):
+def test_perform_request_errors(fixture_ot, resp_json):
     """
     Tests the assets Graphql list iterator
     """
     responses.add(
         method="POST",
         url="https://localhost/graphql",
-        json={
-            "error": {
-                "errors": [
-                    {
-                        "message": "whoopsy",
-                        "path": ["/graphql"],
-                    }
-                ]
-            }
-        },
+        json=resp_json,
     )
     with pytest.raises(GraphqlError):
         resp = fixture_ot.assets.list().next()


### PR DESCRIPTION
# Description

## Unhandled error response
I noticed that some of the errors sent by the Tenable OT API were not being handled by `OTGraphIterator`. I opened a[n issue describing the problem](https://github.com/tenable/pyTenable/issues/934) yesterday.

The issue is that most error responses are a dict with an `error` dict that contains an `errors` list:
```python
{
    'error': {
        'errors': [
            {
                'message': 'Variable "$sort" of required type "[AssetSortParams!]!" was not provided.',  # noqa: E501
                'locations': [{'line': 1, 'column': 64}],
                'extensions': {'code': 'BAD_USER_INPUT'},
            }
        ]
    }
},
```

But sometimes the API responds directly with an `errors` list that is outside of the `error` field:
```python
{
    'errors': [
        {
            'message': 'Syntax Error: Expected Name, found <EOF>.',
            'locations': [{'line': 23, 'column': 1}],
            'extensions': {'code': 'GRAPHQL_PARSE_FAILED'},
        }
    ]
},
```

You can reproduce the above error with the following API call:
```shell
curl 'https://XXXX/graphql' -H 'Accept-Encoding: gzip, deflate, br' -H 'Content-Type: application/json'  -H 'X-APIKeys: key=XXX' --data-binary '{"query":"query assets(\n  $filter: AssetExpressionsParams\n  $search: String\n  $sort: [AssetSortParams!]!\n  $limit: Int\n  $startAt: String\n) {\n  assets(\n    filter: $filter\n    search: $search\n    sort: $sort\n    first: $limit\n    after: $startAt\n  ) {\n    pageInfo {\n      endCursor\n    }\n    nodes {\n      id\n      name\n    }\n  }\n","variables":{"sort":[{"field":"id","direction":"DescNullLast"}],"limit":2,"startAt":"YXJyYXljb25uZWN0aW9uOjA="}}' --compressed --insecure
```

## data set to None on some errors

The error above wouldn't raise a `GraphqlError`, but at least a `GraphqlParsingError` because the `data` field is not set. 

Unfortunately, I also encountered API errors with `data: null`, which translates to `None` and passes the `if "data" not in resp:` check.

Then the following obscure and hard to catch exception is raised...
```shell
>       graphql_response_object = resp["data"][self._graph_object.object_name]
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: 'NoneType' object is not subscriptable
```

The circumstances that reproduce that condition are a bit harder to reproduce, but you can find info about it [in my original issue](https://github.com/tenable/pyTenable/issues/934).

## GraphqlErrorSchema.extension ValidationError for extensions with an exception

When I handled the cases above, I received a new exception. The error response I was receiving from tenable looked like this:
```python
{
    "errors": [
        {
            "message": "request to http://127.0.0.1:8083/v1/assets/osinfo failed, reason: connect EADDRNOTAVAIL 127.0.0.1:8083 - Local (127.0.0.1:0)",  # noqa: E501
            "locations": [{"line": 46, "column": 7}],
            "path": ["assets", "nodes", 0, "osDetails"],
            "extensions": {
                "code": "INTERNAL_SERVER_ERROR",
                "exception": {
                    "message": "request to http://127.0.0.1:8083/v1/assets/osinfo failed, reason: connect EADDRNOTAVAIL 127.0.0.1:8083 - Local (127.0.0.1:0)",  # noqa: E501
                    "type": "system",
                    "errno": "EADDRNOTAVAIL",
                    "code": "EADDRNOTAVAIL",
                },
            },
        },
        // [...]
     ],
     data=None,
}
```

The `errors[0].path` field expected only string values, but array indexes were passed as strings. This was causing a ValidationError exception:
```python
marshmallow.exceptions.ValidationError: {0: {'path': {2: ['Not a valid string.']}}, 1: {'path': {2: ['Not a valid string.’]}}}
```


## GraphqlErrorSchema.extension ValidationError for extensions with an exception

The `errors[0].extensions` dict has an unexpected key `exception`, which was causing a ValidationError exception:
```python
marshmallow.exceptions.ValidationError: {0: {'extensions': {'exception': ['Unknown field.']}}, 1: {'extensions': {'exception': ['Unknown field.']}}}
```

## Conclusion

I fixed all of these issues in this PR and put them all into separate commits to make it easier to review.

Fixes # (issue)
https://github.com/tenable/pyTenable/issues/934

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I added additional test-cases for `test_perform_request_errors`.

The tests can be run with:
```shell
uv run pytest tests/ot/test__ot_graph_iterator.py
```

**Test Configuration**:
* Python Version(s) Tested: 3.11
* Tenable OT version: 4.2.40

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
