### PR TITLE
Updated the Vulns schema to use UpperCase isntead of LowerCase for state #942

### DIFF
--- a/tenable/io/exports/schema.py
+++ b/tenable/io/exports/schema.py
@@ -8,7 +8,7 @@ from typing import Dict
 from marshmallow import Schema, fields, post_dump
 from marshmallow import validate as v
 
-from tenable.base.schema.fields import LowerCase
+from tenable.base.schema.fields import LowerCase, UpperCase
 from tenable.base.utils.envelope import envelope
 
 
@@ -149,7 +149,7 @@ class VulnExportSchema(Schema):
 
     # Vulnerability Findings fields
     severity = fields.List(LowerCase(fields.Str()))
-    state = fields.List(LowerCase(fields.Str()))
+    state = fields.List(UpperCase(fields.Str()))
     vpr_score = fields.Nested(VPRSchema())
     scan_uuid = fields.Str()
     source = fields.List(fields.Str())


### PR DESCRIPTION
# Description

Fedcloud environments seem to now enforce the case of the state parameters (as noted in #942).  This patch solves the
issue by forcing the case to Upper for all strings in the state field.

Fixes #942

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Manual testing

**Test Configuration**:
* Python Version(s) Tested: 
* Tenable.sc version (if necessary):

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
