### PR TITLE
Removed extraneous time additions #708

### DIFF
--- a/tenable/io/scans.py
+++ b/tenable/io/scans.py
@@ -360,18 +360,13 @@ class ScansAPI(TIOEndpoint):
             schedule[self.schedule_const.enabled] = True
             schedule[self.schedule_const.launch] = launch
 
-            # starttime is rounded-off to 30 min schedule to match with values used in UI
-            # will assign schedule datetime in (19700101T013000) format
             starttime = self._check(
                 self.schedule_const.start_time,
                 starttime,
                 datetime,
                 default=self.schedule_const.start_time_default,
             )
-            secs = timedelta(minutes=30).total_seconds()
-            starttime = datetime.fromtimestamp(
-                starttime.timestamp() + secs - starttime.timestamp() % secs
-            )
+
             schedule[self.schedule_const.start_time] = starttime.strftime(
                 self.schedule_const.time_format
             )
@@ -540,18 +535,12 @@ class ScansAPI(TIOEndpoint):
             schedule[self.schedule_const.enabled] = True
             schedule[self.schedule_const.launch] = launch
 
-            # starttime is rounded-off to 30 min schedule and
-            # will assign schedule datetime in (19700101T011223) manner
             starttime = self._check(
                 self.schedule_const.start_time,
                 starttime,
                 datetime,
                 default=existing_rrules.get(self.schedule_const.start_time, None)
                 or self.schedule_const.start_time_default,
-            )
-            secs = timedelta(minutes=30).total_seconds()
-            starttime = datetime.fromtimestamp(
-                starttime.timestamp() + secs - starttime.timestamp() % secs
             )
             schedule[self.schedule_const.start_time] = starttime.strftime(
                 self.schedule_const.time_format


### PR DESCRIPTION
# Description

Removes unnecessary 30 minute additions to the scan schedule start time.

Fixes #708

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
# How Has This Been Tested?


**Test Configuration**:
* Python Version(s) Tested: 3.10 - 3.13

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
