### PR TITLE
Updated Documentation for #976, fixed other documentation issues, and generally cleaned up the doc build

### DIFF
--- a/docs/api/io/access_groups.rst
+++ b/docs/api/io/access_groups.rst
@@ -1,1 +1,0 @@
-.. automodule:: tenable.io.access_groups

--- a/docs/api/io/access_groups_v2.rst
+++ b/docs/api/io/access_groups_v2.rst
@@ -1,1 +1,0 @@
-.. automodule:: tenable.io.access_groups_v2

--- a/docs/api/io/pci/attestations.rst
+++ b/docs/api/io/pci/attestations.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.io.pci.attestations

--- a/docs/api/io/pci/index.rst
+++ b/docs/api/io/pci/index.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.io.pci

--- a/docs/api/io/pci/scans.rst
+++ b/docs/api/io/pci/scans.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.io.pci.scans

--- a/docs/api/io/target_groups.rst
+++ b/docs/api/io/target_groups.rst
@@ -1,1 +1,0 @@
-.. automodule:: tenable.io.target_groups

--- a/docs/api/nessus/plugin_rules.rst
+++ b/docs/api/nessus/plugin_rules.rst
@@ -1,0 +1,4 @@
+.. important::
+	The Nessus Package is currently a Technology Preview
+
+.. automodule:: tenable.nessus.plugin_rules

--- a/docs/api/sc/license.rst
+++ b/docs/api/sc/license.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.sc.license

--- a/docs/api/sc/report_definition.rst
+++ b/docs/api/sc/report_definition.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.sc.report_definition

--- a/docs/api/sc/tickets.rst
+++ b/docs/api/sc/tickets.rst
@@ -1,0 +1,1 @@
+.. automodule:: tenable.sc.tickets

--- a/docs/api/tenableone/inventory/findings/schema.rst
+++ b/docs/api/tenableone/inventory/findings/schema.rst
@@ -1,1 +1,0 @@
-.. automodule:: tenable.tenableone.inventory.findings.schema

--- a/tenable/__init__.py
+++ b/tenable/__init__.py
@@ -7,7 +7,6 @@ Welcome to pyTenable's documentation!
 .. image:: https://img.shields.io/readthedocs/pytenable
 .. image:: https://img.shields.io/pypi/dm/pytenable
 .. image:: https://img.shields.io/github/license/tenable/pyTenable.svg
-.. image:: https://sonarcloud.io/api/project_badges/measure?project=tenable_pyTenable&metric=alert_status
 
 pyTenable is intended to be a pythonic interface into the Tenable application
 APIs.  Further by providing a common interface and a common structure between

--- a/tenable/io/__init__.py
+++ b/tenable/io/__init__.py
@@ -11,6 +11,7 @@ Tenable Vulnerability Management
     :glob:
 
     cs/index
+    pci/index
     access_control
     agent_config
     agent_exclusions
@@ -436,10 +437,6 @@ class TenableIO(APIPlatform):  # noqa: PLR0904
 
     @property
     def v3(self):
-        """
-        The interface object for the
-        :doc:`Tenable Vulnerability Management v3 APIs <v3/index>`.
-        """
         warnings.warn(
             'The V3 sub-pkg have been deprecated from the TVM '
             'package.  This method will be removed in a future '

--- a/tenable/io/exports/api.py
+++ b/tenable/io/exports/api.py
@@ -932,7 +932,7 @@ class ExportsAPI(APIEndpoint):
             cve_category:
                 Returns findings the match the specified CVE category. For more
                 information about categories, see the *Vulnerability Categories*
-                section in the _Tenable Vulnerability Management User Guide_.
+                section in the Tenable Vulnerability Management User Guide.
             exploit_maturity:
                 Returns findings that match the specified exploit maturity. Tenable
                 assigns exploit maturity values to vulnerabilities based on the
@@ -1079,6 +1079,7 @@ class ExportsAPI(APIEndpoint):
         """
         Initiate a WAS vulnerability export.
         :devportal:`API Documentation <was-export-findings>`
+
         Args:
             first_found:
                 Findings first discovered after this timestamp will be returned.

--- a/tenable/io/pci/__init__.py
+++ b/tenable/io/pci/__init__.py
@@ -10,6 +10,13 @@ Methods available on ``tio.pci``:
 .. autoclass:: PCIASVAPI
     :members:
 
+.. toctree::
+    :hidden:
+    :glob:
+
+    attestations
+    scans
+
 """
 
 from typing import Any, Literal, Type

--- a/tenable/nessus/api.py
+++ b/tenable/nessus/api.py
@@ -1,4 +1,4 @@
-'''
+"""
 Nessus
 ======
 
@@ -20,6 +20,7 @@ This package covers the Nessus interface.
     groups
     mail
     permissions
+    plugin_rules
     plugins
     policies
     proxy
@@ -31,8 +32,10 @@ This package covers the Nessus interface.
     software_update
     tokens
     users
-'''
+"""
+
 from tenable.base.platform import APIPlatform
+
 from .agent_groups import AgentGroupsAPI
 from .agents import AgentsAPI
 from .editor import EditorAPI
@@ -42,9 +45,9 @@ from .groups import GroupsAPI
 from .mail import MailAPI
 from .permissions import PermissionsAPI
 from .plugin_rules import PluginRulesAPI
+from .plugins import PluginsAPI
 from .policies import PoliciesAPI
 from .proxy import ProxyAPI
-from .plugins import PluginsAPI
 from .scanners import ScannersAPI
 from .scans import ScansAPI
 from .server import ServerAPI
@@ -56,165 +59,163 @@ from .users import UsersAPI
 
 
 class Nessus(APIPlatform):
-    '''
+    """
     The Nessus object is the primary interaction point for users to
     interface with Tenable Nessus via the pyTenable library.  All of the API
     endpoint classes that have been written will be grafted onto this class.
-    '''
+    """
+
     _env_base = 'NESSUS'
     _ssl_verify = False
     _conv_json = True
 
     def _session_auth(self, username, password):  # noqa: PLW0221,PLW0613
-        token = self.post('session', json={
-            'username': username,
-            'password': password
-        }).get('token')
-        self._session.headers.update({
-            'X-Cookie': f'token={token}'
-        })
+        token = self.post(
+            'session', json={'username': username, 'password': password}
+        ).get('token')
+        self._session.headers.update({'X-Cookie': f'token={token}'})
         self._auth_mech = 'user'
 
     @property
     def agent_groups(self):
-        '''
+        """
         The interface object for the
         :doc:`Tenable Nessus Agent Groups APIs <agent_groups>`.
-        '''
+        """
         return AgentGroupsAPI(self)
 
     @property
     def agents(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Agents APIs <agents>`.
-        '''
+        """
         return AgentsAPI(self)
 
     @property
     def editor(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Editor APIs <editor>`.
-        '''
+        """
         return EditorAPI(self)
 
     @property
     def files(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus File APIs <files>`.
-        '''
+        """
         return FilesAPI(self)
 
     @property
     def folders(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Folders APIs <folders>`.
-        '''
+        """
         return FoldersAPI(self)
 
     @property
     def groups(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Groups APIs <groups>`.
-        '''
+        """
         return GroupsAPI(self)
 
     @property
     def mail(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Mail APIs <mail>`.
-        '''
+        """
         return MailAPI(self)
 
     @property
     def permissions(self):
-        '''
+        """
         The interface object for the
         :doc:`Tenable Nessus Permissions APIs <permissions>`.
-        '''
+        """
         return PermissionsAPI(self)
 
     @property
     def plugin_rules(self):
-        '''
+        """
         The interface object for the
         :doc:`Tenable Nessus Plugin Rules APIs <plugin_rules>`.
-        '''
+        """
         return PluginRulesAPI(self)
 
     @property
     def plugins(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Plugins APIs <plugins>`.
-        '''
+        """
         return PluginsAPI(self)
 
     @property
     def policies(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Policies APIs <policies>`.
-        '''
+        """
         return PoliciesAPI(self)
 
     @property
     def proxy(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Proxy APIs <proxy>`.
-        '''
+        """
         return ProxyAPI(self)
 
     @property
     def scanners(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Scanners APIs <scanners>`.
-        '''
+        """
         return ScannersAPI(self)
 
     @property
     def scans(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Scans APIs <scans>`.
-        '''
+        """
         return ScansAPI(self)
 
     @property
     def server(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Server APIs <server>`.
-        '''
+        """
         return ServerAPI(self)
 
     @property
     def session(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Session APIs <session>`.
-        '''
+        """
         return SessionAPI(self)
 
     @property
     def settings(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Settings APIs <settings>`.
-        '''
+        """
         return SettingsAPI(self)
 
     @property
     def software_update(self):
-        '''
+        """
         The interface object for the
         :doc:`Tenable Nessus Software Update APIs <software_update>`.
-        '''
+        """
         return SoftwareUpdateAPI(self)
 
     @property
     def tokens(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Tokens APIs <tokens>`.
-        '''
+        """
         return TokensAPI(self)
 
     @property
     def users(self):
-        '''
+        """
         The interface object for the :doc:`Tenable Nessus Users APIs <users>`.
-        '''
+        """
         return UsersAPI(self)

--- a/tenable/sc/__init__.py
+++ b/tenable/sc/__init__.py
@@ -29,6 +29,7 @@ Tenable Security Center
     feeds
     files
     groups
+    hosts
     license
     organizations
     plugins
@@ -68,8 +69,8 @@ from .current import CurrentSessionAPI
 from .feeds import FeedAPI
 from .files import FileAPI
 from .groups import GroupAPI
-from .license import LicenseAPI
 from .hosts import HostsAPI
+from .license import LicenseAPI
 from .organizations import OrganizationAPI
 from .plugins import PluginAPI
 from .policies import ScanPolicyAPI
@@ -230,8 +231,7 @@ class TenableSC(APIPlatform):  # noqa PLR0904
                 stacklevel=2,
             )
             kwargs['url'] = (
-                f'{kwargs.get("scheme", "https")}://'
-                f'{host}:{kwargs.get("port", 443)}'
+                f'{kwargs.get("scheme", "https")}://{host}:{kwargs.get("port", 443)}'
             )
 
         kwargs['access_key'] = access_key
@@ -509,12 +509,12 @@ class TenableSC(APIPlatform):  # noqa PLR0904
 
     @property
     def license(self):
-        '''
+        """
         The interface object for the
         :doc:`Tenable Security Center License APIs <license>`.
-        '''
-        return LicenseAPI(self)      
-    
+        """
+        return LicenseAPI(self)
+
     @property
     def organizations(self):
         """
@@ -626,15 +626,15 @@ class TenableSC(APIPlatform):  # noqa PLR0904
         :doc:`Tenable Security Center System APIs <system>`.
         """
         return SystemAPI(self)
-    
+
     @property
     def tickets(self):
-        '''
+        """
         The interface object for the
         :doc:`Tenable Security Center Ticket APIs <system>`.
-        '''
+        """
         return TicketAPI(self)
-    
+
     @property
     def users(self):
         """

--- a/tenable/sc/hosts.py
+++ b/tenable/sc/hosts.py
@@ -3,7 +3,7 @@ Hosts
 =====
 
 The following methods allow for interaction with the Tenable Security Center
-:sc-api:`Hosts <Hosts.htm>` API.  These items are typically seen under the
+:sc-api:`Hosts <Hosts.htm>` API. These items are typically seen under the
 **Hosts** section of Tenable Security Center.
 
 Methods available on ``sc.hosts``:
@@ -36,7 +36,7 @@ class HostsAPI(SCEndpoint):
         return_json: bool = False,
     ) -> Union[HostsResultsIterator, Dict]:
         """
-        Retreive the list of hosts from the system.
+        Retrieve the list of hosts from the system.
 
         Args:
             fields (list[str], optional):
@@ -55,10 +55,9 @@ class HostsAPI(SCEndpoint):
         Response:
             The response will be either the HostResultsIterator to handle
             pagination of the data (preferred) or the raw response from the
-            api (if return_json is set to `True`).
+            API (if return_json is set to `True`).
 
         Examples:
-
             >>> for host in sc.hosts.list():
             ...     print(host)
         """
@@ -112,7 +111,7 @@ class HostsAPI(SCEndpoint):
         return_json: bool = False,
     ) -> Union[HostsResultsIterator, Dict]:
         """
-        Retreive the list of hosts from the system.
+        Retrieve the list of hosts from the system.
 
         Args:
             filters (list[tuple[str, str, str]], optional):
@@ -136,7 +135,7 @@ class HostsAPI(SCEndpoint):
         Response:
             The response will be either the HostResultsIterator to handle
             pagination of the data (preferred) or the raw response from the
-            api (if return_json is set to `True`).
+            API (if return_json is set to `True`).
 
         Examples:
 
@@ -201,7 +200,7 @@ class HostsAPI(SCEndpoint):
     ) -> Dict:
         """
         Override the Asset Criticality Rating (ACR) score and the reasons for the
-        specified Host
+        specified host.
 
         Args:
             host_uuid (str): The Host UUID to modify

--- a/tenable/sc/report_definition.py
+++ b/tenable/sc/report_definition.py
@@ -1,6 +1,6 @@
-'''
+"""
 Reports Definition
-============
+==================
 
 The following methods allow for interaction into the Tenable.sc
 :sc-api:`ReportsDefinition <ReportsDefinition.html>` API.
@@ -10,12 +10,14 @@ Methods available on ``sc.report_definition``:
 .. rst-class:: hide-signature
 .. autoclass:: ReportDefinitionAPI
     :members:
-'''
+"""
+
 from .base import SCEndpoint
+
 
 class ReportDefinitionAPI(SCEndpoint):
     def launch(self, id):
-        '''
+        """
         Launches a Report definition.
         :sc-api:`report-definition: launch <ReportDefinition.html#ReportDefinitionRESTReference-/reportDefinition/{id}/launch>`
         Args:
@@ -27,7 +29,8 @@ class ReportDefinitionAPI(SCEndpoint):
             >>> running = sc.report_definition.launch(1)
             >>> print('The Scan Result ID is {}'.format(
             ...     running['scanResult']['id']))
-        '''
+        """
 
-        return self._api.post('reportDefinition/{}/launch'.format(
-            self._check('id', id, int))).json()['response']
+        return self._api.post(
+            'reportDefinition/{}/launch'.format(self._check('id', id, int))
+        ).json()['response']

--- a/tenable/sc/tickets.py
+++ b/tenable/sc/tickets.py
@@ -1,25 +1,27 @@
-'''
-tickets
-=====
+"""
+Tickets
+=======
+
 The following methods allow for interaction into the Tenable.sc
 :sc-api:`Ticket <Ticket.html>` API.  These items are typically seen under the
 Worklow --> Tickets section of Tenable.sc.
 Methods available on ``sc.tickets``:
+
 .. rst-class:: hide-signature
 .. autoclass:: TicketAPI
-    .. automethod:: create
-    .. automethod:: details
-    .. automethod:: edit
-    .. automethod:: list
-    Note: you cannot delete tickets, must set them to resolved and they will be auto-purged via system configured retention period
-'''
+    :members:
+
+Note: you cannot delete tickets, must set them to resolved and they will be auto-purged via system configured retention period
+"""
+
 from .base import SCEndpoint
+
 
 class TicketAPI(SCEndpoint):
     def _constructor(self, **kw):
-        '''
+        """
         Handles parsing the keywords and returns a ticket document
-        '''
+        """
 
         # Validate as dict and pass to assignee
         if 'assignee' in kw:
@@ -60,8 +62,8 @@ class TicketAPI(SCEndpoint):
                     'Bad Credentials',
                     'Unauthorized Software',
                     'Unauthorized System',
-                    'Unauthorized User'
-                ]
+                    'Unauthorized User',
+                ],
             )
 
         if 'status' in kw:
@@ -76,15 +78,16 @@ class TicketAPI(SCEndpoint):
                     'More Information',
                     'Not Applicable',
                     'Duplicate',
-                    'Closed'
-                ]
+                    'Closed',
+                ],
             )
         return kw
 
     def create(self, name, assignee, **kw):
-        '''
+        """
         Creates a ticket.
         :sc-api:`ticket: create <Ticket.html#ticket_POST>`
+
         Args:
             name (str):
                 Required: The name for the ticket
@@ -102,33 +105,38 @@ class TicketAPI(SCEndpoint):
                 Optional list of IDs of queries to associate with the ticket
             query (object, optional):
                 Optional query object
+
         Returns:
             :obj:`dict`:
                 The newly created ticket.
+
         Examples:
             >>> ticket = sc.tickets.create('Example Ticket', {'id':1}, status='assigned', classification='information', description='This is an example ticket', notes='Example notes')
-        '''
+        """
         kw['name'] = name
         kw['assignee'] = assignee
         payload = self._constructor(**kw)
         return self._api.post('ticket', json=payload).json()['response']
 
     def details(self, id, fields=None):
-        '''
+        """
         Returns the details for a specific ticket.
         :sc-api:`ticket: details <Ticket.html#TicketRESTReference-/ticket/{id}>`
+
         Args:
-            id (int): 
+            id (int):
                 Required: the unique identifier for the ticket to be returned
-            fields (list): 
+            fields (list):
                 An optional list of attributes to return.
+
         Returns:
             :obj:`dict`:
                 The ticket resource record.
+
         Examples:
             >>> ticket = sc.tickets.details(1)
             >>> pprint(ticket)
-        '''
+        """
         params = {}
         if fields:
             params['fields'] = ','.join([self._check('field', f, str) for f in fields])
@@ -136,9 +144,10 @@ class TicketAPI(SCEndpoint):
         return self._api.get(f'ticket/{ticket_id}', params=params).json()['response']
 
     def edit(self, id, **kw):
-        '''
+        """
         Edits a ticket.
         :sc-api:`ticket: edit <Ticket.html#ticket_id_PATCH>`
+
         Args:
             id (int):
                 Required: unique identifier of the ticket to be edited
@@ -162,30 +171,33 @@ class TicketAPI(SCEndpoint):
         Returns:
             :obj:`dict`:
                 The newly updated ticket.
+
         Examples:
             >>> ticket = sc.tickets.edit(1, status='Resolved', notes='ran updates')
-        '''
+        """
         payload = self._constructor(**kw)
         ticket_id = self._check('id', id, int)
         return self._api.patch(f'ticket/{ticket_id}', json=payload).json()['response']
 
     def list(self, fields=None):
-        '''
+        """
         Outputs a dictionary of usable and manageable tickets, within which is a list of tickets.
         :sc-api:`ticket: list <Ticket.html#ticket_GET>`
+
         Args:
             fields (list):
                 Optional list of attributes to return for each ticket, e.g. ["name","description"]. If not specified, only a list of ticket IDs will return
+
         Returns:
             :obj:`dict`:
                 A dictionary with two lists of ticket resources.
+
         Examples:
             >>> for ticket in sc.tickets.list():
             ...     pprint(ticket)
-        '''
+        """
         params = {}
         if fields:
-            params['fields'] = ','.join([self._check('field', f, str)
-                for f in fields])
+            params['fields'] = ','.join([self._check('field', f, str) for f in fields])
 
         return self._api.get('ticket', params=params).json()['response']

--- a/tenable/tenableone/attack_path/vectors/api.py
+++ b/tenable/tenableone/attack_path/vectors/api.py
@@ -8,13 +8,6 @@ These methods can be accessed at ``TenableOne.attack_path``.
 .. rst-class:: hide-signature
 .. autoclass:: VectorsAPI
     :members:
-
-.. toctree::
-    :hidden:
-    :glob:
-
-    findings/index
-    vectors/index
 """
 
 from copy import copy


### PR DESCRIPTION
# Description

Documentation cleanup, bug fixes, and addressing warnings.

Fixes #976

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

# How Has This Been Tested?

Manually running the sphinx HTML builder. Builds now result in a clean build (no errors or warnings).

```
The HTML pages are in _build/html.
❯ make clean
Removing everything under './_build'...
❯ make html
Running Sphinx v7.4.7
loading translations [en]... done
making output directory... done
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
loading intersphinx inventory 'python' from https://docs.python.org/3/objects.inv...
loading intersphinx inventory 'requests' from https://requests.readthedocs.io/en/latest/objects.inv...
loading intersphinx inventory 'restfly' from https://restfly.readthedocs.io/en/latest/objects.inv...
building [mo]: targets for 0 po files that are out of date
writing output...
building [html]: targets for 156 source files that are out of date
updating environment: [new config] 156 added, 0 changed, 0 removed
reading sources... [100%] testing
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets...
copying static files... done
copying extra files... done
copying assets: done
writing output... [100%] testing
generating indices... genindex py-modindex done
highlighting module code... [100%] tenable.tenableone.tags.api
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in _build/html.
```
