### PR TITLE
Updated Pip-audit to ignore 'GHSA-4xh5-x5gv-qwph'

### DIFF
--- a/.github/workflows/snyk_main.yml
+++ b/.github/workflows/snyk_main.yml
@@ -18,11 +18,11 @@ jobs:
 
       - name: Run pip-audit
         run: |
-          uv export --format requirements-txt | uv tool run pip-audit
+          uv export --format requirements-txt | uv tool run pip-audit --ignore-vuln GHSA-4xh5-x5gv-qwph
 
       - name: Run Bandit code auditor
         run: uv tool run --with "bandit[toml,baseline,sarif]" bandit -c pyproject.toml -r . -ll
-      
+
       - name: Export & Install requirements to run Snyk
         run: |
           uv pip compile pyproject.toml -o requirements.txt

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.10"
-        - "3.11"
-        - "3.12"
-        - "3.13"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
 
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
             --vcr-record=none \
             --cov-report=xml:coverage.xml \
             --cov-fail-under=95
-          
+
   code-assessments:
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Run pip-audit
-        run: uv export --format requirements-txt | uv tool run pip-audit
+        run: uv export --format requirements-txt | uv tool run pip-audit --ignore-vuln GHSA-4xh5-x5gv-qwph
 
       - name: Run Bandit code auditor
         run: uv tool run --with "bandit[toml,baseline,sarif]" bandit -c pyproject.toml -r . -ll


### PR DESCRIPTION
# Description

GHSA-4xh5-x5gv-qwph (https://github.com/advisories/GHSA-4xh5-x5gv-qwph) is a CVE related to PIP 25.2 itself, which isn't in any of our requirements, however pip is being used as part of the auditing pipeline.  This issue (while still a concern) isn't directly or indirectly related to installing pyTenable.