### PR TITLE
Fix KeyError: 'id' in io filters _normalize on name-only choice lists

### DIFF
--- a/tenable/io/filters.py
+++ b/tenable/io/filters.py
@@ -44,10 +44,20 @@ class FiltersAPI(TIOEndpoint):
                 # is a list of dictionary items, and in other cases the "list"
                 # is a list of string values.
                 if isinstance(item['control']['list'][0], dict):
-                    key = 'value' if 'value' in item['control']['list'][0] else 'id'
-                    datablock['choices'] = [
-                        str(i[key]) for i in item['control']['list']
-                    ]
+                    # The list items don't always carry the same key. Most use
+                    # 'value' or 'id', but some (e.g. the target_group filter)
+                    # only provide a 'name'. Pick the first key that exists
+                    # rather than assuming 'id', which raised KeyError before.
+                    first = item['control']['list'][0]
+                    key = next(
+                        (k for k in ('value', 'id', 'name') if k in first), None
+                    )
+                    if key is not None:
+                        datablock['choices'] = [
+                            str(i[key])
+                            for i in item['control']['list']
+                            if key in i
+                        ]
                 elif isinstance(item['control']['list'], list):
                     datablock['choices'] = [str(i) for i in item['control']['list']]
             if 'regex' in item['control']:

--- a/tests/io/test_filters.py
+++ b/tests/io/test_filters.py
@@ -167,3 +167,24 @@ def test_filters_credentials_false_filters(api):
         check(data[1], 'readable_name', str, allow_none=True)
         check(data[1], 'operators', list, allow_none=True)
         check(data[1], 'control', dict, allow_none=True)
+
+
+def test_normalize_name_only_choices(api):
+    """
+    test that _normalize handles list items that only carry a 'name' key
+    (e.g. the target_group filter) instead of raising KeyError: 'id'
+    """
+    filterset = [
+        {
+            'name': 'target_group',
+            'operators': ['eq', 'neq'],
+            'control': {
+                'type': 'dropdown_multi',
+                'list': [{'name': 'mygroup'}],
+            },
+        }
+    ]
+    result = getattr(api.filters, '_normalize')(filterset)
+    assert result['target_group']['choices'] == ['mygroup']
+    assert result['target_group']['operators'] == ['eq', 'neq']
+    assert result['target_group']['pattern'] is None


### PR DESCRIPTION
Calling `tio.assets.bulk_delete()` blows up with `KeyError: 'id'` on any tenant that still has Target groups. The cause is in `io.filters._normalize`: when a choice list item only carries a `name` (the shape the `target_group` filter returns), the code falls back to assuming an `id` key and indexes into something that isn't there. This now picks the first key that actually exists out of value, id, then name, and skips list items that don't have it, so a name-only list resolves to its names instead of throwing.

Fixes #1009

I added a regression test (`test_normalize_name_only_choices`) that feeds `_normalize` the exact `target_group` shape from the issue. It fails with `KeyError: 'id'` on current main and passes with this change. `pytest tests/io/test_filters.py tests/io/test_assets.py` stays green (31 passed) and ruff is clean on the changed file. Tested on Python 3.12.

Type of change:

- [x] Bug fix (non-breaking change which fixes an issue)
